### PR TITLE
Improved dot graph to include non-traversed but enabled edges

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 #[cfg(not(target_arch = "wasm32"))]
 use std::fs::File;
 #[cfg(not(target_arch = "wasm32"))]
@@ -38,7 +38,7 @@ pub struct StateMetadata {
     pub via: Option<TransitionSource>,
 
     /// Successor states found from this state
-    pub successors: HashSet<usize>,
+    pub successors: HashMap<usize, Option<Arc<str>>>,
 }
 
 #[derive(Debug)]
@@ -343,7 +343,7 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
         if is_new {
             metadata.push(StateMetadata {
                 via: None,
-                successors: HashSet::new(),
+                successors: HashMap::new(),
             });
             queue.push_back((idx, 1));
         }
@@ -571,14 +571,14 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
                 metadata.push(StateMetadata {
                     via: Some(TransitionSource {
                         state_idx: current_idx,
-                        action: transition.action,
+                        action: transition.action.clone(),
                     }),
-                    successors: HashSet::new(),
+                    successors: HashMap::new(),
                 });
                 queue.push_back((succ_idx, depth + 1));
             }
             if let Some(meta) = metadata.get_mut(current_idx) {
-                meta.successors.insert(succ_idx);
+                meta.successors.insert(succ_idx, transition.action);
             }
         }
     }

--- a/src/export.rs
+++ b/src/export.rs
@@ -56,15 +56,23 @@ pub fn export_dot<W: Write>(
 
     for (idx, meta) in metadata.iter().enumerate() {
         for succ in &meta.successors {
-            let is_trace_edge = trace_edges.contains(&(idx, *succ));
+            let is_trace_edge = trace_edges.contains(&(idx, *succ.0));
 
-            let attributes = if is_trace_edge {
-                " [penwidth=3.0, color=\"black\"]"
+            let style = if is_trace_edge {
+                "penwidth=3.0, color=\"black\""
             } else {
-                " [color=\"gray50\"]"
+                "color=\"gray50\""
             };
 
-            writeln!(out, "  s{} -> s{}{};", idx, succ, attributes)?;
+            let label = match succ.1 {
+                None => String::from(""),
+                Some(label) => {
+                    let escaped = format_str_escaped(label);
+                    format!(", label=\"{escaped}\"")
+                }
+            };
+
+            writeln!(out, "  s{} -> s{} [{}{}];", idx, succ.0, style, label)?;
         }
     }
 
@@ -85,6 +93,10 @@ fn format_state_label(state: &State, vars: &[Arc<str>]) -> String {
         .join("\\n")
 }
 
+fn format_str_escaped(str: &str) -> String {
+    str.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 fn format_value_escaped(val: &Value) -> String {
-    format_value(val).replace('\\', "\\\\").replace('"', "\\\"")
+    format_str_escaped(&format_value(val))
 }


### PR DESCRIPTION
Fixes https://github.com/fabracht/tla-rs/issues/3

Additionally cleans up the code by putting all data derived from states into a `StateMetadata` struct. This might also improve performance, as this means fewer allocations are being made by the checker.

On the other hand, some data (`successors`) is being collected even if we don't end up using it with dot export. Perhaps it could be collected conditionally, but on the other hand the code isn't trying to do any particular performance optimizations, so perhaps such improvements can be done later (and e.g. the choices of optimal data structures can be revisited).

Additionally the dot graph only highlights the trace to the error state, not all transitions done by BFS, as I did not see any point in seeing the data that is basically arbitrary from the user point of view. In future this could be extended to support tracing to all error states, if using the flag to continue on error.