### PR TITLE
ship tla-mcp prebuilt binaries and document crates.io install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,20 +118,20 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            artifact_name: tla
-            asset_name: tla-linux-amd64
+            ext: ""
+            suffix: linux-amd64
           - os: macos-latest
             target: x86_64-apple-darwin
-            artifact_name: tla
-            asset_name: tla-macos-amd64
+            ext: ""
+            suffix: macos-amd64
           - os: macos-latest
             target: aarch64-apple-darwin
-            artifact_name: tla
-            asset_name: tla-macos-arm64
+            ext: ""
+            suffix: macos-arm64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            artifact_name: tla.exe
-            asset_name: tla-windows-amd64.exe
+            ext: ".exe"
+            suffix: windows-amd64
     steps:
       - uses: actions/checkout@v4
 
@@ -140,20 +140,21 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Build CLI
-        run: cargo build --release --bin tla --target ${{ matrix.target }}
+      - name: Build CLI binaries
+        run: cargo build --release --bin tla --bin tla-mcp --target ${{ matrix.target }}
 
-      - name: Rename binary
+      - name: Stage binaries
         shell: bash
         run: |
           mkdir -p dist
-          cp ./target/${{ matrix.target }}/release/${{ matrix.artifact_name }} dist/${{ matrix.asset_name }}
+          cp ./target/${{ matrix.target }}/release/tla${{ matrix.ext }} dist/tla-${{ matrix.suffix }}${{ matrix.ext }}
+          cp ./target/${{ matrix.target }}/release/tla-mcp${{ matrix.ext }} dist/tla-mcp-${{ matrix.suffix }}${{ matrix.ext }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.asset_name }}
-          path: dist/${{ matrix.asset_name }}
+          name: binaries-${{ matrix.suffix }}
+          path: dist/*
 
   create-release:
     name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.4.1] - 2026-05-17
+
+### Distribution
+
+- Pre-built `tla-mcp` binaries are now produced by the release pipeline alongside `tla` for Linux x86_64, macOS x86_64, macOS arm64, and Windows x86_64. GitHub release assets are renamed to `tla-<platform>` and `tla-mcp-<platform>` to disambiguate
+- README now advertises `cargo install tla-checker --bin tla-mcp` (no clone needed) as the primary install path for the MCP server, with the release-binary download and `--path .` workflows documented as alternatives
+
 ## [0.4.0] - 2026-05-17
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -257,13 +257,25 @@ if (result.dot) {
 
 `tla-mcp` exposes the model checker as a Model Context Protocol server over stdio, so agentic clients (Claude Code, Cursor, etc.) can call it as a first-class tool.
 
-Build and register:
+### Install
+
+The fastest path — install the published crate from crates.io (no clone needed):
+
+```bash
+cargo install tla-checker --bin tla-mcp
+```
+
+Or download a pre-built binary from the [latest GitHub release](https://github.com/fabracht/tla-rs/releases/latest) (Linux, macOS Intel/Apple Silicon, Windows).
+
+From a working copy:
 
 ```bash
 cargo install --path . --bin tla-mcp
 ```
 
-Then add to your MCP client config (Claude Code example, `~/.claude/mcp.json` or `claude_desktop_config.json`):
+### Register with your client
+
+Add to your MCP client config (Claude Code example, `~/.claude/mcp.json` or `claude_desktop_config.json`):
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Release pipeline (`.github/workflows/release.yml`) now builds both `tla` and `tla-mcp` for Linux x86_64, macOS x86_64, macOS arm64, and Windows x86_64. Single matrix entry per platform, single `cargo build` per platform produces both binaries (lib is shared). Artifacts uploaded as `binaries-<suffix>` so the create-release job can attach them all
- GitHub release asset filenames disambiguated: `tla-<platform>` and `tla-mcp-<platform>`
- README MCP section restructured with an explicit \"Install\" subsection. Primary path advertised is `cargo install tla-checker --bin tla-mcp` from crates.io (no clone needed, works since v0.4.0). Pre-built release binaries listed as the second option; `--path .` from a working copy as third
- Bumped Cargo.toml 0.4.0 → 0.4.1, CHANGELOG `[0.4.1]` entry under a new `### Distribution` section

## Test plan

- [x] `cargo make check-format` clean
- [x] `cargo make clippy` clean
- [x] `cargo test --lib --release` — 160 pass
- [x] Local `cargo build --release --bin tla --bin tla-mcp` produces both binaries (1.4 MB / 2.1 MB)
- [ ] Release pipeline end-to-end exercised by pushing the v0.4.1 tag after merge