### PR TITLE
fix clippy missing_const_for_thread_local on RNG

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"
@@ -43,7 +43,7 @@ codegen-units = 1
 split-debuginfo = "packed"
 
 [dependencies]
-fastrand = "2.3.0"
+fastrand = "2.4"
 indexmap = "2.13.0"
 wasm-bindgen = { version = "0.2", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/src/eval/global_state.rs
+++ b/src/eval/global_state.rs
@@ -67,7 +67,7 @@ impl CheckerStats {
 }
 
 thread_local! {
-    pub(super) static RNG: RefCell<fastrand::Rng> = RefCell::new(fastrand::Rng::with_seed(0));
+    pub(super) static RNG: RefCell<fastrand::Rng> = const { RefCell::new(fastrand::Rng::with_seed(0)) };
     pub(super) static TLC_STATE: RefCell<BTreeMap<i64, Value>> = const { RefCell::new(BTreeMap::new()) };
     pub(super) static CHECKER_STATS: RefCell<CheckerStats> = const { RefCell::new(CheckerStats::new()) };
     pub(super) static RESOLVED_INSTANCES: RefCell<ResolvedInstances> = const { RefCell::new(BTreeMap::new()) };


### PR DESCRIPTION
## Summary
- Wrap the `RNG` `thread_local!` initializer in `const { ... }` to satisfy `clippy::missing_const_for_thread_local` (clippy 1.94+).
- Bump `fastrand` from `2.3.0` to `2.4` so that `Rng::with_seed` is `const fn` (made const in fastrand 2.4.0).
- Bump crate version to `0.3.8`.

## Test plan
- [x] `cargo clippy -- -D warnings` (matches CI invocation) — clean
- [x] `cargo fmt --check`
- [x] `cargo check --all-features` (wasm path)
- [x] `cargo test --lib` — 158 passed