### PR TITLE
add tla-mcp landing page for github pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>tla-mcp — TLA+ model checker as an MCP server</title>
+    <meta
+      name="description"
+      content="An MCP server that gives Claude Code, Cursor, and other agentic clients first-class access to a TLA+ model checker. Verify your spec, replay scenarios, and catch invariant violations from the same chat where you wrote them."
+    />
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ctext y='52' font-size='52'%3E%E2%97%87%3C/text%3E%3C/svg%3E" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>tla-mcp</h1>
+        <p class="tagline">
+          A TLA+ model checker as a Model Context Protocol server.
+        </p>
+        <p class="lede">
+          Plug a working model checker into Claude Code, Cursor, or any
+          MCP-aware client. Validate specs, replay counterexamples, and
+          catch invariant violations without leaving the conversation.
+        </p>
+        <div class="badges">
+          <a href="https://crates.io/crates/tla-checker"
+            ><img alt="crates.io"
+              src="https://img.shields.io/crates/v/tla-checker?style=flat-square&amp;label=crates.io"
+          /></a>
+          <a href="https://www.npmjs.com/package/tla-checker"
+            ><img alt="npm"
+              src="https://img.shields.io/npm/v/tla-checker?style=flat-square&amp;label=npm"
+          /></a>
+          <a href="https://github.com/fabracht/tla-rs/releases/latest"
+            ><img alt="latest release"
+              src="https://img.shields.io/github/v/release/fabracht/tla-rs?style=flat-square&amp;label=release"
+          /></a>
+          <a href="https://github.com/fabracht/tla-rs/blob/main/LICENSE"
+            ><img alt="license"
+              src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue?style=flat-square"
+          /></a>
+        </div>
+      </header>
+
+      <section id="what">
+        <h2>What is this?</h2>
+        <p>
+          <strong>TLA+</strong> is a specification language for designing
+          and verifying concurrent and distributed systems. You describe
+          what your protocol should do; a model checker tries every
+          reachable state and tells you when something goes wrong.
+        </p>
+        <p>
+          <strong>The Model Context Protocol</strong> (MCP) is how
+          agentic clients like Claude Code call external tools.
+        </p>
+        <p>
+          <code>tla-mcp</code> bridges the two. It's a stdio MCP server
+          built on top of <a href="https://github.com/fabracht/tla-rs">tla-rs</a>,
+          a fast TLA+ model checker written in Rust. Once registered,
+          your client can parse a spec, list its invariants, run a full
+          check with a budgeted time limit, and replay specific
+          scenarios — all from inside the chat.
+        </p>
+      </section>
+
+      <section id="install">
+        <h2>Install</h2>
+        <p>Pick whichever fits your toolchain. All paths install the same v0.4.3 binary.</p>
+
+        <h3>Homebrew (macOS, Linuxbrew)</h3>
+        <pre><code>brew install fabracht/tla/tla-mcp</code></pre>
+        <p class="aside">Installs both <code>tla</code> (model checker CLI) and <code>tla-mcp</code> (MCP server).</p>
+
+        <h3>Install script (Linux, macOS)</h3>
+        <pre><code>curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash</code></pre>
+        <p class="aside">SHA256-verified binary download. Pass <code>--bin tla-mcp</code> to install just the server.</p>
+
+        <h3>Cargo (any platform with a Rust toolchain)</h3>
+        <pre><code>cargo install tla-checker --bin tla-mcp</code></pre>
+
+        <h3>Pre-built release binaries</h3>
+        <p>
+          Linux x86_64, macOS x86_64, macOS arm64, Windows x86_64 are attached to
+          every <a href="https://github.com/fabracht/tla-rs/releases/latest">GitHub release</a>
+          as <code>tla-&lt;platform&gt;</code> and <code>tla-mcp-&lt;platform&gt;</code>,
+          alongside a <code>SHA256SUMS</code> file.
+        </p>
+      </section>
+
+      <section id="register">
+        <h2>Register with your client</h2>
+        <p>Add to your MCP client config (Claude Code example, <code>~/.claude/mcp.json</code>):</p>
+        <pre><code>{
+  "mcpServers": {
+    "tla": {
+      "command": "tla-mcp"
+    }
+  }
+}</code></pre>
+        <p>Restart the client. The four tools become available immediately.</p>
+      </section>
+
+      <section id="tools">
+        <h2>What the agent gets</h2>
+        <p>Four tools, versioned JSON schemas (<code>schema_version: "1"</code>):</p>
+        <table>
+          <thead>
+            <tr><th><code>tool</code></th><th>purpose</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>validate_spec</code></td>
+              <td>
+                Parse a <code>.tla</code> file. Returns vars,
+                <strong>constants with resolved values</strong>, detected invariants,
+                <code>has_init</code> / <code>has_next</code>, plus structured parse errors with source spans.
+              </td>
+            </tr>
+            <tr>
+              <td><code>list_invariants</code></td>
+              <td>
+                Return invariant names matching <code>Inv*</code>, <code>TypeOK*</code>, <code>NotSolved*</code>,
+                plus anything declared via cfg <code>INVARIANT</code> directive.
+              </td>
+            </tr>
+            <tr>
+              <td><code>check_spec</code></td>
+              <td>
+                Full model checking with required <code>max_states</code> / <code>max_depth</code> /
+                <code>max_seconds</code> budgets. Returns <code>ok</code>,
+                <code>invariant_violation</code> (with trace + actions), <code>deadlock</code>,
+                <code>liveness_violation</code> (prefix + cycle), <code>limit_reached</code>, or structured <code>error</code>.
+              </td>
+            </tr>
+            <tr>
+              <td><code>replay_scenario</code></td>
+              <td>
+                Step through a spec along a guided path (<code>step: &lt;TLA+ expr&gt;</code> lines).
+                Returns per-step state snapshots + variable changes, or a failure with
+                <code>available_actions</code> on a mismatch.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="why">
+        <h2>Why TLA+ for an agent?</h2>
+        <p>
+          Most "is this code correct?" questions an agent answers are
+          really questions about <em>reachable behavior</em> — a race
+          condition that fires in one specific interleaving, a queue
+          that grows unboundedly under a corner-case workload, a
+          consensus rule that lets two leaders coexist for one tick.
+          Reasoning about all these by reading code is hard. Asking a
+          model checker is straightforward, when the model checker is
+          one tool call away.
+        </p>
+        <p>
+          <code>tla-mcp</code> is opinionated about how an agent should
+          use it. Tool descriptions explicitly tell the agent: budget
+          all three limits upfront; inspect constants before running;
+          treat <code>limit_reached</code> as inconclusive, not as a
+          pass; bugs are usually in the last transition of the trace.
+          These are not soft hints — they're encoded in the tool
+          metadata so they survive context truncation.
+        </p>
+      </section>
+
+      <section id="links">
+        <h2>More</h2>
+        <ul>
+          <li><a href="https://github.com/fabracht/tla-rs">Source &amp; docs on GitHub</a></li>
+          <li><a href="https://github.com/fabracht/tla-rs/blob/main/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/fabracht/tla-rs/releases">Releases</a></li>
+          <li><a href="https://github.com/fabracht/homebrew-tla">Homebrew tap</a></li>
+          <li><a href="https://modelcontextprotocol.io/">Model Context Protocol spec</a></li>
+          <li><a href="https://lamport.azurewebsites.net/tla/tla.html">Learn TLA+ (Leslie Lamport)</a></li>
+        </ul>
+      </section>
+
+      <footer>
+        <p>
+          <code>tla-mcp</code> is MIT / Apache-2.0 licensed.
+          <a href="https://github.com/fabracht/tla-rs">View on GitHub</a>.
+        </p>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,202 @@
+:root {
+  --bg: #fafaf7;
+  --fg: #1c1c1c;
+  --muted: #6b6b6b;
+  --accent: #2a52be;
+  --code-bg: #f0eee6;
+  --border: #d8d4c8;
+  --max: 720px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #14140f;
+    --fg: #e8e6dd;
+    --muted: #a0a09a;
+    --accent: #8ab4ff;
+    --code-bg: #1f1f18;
+    --border: #2e2e26;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial,
+    sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+main {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 3rem 1.25rem 4rem;
+}
+
+header {
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--border);
+}
+
+h1 {
+  font-size: 2.4rem;
+  margin: 0 0 0.5rem;
+  font-family:
+    "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+  letter-spacing: -0.02em;
+}
+
+h2 {
+  font-size: 1.4rem;
+  margin: 2.5rem 0 0.75rem;
+  padding-top: 0.5rem;
+}
+
+h3 {
+  font-size: 1.05rem;
+  margin: 1.5rem 0 0.5rem;
+  font-weight: 600;
+}
+
+p {
+  margin: 0.75rem 0;
+}
+
+.tagline {
+  font-size: 1.15rem;
+  color: var(--fg);
+  font-weight: 500;
+  margin-top: 0;
+}
+
+.lede {
+  color: var(--muted);
+  font-size: 1rem;
+}
+
+.aside {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin-top: -0.25rem;
+}
+
+.badges {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.badges img {
+  display: block;
+  height: 20px;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+code,
+pre {
+  font-family:
+    "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.875em;
+}
+
+code {
+  background: var(--code-bg);
+  padding: 0.1em 0.35em;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+pre {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.85rem 1rem;
+  overflow-x: auto;
+  line-height: 1.45;
+  margin: 0.5rem 0;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  white-space: pre;
+}
+
+ul {
+  padding-left: 1.25rem;
+}
+
+li {
+  margin: 0.25rem 0;
+}
+
+section {
+  margin-top: 2.5rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0;
+  font-size: 0.9rem;
+}
+
+th,
+td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+}
+
+th {
+  font-weight: 600;
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+td code {
+  white-space: normal;
+}
+
+footer {
+  margin-top: 4rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 600px) {
+  main {
+    padding: 2rem 1rem;
+  }
+  h1 {
+    font-size: 1.85rem;
+  }
+}


### PR DESCRIPTION
## Summary

Single static landing page for the MCP server, ready to be served by GitHub Pages from `main` → `/docs`. No build step, no JS dependencies, no tracking.

Contents (`docs/index.html`):
- Hero with tagline and shields.io badges (crates.io, npm, latest release, license)
- "What is this?" — brief MCP + TLA+ explainer for visitors who don't know one or the other
- "Install" — five paths (Homebrew, install script, cargo, prebuilt binary download)
- "Register with your client" — Claude Code config example
- "What the agent gets" — table of the four tools and what they return
- "Why TLA+ for an agent?" — short pitch focused on agentic use cases
- "More" — link block (repo, changelog, releases, tap, MCP spec, learn TLA+)

`docs/styles.css`:
- Single column, max-width 720px, system font stack with JetBrains Mono fallback for headings/code
- Light + dark mode via `prefers-color-scheme`
- Mobile-friendly via one media query at 600px
- ~140 lines total

`docs/.nojekyll`:
- Disables Jekyll processing on Pages (we don't use Liquid/front-matter; this avoids quirky underscore-prefixed file handling)

## Activation after merge

GitHub Pages needs to be enabled in repo Settings → Pages, source = main / `/docs`. I can do that via `gh api` after merge if you want.

## Test plan

- [x] HTML parses without unclosed elements (HTML5 void-element false positives ignored)
- [x] `python3 -m http.server` against `docs/` serves both files with HTTP 200
- [x] CSS is well-formed (uses standard properties; tested via inspection)