### PR TITLE
add install script and homebrew formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,9 @@ jobs:
         run: |
           mkdir -p release
           find artifacts -type f -exec cp {} release/ \;
-          ls -la release/
+          cd release
+          sha256sum * > SHA256SUMS
+          ls -la
 
       - name: Create Release
         uses: ncipollo/release-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@
 
 ### Distribution
 
-- `scripts/install.sh` — POSIX shell installer that detects platform (Linux x86_64, macOS x86_64, macOS arm64), fetches the appropriate prebuilt binaries from a GitHub release, and drops them on the user's PATH. Flags: `--bin <tla|tla-mcp|both>`, `--version <tag>`, `--dir <path>`. Default install location is `$HOME/.local/bin`. Usable via `curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash`
-- `packaging/homebrew/tla-mcp.rb` — Homebrew formula installing both `tla` and `tla-mcp` from release binaries on macOS arm64, macOS x86_64, and Linux x86_64. Intended for a `homebrew-tla` tap repo (setup documented in `packaging/homebrew/README.md`); end users install with `brew install fabracht/tla/tla-mcp`
+- `scripts/install.sh` — POSIX shell installer that detects platform (Linux x86_64, macOS x86_64, macOS arm64), fetches the appropriate prebuilt binaries from a GitHub release, **verifies SHA256 against the release's `SHA256SUMS` asset**, and drops them on the user's PATH. Flags: `--bin <tla|tla-mcp|both>`, `--version <tag>`, `--dir <path>`. Default install location is `$HOME/.local/bin`. Usable via `curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash`. Releases before v0.4.3 lack the `SHA256SUMS` asset and are rejected
+- Release workflow now generates a `SHA256SUMS` asset (output of `sha256sum *` over the staged binary set) and attaches it to every GitHub release alongside the binaries
+- `packaging/homebrew/tla-mcp.rb` — Homebrew formula installing both `tla` and `tla-mcp` from release binaries on macOS arm64, macOS x86_64, and Linux x86_64. Includes a `livecheck` block (`strategy :github_latest`) so `brew livecheck` and `brew bump-formula-pr` can detect new releases. Intended for a `homebrew-tla` tap repo (setup documented in `packaging/homebrew/README.md`); end users install with `brew install fabracht/tla/tla-mcp`
 - README MCP "Install" section restructured to list all five paths (Homebrew, install script, cargo from crates.io, release binary download, `--path .` from a clone)
+
+### Notes
+
+- The formula in `packaging/homebrew/tla-mcp.rb` is a template pinned to the *previous* release (v0.4.2 here). On each new release, run `packaging/homebrew/README.md`'s SHA256-refresh recipe and commit the updated formula to the `homebrew-tla` tap repo. `brew bump-formula-pr` can automate the PR once the tap is established
 
 ## [0.4.2] - 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.4.3] - 2026-05-17
