### PR TITLE
support .. operator in recursive function domains and CHOOSE

### DIFF
--- a/src/parser/primary.rs
+++ b/src/parser/primary.rs
@@ -356,7 +356,7 @@ impl Parser {
         let var = self.expect_ident()?;
         if *self.peek() == Token::In {
             self.advance();
-            let domain = self.parse_additive()?;
+            let domain = self.parse_range()?;
             self.expect(Token::Colon)?;
             let body = self.parse_expr()?;
             Ok(Expr::Choose(var, Box::new(domain), Box::new(body)))
@@ -504,7 +504,7 @@ impl Parser {
                 self.advance();
                 let param = self.expect_ident()?;
                 self.expect(Token::In)?;
-                let domain = self.parse_additive()?;
+                let domain = self.parse_range()?;
                 self.expect(Token::RBracket)?;
                 self.expect(Token::EqEq)?;
                 let body = self.parse_expr()?;

--- a/test_cases/should_pass/recursive_dotdot.tla
+++ b/test_cases/should_pass/recursive_dotdot.tla
@@ -1,0 +1,17 @@
+---- MODULE recursive_dotdot ----
+EXTENDS Naturals
+
+VARIABLE x
+
+Sum(limit) ==
+  LET f[i \in 1..limit] ==
+    IF i = 1 THEN 1 ELSE i + f[i - 1]
+  IN f[limit]
+
+Init == x = 0
+
+Next == x' = Sum(3)
+
+Inv == x \in {0, 6}
+
+====

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -231,6 +231,16 @@ fn test_should_pass_recursive_in_next() {
 }
 
 #[test]
+fn test_should_pass_recursive_dotdot() {
+    let path = Path::new("test_cases/should_pass/recursive_dotdot.tla");
+    let result = check_spec_file(path);
+    match &result {
+        CheckResult::Ok(stats) => assert_eq!(stats.states_explored, 2),
+        _ => panic!("recursive_dotdot.tla should pass, got: {:?}", result),
+    }
+}
+
+#[test]
 fn test_should_pass_exponentiation() {
     let path = Path::new("test_cases/should_pass/exponentiation.tla");
     let result = check_spec_file(path);


### PR DESCRIPTION
Closes #24

## Summary
- Fix `..` (range) operator not being recognized in LET function definition domains (`f[i \in 1..N]`) and CHOOSE domains (`CHOOSE x \in 1..N : P`)
- Both call sites used `parse_additive()` instead of `parse_range()`, so `..` was never parsed in these contexts

## Test plan
- [x] Added `recursive_dotdot.tla` test spec using `1..limit` in a recursive function domain
- [x] Oracle test verifies spec passes with exactly 2 states
- [x] Full test suite passes (158 unit + 56 oracle)
- [x] `cargo clippy` clean