### PR TITLE
add wasm npm publish pipeline

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -3,8 +3,12 @@ command = "cargo"
 args = ["install", "--path", ".", "--force"]
 
 [tasks.wasm]
-description = "Build wasm package"
-dependencies = ["wasm-build", "wasm-bindgen"]
+description = "Build wasm package for npm"
+dependencies = ["wasm-clean", "wasm-build", "wasm-bindgen", "wasm-package"]
+
+[tasks.wasm-clean]
+description = "Clean pkg directory"
+script = ["rm -rf pkg"]
 
 [tasks.wasm-build]
 command = "cargo"
@@ -14,3 +18,44 @@ args = ["build", "--lib", "--release", "--target", "wasm32-unknown-unknown", "--
 command = "wasm-bindgen"
 args = ["--target", "web", "--out-dir", "pkg", "target/wasm32-unknown-unknown/release/tla_checker.wasm"]
 dependencies = ["wasm-build"]
+
+[tasks.wasm-package]
+description = "Generate package.json and copy README into pkg"
+dependencies = ["wasm-bindgen"]
+script = [
+    '''
+    VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+    cat > pkg/package.json << PKGJSON
+{
+  "name": "tla-checker",
+  "version": "$VERSION",
+  "type": "module",
+  "description": "A TLA+ model checker compiled to WebAssembly",
+  "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fabracht/tla-rs.git"
+  },
+  "main": "tla_checker.js",
+  "types": "tla_checker.d.ts",
+  "files": [
+    "tla_checker_bg.wasm",
+    "tla_checker.js",
+    "tla_checker.d.ts",
+    "tla_checker_bg.wasm.d.ts"
+  ],
+  "keywords": [
+    "tla",
+    "model-checking",
+    "formal-verification",
+    "wasm"
+  ],
+  "sideEffects": [
+    "./snippets/*"
+  ]
+}
+PKGJSON
+    cp README.md pkg/README.md
+    cd pkg && npm pkg fix
+    '''
+]


### PR DESCRIPTION
## Summary
- Add `wasm-clean` task to remove stale artifacts before build
- Add `wasm-package` task to generate `package.json` (version from Cargo.toml) and copy README into `pkg/`
- Run `npm pkg fix` to normalize package metadata
- Wire all steps into `cargo make wasm` pipeline: clean → build → bindgen → package

## Test plan
- [x] `cargo make wasm` produces clean `pkg/` with correct artifacts
- [x] `npm publish --dry-run` passes with no warnings
- [x] `.d.ts` includes all 4 exported functions