### PR TITLE
Reuse liveness edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 - `extract_fairness_and_liveness` now warns when it encounters `<<A>>_v` (diamond action) or `<>[]P` (stable-eventually) — both are silently dropped today but the warning surfaces the cfg-debug mismatch instead of leaving the user wondering why fairness wasn't applied
 - `state_passes_constraints` no longer clones `base_env` on every state and every transition — the env is hoisted out of both loops and reused, matching the pattern used elsewhere in the BFS loop
 
+### Performance
+
+- Liveness checking now reuses forward edges collected during BFS exploration instead of recomputing successors via a second `next_states` pass over every reachable state. For specs with expensive `Next` evaluation this halves the per-state evaluation cost when `check_liveness` is enabled. Closes #36 (#38)
+
 ### Notes
 
 - Constraint expressions are evaluated against unprimed variables (state predicates). They run at both initial-state enumeration and successor expansion, before symmetry canonicalization. `ACTION_CONSTRAINT` (transition predicate) remains unsupported and still warns
@@ -34,6 +38,7 @@
 - The liveness sub-SCC analysis is sound (any reported violation is real) and complete when the parent SCC is fair, but does not check fairness on the sub-SCC itself — a !Q sub-cycle that happens to be unfair will still be reported. In practice rare for typical specs; flagged here for future tightening
 - `check_leads_to` and `check_eventually` now return `Result<Option<Vec<usize>>>` (Some = sub-SCC states forming the violating cycle, None = property satisfied), enabling accurate cycle reporting
 - `Spec::extract_fairness_and_liveness` now returns `Vec<String>` of warnings (empty when nothing unexpected). Callers in the parser and `apply_config` collect and surface these
+- BFS now collects forward edges in `all_edges` whenever liveness checking is enabled, not only when DOT export is requested. This adds memory proportional to total transitions (one `(usize, Option<Arc<str>>)` per edge) during the BFS phase, in exchange for skipping the duplicate `next_states` pass during liveness. Specs that are state-count-bounded but memory-tight may need to budget for the extra edge storage
 
 ## [0.4.0] - 2026-05-14
 

--- a/benches/model_checking.rs
+++ b/benches/model_checking.rs
@@ -122,7 +122,7 @@ fn bench_tcommit(c: &mut Criterion) {
     group.finish();
 }
 
