### PR TITLE
load file-based modules from EXTENDS

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1,3 +1,5 @@
+#[cfg(not(target_arch = "wasm32"))]
+use std::collections::BTreeSet;
 use std::collections::{BTreeMap, VecDeque};
 #[cfg(not(target_arch = "wasm32"))]
 use std::fs::File;
@@ -150,7 +152,7 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
             .filter(|m| !stdlib::is_stdlib_module(m))
             .cloned()
             .collect();
-        let mut visited: std::collections::BTreeSet<Arc<str>> = worklist.iter().cloned().collect();
+        let mut visited: BTreeSet<Arc<str>> = worklist.iter().cloned().collect();
         while let Some(module) = worklist.pop() {
             match registry.load(&module, spec_path) {
                 Ok(loaded) => {

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1,5 +1,3 @@
-#[cfg(not(target_arch = "wasm32"))]
-use std::collections::BTreeSet;
 use std::collections::{BTreeMap, VecDeque};
 #[cfg(not(target_arch = "wasm32"))]
 use std::fs::File;
@@ -24,7 +22,7 @@ use crate::export::{DotExport, DotMode, EdgeList, export_dot};
 use crate::graph::StateGraph;
 use crate::liveness::{self, LivenessViolation};
 #[cfg(not(target_arch = "wasm32"))]
-use crate::modules::{ModuleRegistry, resolve_instances};
+use crate::modules::{ModuleError, ModuleRegistry, resolve_instances};
 use crate::scc::compute_sccs;
 use crate::stdlib;
 use crate::symmetry::SymmetryConfig;
@@ -131,6 +129,83 @@ pub enum CheckResult {
     MissingConstants(Vec<Arc<str>>),
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+fn load_module_extends(
+    name: &Arc<str>,
+    spec_path: &std::path::Path,
+    registry: &mut ModuleRegistry,
+    domains: &mut crate::ast::Env,
+    extended_defs: &mut Definitions,
+    ancestors: &mut Vec<Arc<str>>,
+) -> Result<(), EvalError> {
+    if ancestors.iter().any(|a| a == name) {
+        let mut cycle_path: Vec<String> = ancestors
+            .iter()
+            .skip_while(|a| a.as_ref() != name.as_ref())
+            .map(|a| a.to_string())
+            .collect();
+        cycle_path.push(name.to_string());
+        return Err(EvalError::DomainError {
+            message: format!("cyclic EXTENDS dependency: {}", cycle_path.join(" -> ")),
+            span: None,
+        });
+    }
+
+    if let Some(cached) = registry.get(name) {
+        for (def_name, def) in &cached.definitions {
+            extended_defs.insert(def_name.clone(), def.clone());
+        }
+        return Ok(());
+    }
+
+    let (child_extends, child_defs) = match registry.load(name, spec_path) {
+        Ok(loaded) => (loaded.extends.clone(), loaded.definitions.clone()),
+        Err(ModuleError::NotFound(_)) => {
+            return Err(EvalError::DomainError {
+                message: format!(
+                    "module {} not found (no file {}.tla in spec directory)",
+                    name, name
+                ),
+                span: None,
+            });
+        }
+        Err(ModuleError::ParseError(msg)) => {
+            return Err(EvalError::DomainError {
+                message: format!("parse error in module {}: {}", name, msg),
+                span: None,
+            });
+        }
+        Err(ModuleError::CyclicDependency(dep)) => {
+            return Err(EvalError::DomainError {
+                message: format!("cyclic dependency loading module {}", dep),
+                span: None,
+            });
+        }
+        Err(ModuleError::IoError(msg)) => {
+            return Err(EvalError::DomainError {
+                message: format!("I/O error loading module {}: {}", name, msg),
+                span: None,
+            });
+        }
+    };
+
+    ancestors.push(name.clone());
+    for ext in &child_extends {
+        if stdlib::is_stdlib_module(ext) {
+            stdlib::load_module(ext, domains);
+        } else {
+            load_module_extends(ext, spec_path, registry, domains, extended_defs, ancestors)?;
+        }
+    }
+    ancestors.pop();
+
+    for (def_name, def) in child_defs {
+        extended_defs.insert(def_name, def);
+    }
+
+    Ok(())
+}
+
 pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult {
     let user_constants = domains.clone();
     let mut domains = Env::new();
@@ -146,54 +221,20 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
     #[cfg(not(target_arch = "wasm32"))]
     if let Some(ref spec_path) = config.spec_path {
         let mut registry = ModuleRegistry::new();
-        let mut worklist: Vec<Arc<str>> = spec
-            .extends
-            .iter()
-            .filter(|m| !stdlib::is_stdlib_module(m))
-            .cloned()
-            .collect();
-        let mut visited: BTreeSet<Arc<str>> = worklist.iter().cloned().collect();
-        while let Some(module) = worklist.pop() {
-            match registry.load(&module, spec_path) {
-                Ok(loaded) => {
-                    for ext in &loaded.extends {
-                        if stdlib::is_stdlib_module(ext) {
-                            stdlib::load_module(ext, &mut domains);
-                        } else if visited.insert(ext.clone()) {
-                            worklist.push(ext.clone());
-                        }
-                    }
-                    for (name, def) in &loaded.definitions {
-                        extended_defs.insert(name.clone(), def.clone());
-                    }
-                }
-                Err(crate::modules::ModuleError::NotFound(_)) => {
-                    return CheckResult::InitError(EvalError::DomainError {
-                        message: format!(
-                            "module {} not found (no file {}.tla in spec directory)",
-                            module, module
-                        ),
-                        span: None,
-                    });
-                }
-                Err(crate::modules::ModuleError::ParseError(msg)) => {
-                    return CheckResult::InitError(EvalError::DomainError {
-                        message: format!("parse error in module {}: {}", module, msg),
-                        span: None,
-                    });
-                }
-                Err(crate::modules::ModuleError::CyclicDependency(name)) => {
-                    return CheckResult::InitError(EvalError::DomainError {
-                        message: format!("cyclic dependency loading module {}", name),
-                        span: None,
-                    });
-                }
-                Err(crate::modules::ModuleError::IoError(msg)) => {
-                    return CheckResult::InitError(EvalError::DomainError {
-                        message: format!("I/O error loading module {}: {}", module, msg),
-                        span: None,
-                    });
-                }
+        let mut ancestors: Vec<Arc<str>> = Vec::new();
+        for module in &spec.extends {
+            if stdlib::is_stdlib_module(module) {
+                continue;
+            }
+            if let Err(err) = load_module_extends(
+                module,
+                spec_path,
+                &mut registry,
+                &mut domains,
+                &mut extended_defs,
+                &mut ancestors,
+            ) {
+                return CheckResult::InitError(err);
             }
         }
     }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -140,6 +140,66 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
         domains.insert(k, v);
     }
 
+    let mut extended_defs: Definitions = BTreeMap::new();
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(ref spec_path) = config.spec_path {
+        let mut registry = ModuleRegistry::new();
+        let mut worklist: Vec<Arc<str>> = spec
+            .extends
+            .iter()
+            .filter(|m| !stdlib::is_stdlib_module(m))
+            .cloned()
+            .collect();
+        let mut visited: std::collections::BTreeSet<Arc<str>> = worklist.iter().cloned().collect();
+        while let Some(module) = worklist.pop() {
+            match registry.load(&module, spec_path) {
+                Ok(loaded) => {
+                    for ext in &loaded.extends {
+                        if stdlib::is_stdlib_module(ext) {
+                            stdlib::load_module(ext, &mut domains);
+                        } else if visited.insert(ext.clone()) {
+                            worklist.push(ext.clone());
+                        }
+                    }
+                    for (name, def) in &loaded.definitions {
+                        extended_defs.insert(name.clone(), def.clone());
+                    }
+                }
+                Err(crate::modules::ModuleError::NotFound(_)) => {
+                    return CheckResult::InitError(EvalError::DomainError {
+                        message: format!(
+                            "module {} not found (no file {}.tla in spec directory)",
+                            module, module
+                        ),
+                        span: None,
+                    });
+                }
+                Err(crate::modules::ModuleError::ParseError(msg)) => {
+                    return CheckResult::InitError(EvalError::DomainError {
+                        message: format!("parse error in module {}: {}", module, msg),
+                        span: None,
+                    });
+                }
+                Err(crate::modules::ModuleError::CyclicDependency(name)) => {
+                    return CheckResult::InitError(EvalError::DomainError {
+                        message: format!("cyclic dependency loading module {}", name),
+                        span: None,
+                    });
+                }
+                Err(crate::modules::ModuleError::IoError(msg)) => {
+                    return CheckResult::InitError(EvalError::DomainError {
+                        message: format!("I/O error loading module {}: {}", module, msg),
+                        span: None,
+                    });
+                }
+            }
+        }
+    }
+    for (name, def) in &spec.definitions {
+        extended_defs.insert(name.clone(), def.clone());
+    }
+    let defs = extended_defs;
+
     for inst in &spec.instances {
         if stdlib::is_stdlib_module(&inst.module_name) {
             stdlib::load_module(&inst.module_name, &mut domains);
@@ -195,7 +255,7 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
     }
 
     for (idx, assume) in spec.assumes.iter().enumerate() {
-        match eval(assume, &mut domains, &spec.definitions) {
+        match eval(assume, &mut domains, &defs) {
             Ok(Value::Bool(true)) => {}
             Ok(Value::Bool(false)) => return CheckResult::AssumeViolation(idx),
             Ok(_) => {
@@ -277,7 +337,7 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
     if !config.quiet {
         eprintln!("  Computing initial states...");
     }
-    let initial = match init_states(init_expr, &spec.vars, &domains, &spec.definitions) {
+    let initial = match init_states(init_expr, &spec.vars, &domains, &defs) {
         Ok(states) => states,
         Err(e) => return CheckResult::InitError(e),
     };
@@ -341,7 +401,7 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
     let count_exprs: Vec<(Arc<str>, Expr)> = config
         .count_properties
         .iter()
-        .filter_map(|name| match spec.definitions.get(name) {
+        .filter_map(|name| match defs.get(name) {
             Some((params, expr)) if params.is_empty() => Some((name.clone(), expr.clone())),
             Some(_) => {
                 if !config.quiet {
@@ -526,7 +586,7 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
         };
 
         for (idx, invariant) in spec.invariants.iter().enumerate() {
-            match eval_with_context(invariant, &mut env, &spec.definitions, &ctx) {
+            match eval_with_context(invariant, &mut env, &defs, &ctx) {
                 Ok(Value::Bool(true)) => {}
                 Ok(Value::Bool(false)) => {
                     if config.continue_on_violation {
@@ -585,7 +645,7 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
             for (idx, (_name, expr)) in count_exprs.iter().enumerate() {
                 let entry = &mut property_counters[idx];
                 *entry.depth_total.entry(depth).or_default() += 1;
-                match eval_with_context(expr, &mut env, &spec.definitions, &ctx) {
+                match eval_with_context(expr, &mut env, &defs, &ctx) {
                     Ok(Value::Bool(true)) => {
                         entry.satisfied += 1;
                         *entry.depth_satisfied.entry(depth).or_default() += 1;
@@ -605,7 +665,7 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
             &spec.vars,
             &primed_vars,
             &mut reusable_env,
-            &spec.definitions,
+            &defs,
         ) {
             Ok(s) => s,
             Err(e) => {
@@ -664,7 +724,8 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
         if !config.quiet {
             eprintln!("  Running liveness checking...");
         }
-        match check_liveness_properties(spec, &states, &parent, &domains, &symmetry, config) {
+        match check_liveness_properties(spec, &states, &parent, &domains, &symmetry, config, &defs)
+        {
             Ok(None) => {}
             Ok(Some(violation)) => {
                 return CheckResult::LivenessViolation(violation, stats);
@@ -685,6 +746,7 @@ fn check_liveness_properties(
     domains: &Env,
     symmetry: &SymmetryConfig,
     config: &CheckerConfig,
+    defs: &Definitions,
 ) -> Result<Option<LivenessViolation>, EvalError> {
     let mut graph = StateGraph::new();
 
@@ -708,7 +770,7 @@ fn check_liveness_properties(
             &spec.vars,
             &primed_vars,
             &mut reusable_env,
-            &spec.definitions,
+            defs,
         )?;
         for transition in successors {
             let canonical = symmetry.canonicalize(&transition.state);
@@ -731,25 +793,22 @@ fn check_liveness_properties(
         );
     }
 
-    if !spec.fairness.is_empty() {
-        let defs: Definitions = spec.definitions.clone();
-        if let Some(scc_idx) =
-            liveness::find_violating_scc(&graph, &sccs, &spec.fairness, &spec.vars, domains, &defs)?
-        {
-            let violation = liveness::build_counterexample(
-                &graph,
-                &sccs[scc_idx],
-                &spec.fairness,
-                &spec.vars,
-                domains,
-                &defs,
-            )?;
-            return Ok(Some(violation));
-        }
+    if !spec.fairness.is_empty()
+        && let Some(scc_idx) =
+            liveness::find_violating_scc(&graph, &sccs, &spec.fairness, &spec.vars, domains, defs)?
+    {
+        let violation = liveness::build_counterexample(
+            &graph,
+            &sccs[scc_idx],
+            &spec.fairness,
+            &spec.vars,
+            domains,
+            defs,
+        )?;
+        return Ok(Some(violation));
     }
 
     for property in &spec.liveness_properties {
-        let defs: Definitions = spec.definitions.clone();
         for scc in &sccs {
             if !liveness::check_fairness_in_scc(
                 &graph,
@@ -757,16 +816,16 @@ fn check_liveness_properties(
                 &spec.fairness,
                 &spec.vars,
                 domains,
-                &defs,
+                defs,
             )? {
                 continue;
             }
 
             let property_satisfied = match property {
                 Expr::LeadsTo(p, q) => {
-                    liveness::check_leads_to(&graph, scc, p, q, domains, &defs, &spec.vars)?
+                    liveness::check_leads_to(&graph, scc, p, q, domains, defs, &spec.vars)?
                 }
-                _ => liveness::check_eventually(&graph, scc, property, domains, &defs, &spec.vars)?,
+                _ => liveness::check_eventually(&graph, scc, property, domains, defs, &spec.vars)?,
             };
 
             if !property_satisfied {

--- a/test_cases/should_error/extends_cycle/CycleA.tla
+++ b/test_cases/should_error/extends_cycle/CycleA.tla
@@ -1,0 +1,4 @@
+---- MODULE CycleA ----
+EXTENDS CycleB
+Foo == 1
+====

--- a/test_cases/should_error/extends_cycle/CycleB.tla
+++ b/test_cases/should_error/extends_cycle/CycleB.tla
@@ -1,0 +1,4 @@
+---- MODULE CycleB ----
+EXTENDS CycleA
+Bar == 2
+====

--- a/test_cases/should_error/extends_cycle/extends_cycle.tla
+++ b/test_cases/should_error/extends_cycle/extends_cycle.tla
@@ -1,0 +1,9 @@
+---- MODULE extends_cycle ----
+EXTENDS CycleA
+
+VARIABLES x
+
+Init == x = Foo
+Next == x' = x
+Inv == x = 1
+====

--- a/test_cases/should_error/extends_missing_module.tla
+++ b/test_cases/should_error/extends_missing_module.tla
@@ -1,0 +1,9 @@
+---- MODULE extends_missing_module ----
+EXTENDS NotThere
+
+VARIABLES x
+
+Init == x = 0
+Next == x' = x
+Inv == x = 0
+====

--- a/test_cases/should_error/extends_parse_error/Broken.tla
+++ b/test_cases/should_error/extends_parse_error/Broken.tla
@@ -1,0 +1,3 @@
+---- MODULE Broken ----
+this is not valid TLA+ at all !!!
+====

--- a/test_cases/should_error/extends_parse_error/extends_parse_error.tla
+++ b/test_cases/should_error/extends_parse_error/extends_parse_error.tla
@@ -1,0 +1,9 @@
+---- MODULE extends_parse_error ----
+EXTENDS Broken
+
+VARIABLES x
+
+Init == x = 0
+Next == x' = x
+Inv == x = 0
+====

--- a/test_cases/should_pass/extends_file_module/Helpers.tla
+++ b/test_cases/should_pass/extends_file_module/Helpers.tla
@@ -1,0 +1,7 @@
+---- MODULE Helpers ----
+EXTENDS Naturals
+
+Max(a, b) == IF a >= b THEN a ELSE b
+Min(a, b) == IF a <= b THEN a ELSE b
+Clamp(x, lo, hi) == Max(lo, Min(x, hi))
+====

--- a/test_cases/should_pass/extends_file_module/extends_file_module.tla
+++ b/test_cases/should_pass/extends_file_module/extends_file_module.tla
@@ -1,0 +1,9 @@
+---- MODULE extends_file_module ----
+EXTENDS Helpers
+
+VARIABLES x
+
+Init == x = 0
+Next == x' = Clamp(x + 1, 0, 3)
+Inv == x \in 0..3
+====

--- a/test_cases/should_pass/extends_multiple/BoolOps.tla
+++ b/test_cases/should_pass/extends_multiple/BoolOps.tla
@@ -1,0 +1,3 @@
+---- MODULE BoolOps ----
+IsEven(n) == n % 2 = 0
+====

--- a/test_cases/should_pass/extends_multiple/MathOps.tla
+++ b/test_cases/should_pass/extends_multiple/MathOps.tla
@@ -1,0 +1,3 @@
+---- MODULE MathOps ----
+Double(n) == n + n
+====

--- a/test_cases/should_pass/extends_multiple/extends_multiple.tla
+++ b/test_cases/should_pass/extends_multiple/extends_multiple.tla
@@ -1,0 +1,9 @@
+---- MODULE extends_multiple ----
+EXTENDS Naturals, MathOps, BoolOps
+
+VARIABLES x
+
+Init == x = 1
+Next == x' = IF x < 4 THEN Double(x) ELSE x
+Inv == x \in 1..8 /\ (x > 1 => IsEven(x))
+====

--- a/test_cases/should_pass/extends_override/Defs.tla
+++ b/test_cases/should_pass/extends_override/Defs.tla
@@ -1,0 +1,3 @@
+---- MODULE Defs ----
+Limit == 99
+====

--- a/test_cases/should_pass/extends_override/extends_override.tla
+++ b/test_cases/should_pass/extends_override/extends_override.tla
@@ -1,0 +1,11 @@
+---- MODULE extends_override ----
+EXTENDS Defs
+
+Limit == 3
+
+VARIABLES x
+
+Init == x = 0
+Next == x' = IF x < Limit THEN x + 1 ELSE x
+Inv == x <= 3
+====

--- a/test_cases/should_pass/extends_transitive/BaseLib.tla
+++ b/test_cases/should_pass/extends_transitive/BaseLib.tla
@@ -1,0 +1,5 @@
+---- MODULE BaseLib ----
+EXTENDS Naturals
+
+Abs(n) == IF n >= 0 THEN n ELSE 0 - n
+====

--- a/test_cases/should_pass/extends_transitive/MidLib.tla
+++ b/test_cases/should_pass/extends_transitive/MidLib.tla
@@ -1,0 +1,5 @@
+---- MODULE MidLib ----
+EXTENDS BaseLib
+
+Dist(a, b) == Abs(a - b)
+====

--- a/test_cases/should_pass/extends_transitive/extends_transitive.tla
+++ b/test_cases/should_pass/extends_transitive/extends_transitive.tla
@@ -1,0 +1,11 @@
+---- MODULE extends_transitive ----
+EXTENDS MidLib
+
+VARIABLES x, y
+
+Init == x = 0 /\ y = 5
+Next ==
+    /\ x' = IF x < 3 THEN x + 1 ELSE x
+    /\ y' = IF y > 2 THEN y - 1 ELSE y
+Inv == Dist(x, y) <= 5
+====

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -783,3 +783,71 @@ fn test_cfg_cli_constant_overrides_cfg() {
         other => panic!("TwoPhase with CLI override should pass, got: {:?}", other),
     }
 }
+
+#[test]
+fn test_should_error_extends_missing_module() {
+    let path = Path::new("test_cases/should_error/extends_missing_module.tla");
+    let result = check_spec_file(path);
+    match result {
+        CheckResult::InitError(e) => {
+            let msg = format!("{:?}", e);
+            assert!(
+                msg.contains("NotThere"),
+                "error should mention missing module name, got: {}",
+                msg
+            );
+        }
+        other => panic!(
+            "extends_missing_module.tla should produce InitError, got: {:?}",
+            other
+        ),
+    }
+}
+
+#[test]
+fn test_should_pass_extends_file_module() {
+    let path = Path::new("test_cases/should_pass/extends_file_module/extends_file_module.tla");
+    let result = check_spec_file_allow_deadlock(path);
+    assert!(
+        matches!(result, CheckResult::Ok(_)),
+        "extends_file_module.tla should pass, got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_should_pass_extends_transitive() {
+    let path = Path::new("test_cases/should_pass/extends_transitive/extends_transitive.tla");
+    let result = check_spec_file_allow_deadlock(path);
+    assert!(
+        matches!(result, CheckResult::Ok(_)),
+        "extends_transitive.tla should pass, got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_should_pass_extends_override() {
+    let path = Path::new("test_cases/should_pass/extends_override/extends_override.tla");
+    let result = check_spec_file_allow_deadlock(path);
+    match &result {
+        CheckResult::Ok(stats) => {
+            assert_eq!(
+                stats.states_explored, 4,
+                "spec Limit=3 should produce 4 states (0,1,2,3)"
+            );
+        }
+        other => panic!("extends_override.tla should pass, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_should_pass_extends_multiple() {
+    let path = Path::new("test_cases/should_pass/extends_multiple/extends_multiple.tla");
+    let result = check_spec_file_allow_deadlock(path);
+    assert!(
+        matches!(result, CheckResult::Ok(_)),
+        "extends_multiple.tla should pass, got: {:?}",
+        result
+    );
+}

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -851,3 +851,23 @@ fn test_should_pass_extends_multiple() {
         result
     );
 }
+
+#[test]
+fn test_should_error_extends_parse_error() {
+    let path = Path::new("test_cases/should_error/extends_parse_error/extends_parse_error.tla");
+    let result = check_spec_file(path);
+    match result {
+        CheckResult::InitError(e) => {
+            let msg = format!("{:?}", e);
+            assert!(
+                msg.contains("Broken"),
+                "error should mention the broken module name, got: {}",
+                msg
+            );
+        }
+        other => panic!(
+            "extends_parse_error.tla should produce InitError, got: {:?}",
+            other
+        ),
+    }
+}

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -871,3 +871,23 @@ fn test_should_error_extends_parse_error() {
         ),
     }
 }
+
+#[test]
+fn test_should_error_extends_cycle() {
+    let path = Path::new("test_cases/should_error/extends_cycle/extends_cycle.tla");
+    let result = check_spec_file_allow_deadlock(path);
+    match result {
+        CheckResult::InitError(e) => {
+            let msg = format!("{:?}", e);
+            assert!(
+                msg.contains("cyclic"),
+                "error should mention cyclic dependency, got: {}",
+                msg
+            );
+        }
+        other => panic!(
+            "extends_cycle.tla should produce InitError, got: {:?}",
+            other
+        ),
+    }
+}


### PR DESCRIPTION
## Summary

- `EXTENDS SomeModule` now loads `SomeModule.tla` from disk and merges its definitions into the current spec
- Transitive EXTENDS are resolved recursively (module A extends module B, both file-based)
- Missing modules produce a hard error instead of being silently ignored
- Spec definitions take precedence over extended module definitions on name collision

Fixes #15

## Test plan

- [x] `extends_missing_module.tla` — verify `EXTENDS NotThere` produces InitError
- [x] `extends_file_module/` — spec extends a user-defined module with operators (Clamp via Max/Min)
- [x] `extends_transitive/` — spec extends MidLib which extends BaseLib (both file-based)
- [x] `extends_override/` — spec redefines a name from the extended module, spec wins
- [x] `extends_multiple/` — `EXTENDS Naturals, MathOps, BoolOps` mixed stdlib + file modules