### PR TITLE
fix ~ operator precedence vs \in and comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.10] - 2026-04-19
+
+### Fixed
+
+- `~` (negation) operator precedence: `~state \in S` now correctly parses as `~(state \in S)` instead of `(~state) \in S` (#33)
+
 ## [0.3.9] - 2026-04-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.3.9"
+version = "0.3.10"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -325,6 +325,11 @@ impl Parser {
     }
 
     pub(super) fn parse_comparison(&mut self) -> Result<Expr> {
+        if matches!(self.peek(), Token::Not) {
+            self.advance();
+            let expr = self.parse_comparison()?;
+            return Ok(Expr::Not(Box::new(expr)));
+        }
         let left = self.parse_range()?;
         match self.peek() {
             Token::Eq => {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -229,6 +229,34 @@ mod tests {
     }
 
     #[test]
+    fn negation_binds_looser_than_in() {
+        let expr = parse_expr("~state \\in {\"bar\", \"baz\"}").unwrap();
+        if let Expr::Not(inner) = expr {
+            assert!(
+                matches!(*inner, Expr::In(_, _)),
+                "~state \\in S should parse as ~(state \\in S), got {:?}",
+                inner
+            );
+        } else {
+            panic!("expected Not at top level");
+        }
+    }
+
+    #[test]
+    fn negation_binds_looser_than_eq() {
+        let expr = parse_expr("~x = y").unwrap();
+        if let Expr::Not(inner) = expr {
+            assert!(
+                matches!(*inner, Expr::Eq(_, _)),
+                "~x = y should parse as ~(x = y), got {:?}",
+                inner
+            );
+        } else {
+            panic!("expected Not at top level");
+        }
+    }
+
+    #[test]
     fn parse_spec_counter() {
         let input = r#"
             VARIABLES count

--- a/test_cases/should_pass/negation_in.cfg
+++ b/test_cases/should_pass/negation_in.cfg
@@ -1,0 +1,3 @@
+INIT Init
+NEXT Next
+INVARIANT Inv

--- a/test_cases/should_pass/negation_in.tla
+++ b/test_cases/should_pass/negation_in.tla
@@ -1,0 +1,11 @@
+---- MODULE negation_in ----
+VARIABLE state
+
+Init ==
+  /\ state = "foo"
+  /\ ~state \in { "bar", "baz" }
+
+Next == state' = state
+
+Inv == state = "foo"
+====

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -76,6 +76,17 @@ fn test_should_pass_traffic_light() {
 }
 
 #[test]
+fn test_negation_in_precedence() {
+    let path = Path::new("test_cases/should_pass/negation_in.tla");
+    let result = check_spec_file(path);
+    assert!(
+        matches!(result, CheckResult::Ok(_)),
+        "negation_in.tla should pass (~x \\in S parses as ~(x \\in S)), got: {:?}",
+        result
+    );
+}
+
+#[test]
 fn test_should_violate_counter_overflow() {
     let path = Path::new("test_cases/should_violate/counter_overflow.tla");
     let result = check_spec_file(path);


### PR DESCRIPTION
## Summary
- Fixes #33: `~state \in {"bar", "baz"}` was parsed as `(~state) \in {"bar", "baz"}` instead of `~(state \in {"bar", "baz"})`
- `~` (precedence 4) now correctly binds looser than `\in`, `=`, `#`, `<`, `>`, `\subseteq`, etc. (precedence 5)
- Added `~` handling at the top of `parse_comparison()` so negation wraps the full comparison expression

## Test plan
- [x] New parser unit tests: `negation_binds_looser_than_in`, `negation_binds_looser_than_eq`
- [x] New integration test with the exact spec from the issue
- [x] All 160 unit tests and 57 integration tests pass
- [x] Clippy clean