-#[cfg(test)]
+#[allow(dead_code)]
 fn validate_benchmarks() {
     let large_counter_text = include_str!("../test_cases/benchmark/large_counter.tla");
     let large_counter = parse(large_counter_text).expect("failed to parse large_counter.tla");
@@ -445,6 +445,31 @@ fn bench_enabled(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_liveness_edge_reuse(c: &mut Criterion) {
+    let spec_text = include_str!("../test_cases/benchmark/liveness_edge_reuse.tla");
+    let spec = parse(spec_text).expect("failed to parse liveness_edge_reuse.tla");
+
+    let mut group = c.benchmark_group("liveness_edge_reuse");
+
+    for max in [50, 100, 200] {
+        let mut env = Env::new();
+        env.insert(Arc::from("Max"), Value::Int(max));
+
+        group.bench_with_input(BenchmarkId::new("max", max), &env, |b, env| {
+            b.iter(|| {
+                let config = CheckerConfig {
+                    allow_deadlock: true,
+                    check_liveness: true,
+                    ..quiet_config()
+                };
+                check(&spec, env, &config)
+            });
+        });
+    }
+
+    group.finish();
+}
+
 fn bench_queens(c: &mut Criterion) {
     let spec_text = include_str!("../test_cases/official/Queens.tla");
     let spec = parse(spec_text).expect("failed to parse Queens.tla");
@@ -583,6 +608,7 @@ criterion_group!(
     bench_tcommit,
     bench_twophase,
     bench_enabled,
+    bench_liveness_edge_reuse,
     bench_queens,
     bench_eval_operations,
     bench_symmetry_canonicalize,

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -443,10 +443,14 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
     let mut parent_action: Vec<Option<Arc<str>>> = Vec::new();
     let mut queue: VecDeque<(usize, usize)> = VecDeque::new();
 
+    let needs_liveness_check = config.check_liveness
+        && (!spec.fairness.is_empty() || !spec.liveness_properties.is_empty());
+
     #[cfg(not(target_arch = "wasm32"))]
-    let collect_edges = config.export_dot_path.is_some() || config.export_dot_string;
+    let collect_edges =
+        config.export_dot_path.is_some() || config.export_dot_string || needs_liveness_check;
     #[cfg(target_arch = "wasm32")]
-    let collect_edges = config.export_dot_string;
+    let collect_edges = config.export_dot_string || needs_liveness_check;
     let mut all_edges: Vec<EdgeList> = Vec::new();
     let mut stats = CheckStats {
         states_explored: 0,
@@ -840,8 +844,7 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
 
     stats.property_stats = property_counters;
 
-    if config.check_liveness && (!spec.fairness.is_empty() || !spec.liveness_properties.is_empty())
-    {
+    if needs_liveness_check {
         if !config.quiet {
             eprintln!("  Running liveness checking...");
         }
@@ -849,10 +852,9 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
             spec,
             domains: &domains,
             defs: &defs,
-            symmetry: &symmetry,
             config,
         };
-        match check_liveness_properties(ctx, &states, &parent, &elapsed_secs) {
+        match check_liveness_properties(ctx, &states, &parent, &all_edges, &elapsed_secs) {
             Ok(LivenessCheckOutcome::Ok) => {}
             Ok(LivenessCheckOutcome::Violation(violation)) => {
                 return CheckResult::LivenessViolation(violation, stats);
@@ -881,7 +883,6 @@ struct LivenessContext<'a> {
     spec: &'a Spec,
     domains: &'a Env,
     defs: &'a Definitions,
-    symmetry: &'a SymmetryConfig,
     config: &'a CheckerConfig,
 }
 
@@ -889,13 +890,13 @@ fn check_liveness_properties(
     ctx: LivenessContext<'_>,
     states: &IndexSet<State>,
     parent: &[Option<usize>],
+    all_edges: &[EdgeList],
     elapsed_secs: &dyn Fn() -> f64,
 ) -> Result<LivenessCheckOutcome, EvalError> {
     let LivenessContext {
         spec,
         domains,
         defs,
-        symmetry,
         config,
     } = ctx;
     let time_exceeded = || match config.max_seconds {
@@ -910,31 +911,19 @@ fn check_liveness_properties(
     }
 
     if !config.quiet {
-        eprintln!("  Building forward edges for {} states...", states.len());
+        eprintln!(
+            "  Reusing {} collected forward edge lists...",
+            all_edges.len()
+        );
     }
-    let next_expr = spec.next.as_ref().ok_or_else(|| EvalError::DomainError {
-        message: "missing Next definition".to_string(),
-        span: None,
-    })?;
-    let primed_vars = make_primed_names(&spec.vars);
-    let mut reusable_env = domains.clone();
-    for (state_idx, state) in states.iter().enumerate() {
+
+    for (state_idx, edges) in all_edges.iter().enumerate() {
         if time_exceeded() {
             return Ok(LivenessCheckOutcome::TimeExceeded);
         }
-        let successors = next_states(
-            next_expr,
-            state,
-            &spec.vars,
-            &primed_vars,
-            &mut reusable_env,
-            defs,
-        )?;
-        for transition in successors {
-            let canonical = symmetry.canonicalize(&transition.state);
-            if let Some(succ_idx) = states.get_index_of(canonical.as_ref()) {
-                graph.add_edge(state_idx, succ_idx, transition.action);
-            }
+
+        for (succ_idx, action) in edges {
+            graph.add_edge(state_idx, *succ_idx, action.clone());
         }
     }
 

--- a/test_cases/benchmark/liveness_edge_reuse.tla
+++ b/test_cases/benchmark/liveness_edge_reuse.tla
@@ -1,0 +1,21 @@
+------------------------------ MODULE liveness_edge_reuse ------------------------------
+
+EXTENDS Naturals
+
+CONSTANT Max
+
+VARIABLE x
+
+Init ==
+    x = 0
+
+Next ==
+    \/ /\ x < Max
+       /\ x' = x + 1
+    \/ /\ x > 0
+       /\ x' = x - 1
+
+EventuallyZero ==
+    <> (x = 0)
+
+=============================================================================


### PR DESCRIPTION
## Summary

Closes #36.

This PR avoids rebuilding the forward transition graph during liveness checking.

The BFS exploration already collects forward edges in `all_edges` for DOT export. When liveness checking is enabled, this PR also collects those edges during exploration and reuses them to build the `StateGraph` consumed by the SCC/fairness/eventually/leads-to checks.

This removes the duplicate `next_states` pass that previously happened during the liveness phase.

## Motivation

For specs with expensive `Next` evaluation or many reachable transitions, successor generation can dominate model-checking time.

Before this change:

1. BFS exploration generated successors for every reachable state.
2. Liveness checking rebuilt the same forward edges by calling `next_states` again for every reachable state.

After this change:

1. BFS exploration stores the canonical successor indices in `all_edges`.
2. Liveness checking builds `StateGraph` directly from those collected edges.

## Implementation

The change is intentionally small:

- introduces a `needs_liveness_check` boolean;
- enables `collect_edges` when liveness checking is active, not only when DOT export is requested;
- passes the collected `all_edges` into `check_liveness_properties`;
- builds the liveness `StateGraph` directly from the collected edge lists;
- removes the duplicate per-state `next_states` call from the liveness graph construction path.

The existing SCC, sub-SCC, fairness, `<>`, and `~>` checks still consume `StateGraph` through `graph.successors`, so the source of the edges remains opaque to the liveness analysis.

The `max_seconds` budget check is preserved while constructing the liveness graph.

## Benchmark

This PR adds a small Criterion benchmark, `liveness_edge_reuse`, based on a simple liveness-checking spec.

Run with:

```bash
cargo bench --bench model_checking -- liveness_edge_reuse
````

The benchmark is intended to exercise the liveness path and make the duplicate edge reconstruction cost visible.

## Notes

This builds on the liveness improvements from #37.

While testing locally on top of the current #37 branch, `cargo bench --bench model_checking -- liveness_edge_reuse` attempts to link the unrelated `tla-mcp` binary and fails with MCP linker errors. The failure happens while compiling `bin "tla-mcp"`, not while compiling or running the `liveness_edge_reuse` benchmark.

## Test plan

* [x] `cargo check`
* [x] `cargo test --lib`
* [x] `cargo test --test oracle`
* [x] `cargo test --test mcp_integration`
* [ ] `cargo bench --bench model_checking -- liveness_edge_reuse`

The benchmark target was added, but the local bench run is currently blocked by the unrelated `tla-mcp` linker issue described above.