+
+### Distribution
+
+- `scripts/install.sh` — POSIX shell installer that detects platform (Linux x86_64, macOS x86_64, macOS arm64), fetches the appropriate prebuilt binaries from a GitHub release, and drops them on the user's PATH. Flags: `--bin <tla|tla-mcp|both>`, `--version <tag>`, `--dir <path>`. Default install location is `$HOME/.local/bin`. Usable via `curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash`
+- `packaging/homebrew/tla-mcp.rb` — Homebrew formula installing both `tla` and `tla-mcp` from release binaries on macOS arm64, macOS x86_64, and Linux x86_64. Intended for a `homebrew-tla` tap repo (setup documented in `packaging/homebrew/README.md`); end users install with `brew install fabracht/tla/tla-mcp`
+- README MCP "Install" section restructured to list all five paths (Homebrew, install script, cargo from crates.io, release binary download, `--path .` from a clone)
+
 ## [0.4.2] - 2026-05-17
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -259,15 +259,31 @@ if (result.dot) {
 
 ### Install
 
-The fastest path — install the published crate from crates.io (no clone needed):
+Several paths are supported — pick whichever fits your toolchain.
+
+**Homebrew (macOS, Linuxbrew)** — installs both `tla` and `tla-mcp`:
+
+```bash
+brew install fabracht/tla/tla-mcp
+```
+
+**Install script (Linux, macOS)** — downloads a prebuilt binary, no Rust toolchain required:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash
+```
+
+Pass flags to scope the install: `--bin tla-mcp` for just the MCP server, `--version v0.4.2` to pin a release, `--dir /usr/local/bin` for a system-wide install (requires `sudo`).
+
+**Cargo (any platform with a Rust toolchain)**:
 
 ```bash
 cargo install tla-checker --bin tla-mcp
 ```
 
-Or download a pre-built binary from the [latest GitHub release](https://github.com/fabracht/tla-rs/releases/latest) (Linux, macOS Intel/Apple Silicon, Windows).
+**GitHub release downloads** — prebuilt binaries for Linux x86_64, macOS x86_64, macOS arm64, and Windows x86_64 are attached to every [release](https://github.com/fabracht/tla-rs/releases/latest) as `tla-<platform>` and `tla-mcp-<platform>`.
 
-From a working copy:
+**From a working copy**:
 
 ```bash
 cargo install --path . --bin tla-mcp

--- a/README.md
+++ b/README.md
@@ -267,13 +267,15 @@ Several paths are supported — pick whichever fits your toolchain.
 brew install fabracht/tla/tla-mcp
 ```
 
-**Install script (Linux, macOS)** — downloads a prebuilt binary, no Rust toolchain required:
+Requires the `homebrew-tla` tap to exist. The formula source lives at [`packaging/homebrew/tla-mcp.rb`](packaging/homebrew/tla-mcp.rb); [`packaging/homebrew/README.md`](packaging/homebrew/README.md) explains the one-time tap setup.
+
+**Install script (Linux, macOS)** — downloads a prebuilt binary and verifies its SHA256, no Rust toolchain required:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash
 ```
 
-Pass flags to scope the install: `--bin tla-mcp` for just the MCP server, `--version v0.4.2` to pin a release, `--dir /usr/local/bin` for a system-wide install (requires `sudo`).
+Pass flags to scope the install: `--bin tla-mcp` for just the MCP server, `--version v0.4.3` to pin a release (releases prior to v0.4.3 do not ship a `SHA256SUMS` asset and are rejected), `--dir /usr/local/bin` for a system-wide install (requires `sudo`).
 
 **Cargo (any platform with a Rust toolchain)**:
 

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,60 @@
+# Homebrew formula for tla-rs
+
+`tla-mcp.rb` is a Homebrew formula that installs both the `tla` model checker and the `tla-mcp` MCP server from prebuilt GitHub release binaries. It is **not** discoverable via `brew install` unless it lives in a tap repository.
+
+## Setting up the tap (one-time, by the maintainer)
+
+1. Create a new public GitHub repo named `homebrew-tla` under the same owner as `tla-rs`. The `homebrew-` prefix is required — without it `brew tap` will reject the URL.
+2. Add a `Formula/` directory and copy this file into it:
+
+   ```
+   homebrew-tla/
+   └── Formula/
+       └── tla-mcp.rb
+   ```
+
+3. Commit and push. The tap is now usable as `<owner>/tla`.
+
+## Installing (users)
+
+```bash
+brew tap fabracht/tla
+brew install tla-mcp
+```
+
+Or in a single command:
+
+```bash
+brew install fabracht/tla/tla-mcp
+```
+
+Both `tla` and `tla-mcp` end up on the user's PATH.
+
+## Updating the formula on each release
+
+After tagging `vX.Y.Z` and verifying the release pipeline produced all eight assets:
+
+1. Update `version` in the formula
+2. Update each `url` to point at the new tag
+3. Update each `sha256` with the corresponding asset's checksum
+
+Compute the checksums with:
+
+```bash
+VERSION=v0.4.3  # replace with new tag
+for asset in tla-macos-arm64 tla-macos-amd64 tla-linux-amd64 \
+             tla-mcp-macos-arm64 tla-mcp-macos-amd64 tla-mcp-linux-amd64; do
+    sha=$(curl -fsSL "https://github.com/fabracht/tla-rs/releases/download/$VERSION/$asset" \
+        | shasum -a 256 | cut -d' ' -f1)
+    printf "%s  %s\n" "$sha" "$asset"
+done
+```
+
+Then commit the formula update to the tap repo and push. Long-term automation:
+
+- `brew bump-formula-pr` can prepare the formula update PR
+- `goreleaser` / `release-plz` style automation can keep the tap in sync with each release
+
+## Why a tap and not homebrew-core?
+
+`homebrew-core` requires the project to meet popularity / maintenance criteria (notable user base, stable release cadence, etc.). A personal tap has no such requirement and works identically for end users, just with a slightly longer install command.

--- a/packaging/homebrew/tla-mcp.rb
+++ b/packaging/homebrew/tla-mcp.rb
@@ -1,0 +1,54 @@
+class TlaMcp < Formula
+  desc "TLA+ model checker (tla) and MCP server (tla-mcp)"
+  homepage "https://github.com/fabracht/tla-rs"
+  version "0.4.2"
+  license "MIT OR Apache-2.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/fabracht/tla-rs/releases/download/v0.4.2/tla-macos-arm64"
+      sha256 "13ea423628301e74f5ce3364ccd0a013c27a78bf07ba65bd402c4f6e599501e1"
+
+      resource "tla-mcp-bin" do
+        url "https://github.com/fabracht/tla-rs/releases/download/v0.4.2/tla-mcp-macos-arm64"
+        sha256 "a1c3536d713e0649ffed9903ef621496c7bbc6d3d7aa932b54446bb65c9f9335"
+      end
+    end
+    on_intel do
+      url "https://github.com/fabracht/tla-rs/releases/download/v0.4.2/tla-macos-amd64"
+      sha256 "943b7e54b73ae7196099909a8012c0956cf1c3ada0ebdb93b80af5f1d6bdee01"
+
+      resource "tla-mcp-bin" do
+        url "https://github.com/fabracht/tla-rs/releases/download/v0.4.2/tla-mcp-macos-amd64"
+        sha256 "0117c01eb8d03f2707d6f5ee46cf64345a637c98c602d641f98b58e24858d1e9"
+      end
+    end
+  end
+
+  on_linux do
+    url "https://github.com/fabracht/tla-rs/releases/download/v0.4.2/tla-linux-amd64"
+    sha256 "d228cf356aa9d9998df55844015ce5bc83240899a5de7d4621f9bf6c0b69d009"
+
+    resource "tla-mcp-bin" do
+      url "https://github.com/fabracht/tla-rs/releases/download/v0.4.2/tla-mcp-linux-amd64"
+      sha256 "f72281acb2c41b8a20f8b8edbd36f3f0870b45dd9d1b0be050e6a1a8eb09f32a"
+    end
+  end
+
+  def install
+    tla_asset = OS.mac? ? "tla-macos-#{Hardware::CPU.arm? ? "arm64" : "amd64"}" : "tla-linux-amd64"
+    bin.install tla_asset => "tla"
+
+    resource("tla-mcp-bin").stage do
+      mcp_asset = Dir["tla-mcp-*"].first
+      bin.install mcp_asset => "tla-mcp"
+    end
+  end
+
+  test do
+    assert_match "tla", shell_output("#{bin}/tla --help", 0)
+    # tla-mcp is a stdio server; verify it loads without panic by feeding EOF
+    output = shell_output("echo '' | #{bin}/tla-mcp 2>&1", 1)
+    assert_match "ConnectionClosed", output
+  end
+end

--- a/packaging/homebrew/tla-mcp.rb
+++ b/packaging/homebrew/tla-mcp.rb
@@ -4,6 +4,11 @@ class TlaMcp < Formula
   version "0.4.2"
   license "MIT OR Apache-2.0"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   on_macos do
     on_arm do
       url "https://github.com/fabracht/tla-rs/releases/download/v0.4.2/tla-macos-arm64"
@@ -35,13 +40,19 @@ class TlaMcp < Formula
     end
   end
 
+  def platform_suffix
+    if OS.mac?
+      Hardware::CPU.arm? ? "macos-arm64" : "macos-amd64"
+    else
+      "linux-amd64"
+    end
+  end
+
   def install
-    tla_asset = OS.mac? ? "tla-macos-#{Hardware::CPU.arm? ? "arm64" : "amd64"}" : "tla-linux-amd64"
-    bin.install tla_asset => "tla"
+    bin.install "tla-#{platform_suffix}" => "tla"
 
     resource("tla-mcp-bin").stage do
-      mcp_asset = Dir["tla-mcp-*"].first
-      bin.install mcp_asset => "tla-mcp"
+      bin.install "tla-mcp-#{platform_suffix}" => "tla-mcp"
     end
   end
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Install tla and tla-mcp binaries from a GitHub release.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash -s -- --bin tla-mcp
+#   curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash -s -- --version v0.4.2 --dir /usr/local/bin
+#
+# Flags:
+#   --bin <tla|tla-mcp|both>  Which binary to install (default: both)
+#   --version <vX.Y.Z>        Release tag to install (default: latest)
+#   --dir <path>              Install directory (default: $HOME/.local/bin)
+
+set -euo pipefail
+
+REPO="fabracht/tla-rs"
+INSTALL_DIR="${HOME}/.local/bin"
+VERSION="latest"
+BIN_CHOICE="both"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --bin)
+            BIN_CHOICE="$2"
+            shift 2
+            ;;
+        --version)
+            VERSION="$2"
+            shift 2
+            ;;
+        --dir)
+            INSTALL_DIR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# //;s/^#//' | head -20
+            exit 0
+            ;;
+        *)
+            echo "error: unknown flag '$1'" >&2
+            echo "see --help for usage" >&2
+            exit 2
+            ;;
+    esac
+done
+
+case "$BIN_CHOICE" in
+    tla|tla-mcp|both) ;;
+    *)
+        echo "error: --bin must be one of: tla, tla-mcp, both (got '$BIN_CHOICE')" >&2
+        exit 2
+        ;;
+esac
+
+detect_platform() {
+    local os arch
+    case "$(uname -s)" in
+        Linux*)  os="linux" ;;
+        Darwin*) os="macos" ;;
+        *)
+            echo "error: unsupported OS '$(uname -s)'. Try cargo install tla-checker." >&2
+            exit 1
+            ;;
+    esac
+    case "$(uname -m)" in
+        x86_64|amd64) arch="amd64" ;;
+        arm64|aarch64)
+            if [[ "$os" == "linux" ]]; then
+                echo "error: linux-arm64 prebuilt binary is not produced yet. Try cargo install tla-checker." >&2
+                exit 1
+            fi
+            arch="arm64"
+            ;;
+        *)
+            echo "error: unsupported architecture '$(uname -m)'" >&2
+            exit 1
+            ;;
+    esac
+    echo "${os}-${arch}"
+}
+
+resolve_version() {
+    if [[ "$VERSION" != "latest" ]]; then
+        # Accept both "v0.4.2" and "0.4.2"
+        case "$VERSION" in
+            v*) echo "$VERSION" ;;
+            *)  echo "v$VERSION" ;;
+        esac
+        return
+    fi
+    local resolved
+    resolved="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+        | grep -E '^\s*"tag_name":' \
+        | head -1 \
+        | cut -d'"' -f4)"
+    if [[ -z "$resolved" ]]; then
+        echo "error: failed to resolve latest release tag" >&2
+        exit 1
+    fi
+    echo "$resolved"
+}
+
+download_binary() {
+    local binary="$1" platform="$2" version="$3"
+    local asset="${binary}-${platform}"
+    local url="https://github.com/${REPO}/releases/download/${version}/${asset}"
+    local target="${INSTALL_DIR}/${binary}"
+    echo "  downloading ${asset} from ${version}..."
+    curl --fail --silent --show-error --location --output "$target" "$url"
+    chmod +x "$target"
+    echo "  installed: ${target}"
+}
+
+PLATFORM="$(detect_platform)"
+RESOLVED_VERSION="$(resolve_version)"
+
+echo "platform: ${PLATFORM}"
+echo "version:  ${RESOLVED_VERSION}"
+echo "dir:      ${INSTALL_DIR}"
+
+mkdir -p "$INSTALL_DIR"
+
+case "$BIN_CHOICE" in
+    tla)     download_binary tla     "$PLATFORM" "$RESOLVED_VERSION" ;;
+    tla-mcp) download_binary tla-mcp "$PLATFORM" "$RESOLVED_VERSION" ;;
+    both)
+        download_binary tla     "$PLATFORM" "$RESOLVED_VERSION"
+        download_binary tla-mcp "$PLATFORM" "$RESOLVED_VERSION"
+        ;;
+esac
+
+echo
+echo "Done."
+echo
+case ":${PATH}:" in
+    *":${INSTALL_DIR}:"*) ;;
+    *)
+        echo "note: ${INSTALL_DIR} is not on your PATH."
+        echo "      add it (e.g.) by appending to your shell rc:"
+        echo "        export PATH=\"${INSTALL_DIR}:\$PATH\""
+        ;;
+esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,16 +1,8 @@
 #!/usr/bin/env bash
 #
 # Install tla and tla-mcp binaries from a GitHub release.
