### PR TITLE
decouple create-release from publish-npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    needs: [publish, publish-npm, build-binaries]
+    needs: [publish, build-binaries]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.2] - 2026-05-17
+
+### Fixed
+
+- Release workflow's `create-release` job no longer depends on `publish-npm`. The two are independent — a failed npm publish (e.g., expired or non-automation token) used to block the GitHub release page and binary asset uploads entirely. Now npm publish runs in parallel and its outcome is reported separately
+
 ## [0.4.1] - 2026-05-17
 
 ### Distribution

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- `create-release` job in `.github/workflows/release.yml` no longer lists `publish-npm` in its `needs:`. The GitHub release page and binary uploads are now independent of whether npm publish succeeds
- Background: v0.4.0 and v0.4.1 release runs both had `publish-npm` fail (npm 2FA-for-publish requires an automation token, not a regular access token). That blocked `create-release`, so the binaries — which built successfully — never reached the GitHub release. v0.4.1 was unblocked manually
- Bumped Cargo.toml 0.4.1 → 0.4.2 and added CHANGELOG entry

## Test plan

- [x] `cargo make check-format` clean
- [x] `cargo make clippy` clean
- [x] `cargo test --lib` — 160 pass