### PR TITLE
fix action: pinning for top-level existential actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.5.2] - 2026-05-27
+
+### Fixed
+
+- `action: <Name>` pinning in `replay_scenario` (and therefore `append_beat` / `validate_demo` beats and `--present` scenarios) could not match an action whose definition body is a top-level existential quantifier — `Op == \E x \in S: ...`. Those transitions were emitted unlabeled, so no `action: Op` line matched them and the user saw a misleading "no transition matches condition" even though the transition existed and was reachable. The action-name labeler descended through a top-level `\E` to name the inner body (which never equals the operator's stored body) before trying to match the whole `\E`; it now matches the whole existential against the operator definitions as a fallback. Affects the common `Action == \E p \in Procs: Step(p)` idiom. `available_actions` diagnostics and per-action stats now label these transitions by name as well.
+
 ## [0.5.1] - 2026-05-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/eval/ast_utils.rs
+++ b/src/eval/ast_utils.rs
@@ -50,21 +50,25 @@ pub(crate) fn format_expr_brief(expr: &Expr) -> String {
     }
 }
 
+fn match_def_body(expr: &Expr, defs: &Definitions) -> Option<Arc<str>> {
+    for (name, (params, body)) in defs {
+        if params.is_empty() && body == expr {
+            return Some(name.clone());
+        }
+    }
+    None
+}
+
 pub(crate) fn infer_action_name(expr: &Expr, defs: &Definitions) -> Option<Arc<str>> {
     match expr {
         Expr::LabeledAction(label, _) => Some(label.clone()),
         Expr::Var(name) => Some(name.clone()),
         Expr::FnCall(name, _) => Some(name.clone()),
         Expr::Let(_, _, _) => infer_name_from_let_chain(expr, defs),
-        Expr::Exists(_, _, body) => infer_action_name(body, defs),
-        _ => {
-            for (name, (params, body)) in defs {
-                if params.is_empty() && body == expr {
-                    return Some(name.clone());
-                }
-            }
-            None
+        Expr::Exists(_, _, body) => {
+            infer_action_name(body, defs).or_else(|| match_def_body(expr, defs))
         }
+        _ => match_def_body(expr, defs),
     }
 }
 
@@ -96,22 +100,15 @@ pub(crate) fn collect_disjuncts_with_labels<'a>(
         Expr::LabeledAction(label, action) => vec![(action.as_ref(), Some(label.clone()))],
         Expr::Var(name) => vec![(expr, Some(name.clone()))],
         Expr::FnCall(name, _) => vec![(expr, Some(name.clone()))],
-        Expr::Exists(_, _, body) => {
-            let label = infer_action_name(body, defs);
+        Expr::Exists(_, _, _) => {
+            let label = infer_action_name(expr, defs);
             vec![(expr, label)]
         }
         Expr::Let(_, _, _) => {
             let label = infer_name_from_let_chain(expr, defs);
             vec![(expr, label)]
         }
-        _ => {
-            for (name, (params, body)) in defs {
-                if params.is_empty() && body == expr {
-                    return vec![(expr, Some(name.clone()))];
-                }
-            }
-            vec![(expr, None)]
-        }
+        _ => vec![(expr, match_def_body(expr, defs))],
     }
 }
 

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -602,4 +602,28 @@ Next == Inc \/ Dec
         let result = execute_scenario(&spec, &scenario, &domains).unwrap();
         assert!(result.failure.is_some());
     }
+
+    #[test]
+    fn action_pins_top_level_existential() {
+        let src = r#"---- MODULE T ----
+EXTENDS Integers
+VARIABLES y, z
+Init == y = 0 /\ z = 0
+ConjAction == y' = 1 /\ z' = 0
+TopExists == \E q \in 1..3 : y' = q /\ z' = 1
+Next == ConjAction \/ TopExists
+===="#;
+        let spec = crate::parser::parse(src).expect("spec parses");
+        let domains = Env::new();
+        let scenario = parse_scenario("action: TopExists; y' = 2").unwrap();
+        let result = execute_scenario(&spec, &scenario, &domains).unwrap();
+        assert!(
+            result.failure.is_none(),
+            "an action whose body is a top-level existential must be pinnable by name"
+        );
+        assert_eq!(
+            result.states.last().unwrap().1.values,
+            vec![Value::Int(2), Value::Int(1)]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`action: <Name>` pinning in `replay_scenario` — and therefore in `append_beat` / `validate_demo` beats and `--present` scenarios — could not match an action whose definition body is a **top-level existential quantifier** (`Op == \E x \in S: ...`). Those transitions were emitted unlabeled, so no `action: Op` line ever matched, and the user got a misleading `no transition matches condition` even though the transition existed and was reachable.

This is purely about whether the `\E` is the **outermost** operator of the action body — not about having an `\E` at all, nor the number of bound variables.

| Action shape | Example | Before | After |
|---|---|---|---|
| Top-level conjunction | `ConjAction == /\ y'=1 /\ z'=z` | named | named |
| `\E` nested in a conjunct | `Nested == /\ \E x: y'=x /\ z'=z` | named | named |
| Top-level `\E`, one bound var | `TopExists1 == \E x: ...` | **unnamed** | named |
| Top-level `\E`, multiple bound vars | `TopExists2 == \E a,b: ...` | **unnamed** | named |

## Root cause

Operator references in `Next` are inlined to their bodies before action-naming runs, so the namer reverse-maps each inlined disjunct back to an operator by body-equality. For an `Expr::Exists`, both `infer_action_name` and `collect_disjuncts_with_labels` descended **through** the `\E` to name the inner body — which never equals the operator's stored def body (the def body *is* the whole `\E`) — before ever trying to match the whole existential. Result: `None`.

## Fix

For `Expr::Exists`, name the inner body first (preserves the `\E p: Step(p)` → `Step` idiom), then fall back to matching the **whole** `\E` against the operator definitions (recovers `Reboot` / `TopExists`). Strictly additive: it only assigns names to transitions that were previously unnamed, so per-action stats and existing labels are unchanged. `available_actions` diagnostics now label these transitions by name as well.

This covers the common `Action == \E p \in Procs: Step(p)` idiom that nearly every multi-process spec uses.

## Test plan

- [x] New regression test `action_pins_top_level_existential` (`src/scenario.rs`)
- [x] Manual: all four shapes in the controlled experiment pin by name; `available_actions` no longer prints `(unnamed)`
- [x] End-to-end through the demo/beat layer via `--present --validate`
- [x] Full suite: 275 pass (175 lib + 36 MCP + 64 oracle); clippy clean