-#
-# Usage:
-#   curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash
-#   curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash -s -- --bin tla-mcp
-#   curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash -s -- --version v0.4.2 --dir /usr/local/bin
-#
-# Flags:
-#   --bin <tla|tla-mcp|both>  Which binary to install (default: both)
-#   --version <vX.Y.Z>        Release tag to install (default: latest)
-#   --dir <path>              Install directory (default: $HOME/.local/bin)
+# Verifies SHA256 checksums against the release's SHA256SUMS asset
+# before installing.
 
 set -euo pipefail
 
@@ -19,22 +11,43 @@ INSTALL_DIR="${HOME}/.local/bin"
 VERSION="latest"
 BIN_CHOICE="both"
 
+print_help() {
+    cat <<'EOF'
+Install tla and tla-mcp binaries from a GitHub release.
+
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash
+  curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash -s -- --bin tla-mcp
+  curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash -s -- --version v0.4.2 --dir /usr/local/bin
+
+Flags:
+  --bin <tla|tla-mcp|both>  Which binary to install (default: both)
+  --version <vX.Y.Z>        Release tag to install (default: latest)
+  --dir <path>              Install directory (default: $HOME/.local/bin)
+  -h, --help                Show this message
+
+Each downloaded binary is verified against the SHA256SUMS asset attached
+to the release. If SHA256SUMS is missing from the chosen release (older
+versions before checksum publishing was added), the script fails closed.
+EOF
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --bin)
-            BIN_CHOICE="$2"
+            BIN_CHOICE="${2:?error: --bin requires a value}"
             shift 2
             ;;
         --version)
-            VERSION="$2"
+            VERSION="${2:?error: --version requires a value}"
             shift 2
             ;;
         --dir)
-            INSTALL_DIR="$2"
+            INSTALL_DIR="${2:?error: --dir requires a value}"
             shift 2
             ;;
         -h|--help)
-            grep '^#' "$0" | sed 's/^# //;s/^#//' | head -20
+            print_help
             exit 0
             ;;
         *)
@@ -82,7 +95,6 @@ detect_platform() {
 
 resolve_version() {
     if [[ "$VERSION" != "latest" ]]; then
-        # Accept both "v0.4.2" and "0.4.2"
         case "$VERSION" in
             v*) echo "$VERSION" ;;
             *)  echo "v$VERSION" ;;
@@ -91,7 +103,7 @@ resolve_version() {
     fi
     local resolved
     resolved="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-        | grep -E '^\s*"tag_name":' \
+        | grep -E '^[[:space:]]*"tag_name":' \
         | head -1 \
         | cut -d'"' -f4)"
     if [[ -z "$resolved" ]]; then
@@ -101,19 +113,20 @@ resolve_version() {
     echo "$resolved"
 }
 
-download_binary() {
-    local binary="$1" platform="$2" version="$3"
-    local asset="${binary}-${platform}"
-    local url="https://github.com/${REPO}/releases/download/${version}/${asset}"
-    local target="${INSTALL_DIR}/${binary}"
-    echo "  downloading ${asset} from ${version}..."
-    curl --fail --silent --show-error --location --output "$target" "$url"
-    chmod +x "$target"
-    echo "  installed: ${target}"
+pick_hasher() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        echo "sha256sum"
+    elif command -v shasum >/dev/null 2>&1; then
+        echo "shasum -a 256"
+    else
+        echo "error: no sha256sum or shasum binary available; cannot verify download" >&2
+        exit 1
+    fi
 }
 
 PLATFORM="$(detect_platform)"
 RESOLVED_VERSION="$(resolve_version)"
+HASHER="$(pick_hasher)"
 
 echo "platform: ${PLATFORM}"
 echo "version:  ${RESOLVED_VERSION}"
@@ -121,12 +134,50 @@ echo "dir:      ${INSTALL_DIR}"
 
 mkdir -p "$INSTALL_DIR"
 
+CHECKSUMS_FILE="$(mktemp -t tla-checksums.XXXXXX)"
+trap 'rm -f "$CHECKSUMS_FILE"' EXIT
+CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${RESOLVED_VERSION}/SHA256SUMS"
+if ! curl --fail --silent --show-error --location --output "$CHECKSUMS_FILE" "$CHECKSUMS_URL"; then
+    echo "error: SHA256SUMS asset missing from ${RESOLVED_VERSION} release." >&2
+    echo "       Releases v0.4.2 and earlier do not include this asset." >&2
+    echo "       Pass --version v0.4.3 or later, or use cargo install tla-checker." >&2
+    exit 1
+fi
+echo "fetched: SHA256SUMS"
+
+verify_and_install() {
+    local binary="$1"
+    local asset="${binary}-${PLATFORM}"
+    local url="https://github.com/${REPO}/releases/download/${RESOLVED_VERSION}/${asset}"
+    local target="${INSTALL_DIR}/${binary}"
+    local expected actual
+
+    expected="$(grep -E "[[:space:]]${asset}\$" "$CHECKSUMS_FILE" | awk '{print $1}')"
+    if [[ -z "$expected" ]]; then
+        echo "error: no SHA256 entry for ${asset} in SHA256SUMS" >&2
+        exit 1
+    fi
+
+    echo "  downloading ${asset}..."
+    curl --fail --silent --show-error --location --output "$target" "$url"
+    actual="$($HASHER "$target" | awk '{print $1}')"
+    if [[ "$expected" != "$actual" ]]; then
+        echo "error: checksum mismatch for ${asset}" >&2
+        echo "  expected: ${expected}" >&2
+        echo "  actual:   ${actual}" >&2
+        rm -f "$target"
+        exit 1
+    fi
+    chmod +x "$target"
+    echo "  installed: ${target} (sha256 verified)"
+}
+
 case "$BIN_CHOICE" in
-    tla)     download_binary tla     "$PLATFORM" "$RESOLVED_VERSION" ;;
-    tla-mcp) download_binary tla-mcp "$PLATFORM" "$RESOLVED_VERSION" ;;
+    tla)     verify_and_install tla ;;
+    tla-mcp) verify_and_install tla-mcp ;;
     both)
-        download_binary tla     "$PLATFORM" "$RESOLVED_VERSION"
-        download_binary tla-mcp "$PLATFORM" "$RESOLVED_VERSION"
+        verify_and_install tla
+        verify_and_install tla-mcp
         ;;
 esac
 


### PR DESCRIPTION
## Summary

Two zero-toolchain install paths for `tla` and `tla-mcp`, plus a README rewrite of the MCP install section.

- `scripts/install.sh` — POSIX shell installer (Linux x86_64, macOS x86_64, macOS arm64). Detects platform, resolves the latest release tag (or pinned `--version`), downloads the right prebuilt binaries from GitHub releases, drops them in `$HOME/.local/bin` by default. Flags: `--bin <tla|tla-mcp|both>`, `--version <tag>`, `--dir <path>`. End-to-end smoke test against the v0.4.2 release downloaded both binaries cleanly
- `packaging/homebrew/tla-mcp.rb` — Homebrew formula installing both `tla` and `tla-mcp`. SHA256s pinned to v0.4.2 release assets. Validated locally via a temporary tap (`brew install ...` succeeded, `brew test ...` passed both assertions, binaries landed on PATH)
- `packaging/homebrew/README.md` — explains the one-time `homebrew-tla` tap setup (separate repo with `homebrew-` prefix), end-user install, and how to refresh SHA256s on each release
- README MCP "Install" section now lists five paths in order: Homebrew, install script, cargo from crates.io, GitHub release downloads, `--path .` from a clone

Bumped Cargo.toml 0.4.2 → 0.4.3, CHANGELOG entry under `### Distribution`.

## Test plan

- [x] `cargo make check-format` clean
- [x] `cargo make clippy` clean
- [x] `cargo test --lib` — 160 pass
- [x] `bash -n scripts/install.sh` — shell syntax clean
- [x] End-to-end install script run against v0.4.2 release — both binaries downloaded, `tla-mcp` runs to expected `ConnectionClosed` on empty stdin
- [x] Homebrew formula installed via a temporary tap, both binaries end up in `$(brew --prefix)/bin`, `brew test` passes