### PR TITLE
add explorable HTML export with embedded wasm engine

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,36 @@ jobs:
       - name: Publish to crates.io
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} || echo "Version already published, skipping"
 
+  build-wasm:
+    name: Build WASM engine
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli --version 0.2.108 --locked
+
+      - name: Build wasm engine
+        run: |
+          cargo rustc --lib --release --target wasm32-unknown-unknown --features wasm --crate-type cdylib
+          wasm-bindgen --target web --out-dir pkg target/wasm32-unknown-unknown/release/tla_checker.wasm
+
+      - name: Upload wasm pkg
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-pkg
+          path: |
+            pkg/tla_checker_bg.wasm
+            pkg/tla_checker.js
+
   build-binaries:
     name: Build CLI Binaries
+    needs: build-wasm
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -63,8 +91,17 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Build CLI binaries
-        run: cargo build --release --bin tla --bin tla-mcp --target ${{ matrix.target }}
+      - name: Download wasm pkg
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-pkg
+          path: pkg
+
+      - name: Build tla (with embedded wasm engine)
+        run: cargo build --release --bin tla --features embed-wasm --target ${{ matrix.target }}
+
+      - name: Build tla-mcp
+        run: cargo build --release --bin tla-mcp --target ${{ matrix.target }}
 
       - name: Stage binaries
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.3] - 2026-05-28
+
+### Added
+
+- `tla --present <manifest> --export-html <file> --explorable` embeds the wasm model-checking engine directly in the exported HTML, turning the offline walkthrough into a live state explorer (like interactive CLI mode, in the browser). The "Explore" tab steps through enabled actions from any state, shows live invariant results (`✓`/`✗` per spec invariant) at each state, and includes a REPL for evaluating TLA+ expressions against the current state. Requires building with `--features embed-wasm` (run `cargo make wasm` first to produce the `pkg/` artifacts that get inlined); the engine is base64-inlined and instantiated synchronously, so the file stays fully self-contained and works over `file://`. File-based `INSTANCE` modules are not available in-browser (single-file specs only).
+- WASM bindings `explore_init` / `explore_next` / `explore_eval` / `explore_invariants` expose per-state stepping, successor enumeration, expression evaluation, and invariant checking to JS.
+
 ## [0.5.2] - 2026-05-27
 
 ### Fixed

--- a/CLI_GUIDE.md
+++ b/CLI_GUIDE.md
@@ -1,0 +1,143 @@
+# CLI Guide
+
+Detailed usage for the `tla` command-line tool. See the [README](README.md) for installation, a quick start, and the full options table.
+
+## Configuration Files
+
+tla-rs supports TLC-compatible `.cfg` files. If `Spec.cfg` exists next to `Spec.tla`, it is loaded automatically. Use `--config PATH` to specify an explicit path.
+
+```
+CONSTANT RM = {rm1, rm2, rm3}
+INIT TPInit
+NEXT TPNext
+INVARIANT TPTypeOK
+CHECK_DEADLOCK TRUE
+```
+
+Supported directives: `INIT`/`NEXT`, `SPECIFICATION` (temporal formula in `Init /\ [][Next]_vars` form), `CONSTANT`/`CONSTANTS`, `INVARIANT`/`INVARIANTS`, `PROPERTY`/`PROPERTIES`, `SYMMETRY`, and `CHECK_DEADLOCK`. CLI flags override cfg values.
+
+## Scenarios
+
+Drive the checker along specific execution paths using TLA+ expressions:
+
+```bash
+tla spec.tla --scenario "step: count' = count + 1
+step: count' = count + 1
+step: count' = count + 1"
+```
+
+Or load from a file with `--scenario @scenario.txt`. Each `step:` line is a TLA+ predicate over current (unprimed) and next (primed) state variables.
+
+```
+step: x' > x                    # x increases
+step: "s1" \in active'          # s1 becomes active
+step: pc'["p1"] = "critical"    # p1 enters critical section
+```
+
+## Demo Walkthroughs
+
+`--present` runs a *demo manifest* — a `.json` or `.toml` file beside the spec that bundles named variants (spec + cfg / constant overrides) and ordered "beats". Each beat runs a scenario or replay against one or more variants and checks assertions, producing a guided, tested walkthrough of how a spec behaves.
+
+```bash
+tla --present demo.json                        # guided TUI walkthrough
+tla --present demo.json --validate             # non-interactive pass/fail report
+tla --present demo.json --export-md out.md      # tested Markdown walkthrough
+tla --present demo.json --export-html out.html  # self-contained offline HTML
+```
+
+`--export-html` writes a self-contained, offline HTML walkthrough (variant compare, step navigation, change highlighting, inline assertion results).
+
+Adding `--explorable` additionally embeds the wasm engine in the file, turning the walkthrough into a live state explorer — step through enabled actions from any state, see invariant results per state, and evaluate TLA+ expressions in a REPL, like [Interactive Mode](#interactive-mode) but in the browser. The explorable export must be built with the `embed-wasm` feature (run `cargo make wasm` first to produce the inlined `pkg/` artifacts):
+
+```bash
+cargo make wasm
+cargo build --release --features embed-wasm
+tla --present demo.json --export-html explorer.html --explorable
+```
+
+The engine is base64-inlined and instantiated synchronously, so the file stays fully self-contained and works over `file://`. File-based `INSTANCE` modules aren't available in the browser, so the explorable export works with single-file specs. Prebuilt release binaries are built with `embed-wasm`, so an installed `tla` supports `--explorable` directly.
+
+## Interactive Mode
+
+Launch the TUI with `-i` to step through state spaces manually. You can select and take transitions, backtrack, evaluate expressions in a REPL, trace variable changes across history, test hypotheses against all visited states, and toggle guard condition display. Actions with many variable changes expand inline so you can see exactly what each transition does.
+
+![Interactive mode — navigating the C-3PO asteroid field spec](falcon-escape.gif)
+
+Key bindings: `↑`/`↓` select actions, `Enter` takes the selected action, `→`/`Space` expands grouped changes, `←` collapses, `b` backtracks, `e` opens the REPL, `t` shows variable trace, `h` tests a hypothesis, `g` toggles guards, `w` random walks N steps, `u` steps until a condition holds, `s`/`l` save/load traces, `r` resets to initial state, `q` quits.
+
+```bash
+tla examples/c3po_asteroid_field.tla -c 'Density=3' --allow-deadlock -i
+```
+
+## Analytics
+
+These flags are for understanding *how* a protocol fails, not just *whether* it fails.
+
+Without `--continue`, the checker stops at the first violation. With it, all violations are collected and counted per-invariant across the full state space:
+
+```bash
+tla spec.tla --allow-deadlock --continue
+```
+
+`--count-satisfying` measures what fraction of reachable states satisfy a predicate. Add `--verbose` to get per-depth breakdowns showing at which exploration depth violations start appearing:
+
+```bash
+tla spec.tla --allow-deadlock --continue \
+  --count-satisfying InvSafety --verbose
+```
+
+`--sweep` varies a constant across multiple values and produces a comparison table, useful for sensitivity analysis:
+
+```bash
+tla spec.tla --sweep 'N=2;3;4;5' --count-satisfying Inv --allow-deadlock
+```
+
+`--json` returns structured data including `properties` array with `depth_breakdown` per property.
+
+### The C-3PO Example
+
+C-3PO famously calculates "the possibility of successfully navigating an asteroid field is approximately 3,720 to 1." The spec `examples/c3po_asteroid_field.tla` models the Empire Strikes Back asteroid chase: variable-damage asteroid impacts, TIE fighter attacks, TIEs getting destroyed by asteroids, hiding in the space slug's cave, mynock damage, escaping the exogorth's mouth, and the only real escape — attaching to a Star Destroyer's hull and floating away with the garbage. No hyperspace: the hyperdrive is dead.
+
+The `Density` constant controls asteroid damage range (1..Density). Higher values create more damage variants per action, biasing the state space toward destruction.
+
+```bash
+tla examples/c3po_asteroid_field.tla -c 'Density=3' \
+  --allow-deadlock --continue \
+  --count-satisfying InvNeverTellMeTheOdds \
+  --count-satisfying Escaped --verbose
+```
+
+The depth breakdown shows destruction starting early and escape requiring a long sequence of correct decisions — surviving asteroids, hiding in the cave, taking mynock damage, escaping the slug, then waiting for all TIE fighters to be destroyed before drifting onto a Star Destroyer's hull.
+
+## Output
+
+On success:
+```
+Model checking complete. No errors found.
+
+  States explored: 1331
+  Transitions: 3630
+  Max depth: 31
+  Time: 0.019s
+```
+
+On invariant violation, you get a counterexample trace with state diffs marking changed variables. On deadlock, a trace to the deadlock state with a suggestion to use `--allow-deadlock`. Parse errors show source locations, and undefined variables suggest similar names.
+
+## State Graph Visualization
+
+```bash
+tla spec.tla --export-dot graph.dot
+tla spec.tla --export-dot graph.dot --dot-mode full
+dot -Tpng graph.dot -o graph.png
+```
+
+Four export modes are available via `--dot-mode`:
+
+| Mode | Description |
+|------|-------------|
+| `clean` (default) | All nodes, no self-loops, parallel edges merged into single labeled edges |
+| `full` | All nodes and all edges including self-loops, each edge separate |
+| `trace` | Only counterexample trace nodes and edges (falls back to full if no trace) |
+| `choices` | Trace path plus alternative transitions at each trace state; non-trace nodes shown dashed, alternative edges gray/dashed (falls back to full if no trace) |
+
+Error states are highlighted in red. Trace edges are red and thick in all modes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"
@@ -36,6 +36,7 @@ default = []
 wasm = ["wasm-bindgen", "serde"]
 profiling = []
 dhat = ["dep:dhat"]
+embed-wasm = ["dep:base64"]
 
 [profile.release]
 lto = "fat"
@@ -61,6 +62,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = "1.0"
 dhat = { version = "0.3.3", optional = true }
 stacker = "0.1.22"
+base64 = { version = "0.22", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ratatui = { version = "0.30.0", default-features = false, features = ["crossterm"] }

--- a/MCP.md
+++ b/MCP.md
@@ -1,0 +1,87 @@
+# MCP Server
+
+`tla-mcp` exposes the model checker as a Model Context Protocol server over stdio, so agentic clients (Claude Code, Cursor, etc.) can call it as a first-class tool.
+
+## Install
+
+Several paths are supported — pick whichever fits your toolchain.
+
+**Homebrew (macOS, Linuxbrew)** — installs both `tla` and `tla-mcp`:
+
+```bash
+brew install fabracht/tla/tla-mcp
+```
+
+Requires the `homebrew-tla` tap to exist. The formula source lives at [`packaging/homebrew/tla-mcp.rb`](packaging/homebrew/tla-mcp.rb); [`packaging/homebrew/README.md`](packaging/homebrew/README.md) explains the one-time tap setup.
+
+**Install script (Linux, macOS)** — downloads a prebuilt binary and verifies its SHA256, no Rust toolchain required:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash
+```
+
+Pass flags to scope the install: `--bin tla-mcp` for just the MCP server, `--version v0.4.3` to pin a release (releases prior to v0.4.3 do not ship a `SHA256SUMS` asset and are rejected), `--dir /usr/local/bin` for a system-wide install (requires `sudo`).
+
+**Cargo (any platform with a Rust toolchain)**:
+
+```bash
+cargo install tla-checker --bin tla-mcp
+```
+
+**GitHub release downloads** — prebuilt binaries for Linux x86_64, macOS x86_64, macOS arm64, and Windows x86_64 are attached to every [release](https://github.com/fabracht/tla-rs/releases/latest) as `tla-<platform>` and `tla-mcp-<platform>`.
+
+**From a working copy**:
+
+```bash
+cargo install --path . --bin tla-mcp
+```
+
+## Register with your client
+
+**Claude Code (community plugin marketplace)** — once `tla-mcp` is on PATH:
+
+```
+/plugin marketplace add anthropics/claude-plugins-community
+/plugin install tla-rs@claude-community
+```
+
+**Manual registration (any MCP client)** — add to `~/.claude/mcp.json`, `claude_desktop_config.json`, or your client's equivalent:
+
+```json
+{
+  "mcpServers": {
+    "tla": {
+      "command": "tla-mcp"
+    }
+  }
+}
+```
+
+## Tools
+
+All tools return a `schema_version: "1"` field — the contract is frozen at version 1 and will be bumped explicitly on breaking changes.
+
+| Tool | Purpose |
+|------|---------|
+| `validate_spec` | Parse a `.tla` file and return a summary (vars, **constants with resolved values**, invariants, init/next presence). Returns a structured parse/config error with source span on failure. Inspect the `constants` array before every `check_spec` call — outlier values are the most common cause of timeouts. |
+| `list_invariants` | Return the detected invariants (definitions matching `Inv*`, `TypeOK*`, `NotSolved*`, plus anything declared in a cfg `INVARIANT` directive). |
+| `check_spec` | Run full model checking. **Requires** `max_states`, `max_depth`, AND `max_seconds` (no defaults — agents must budget all three upfront). The `max_seconds` budget is enforced during both BFS exploration and the liveness phase. Returns one of: `ok`, `invariant_violation` (with trace + invariant name + actions), `deadlock`, `liveness_violation` (with prefix + cycle), `limit_reached` (budget exhausted — not an error; `limit` is one of `max_states`/`max_depth`/`max_seconds`), or `error` (with structured phase + message + optional source span). |
+| `replay_scenario` | Walk a spec step-by-step through a guided scenario (text of `step: <TLA+ expression>` lines). Returns the same `StateSnapshot` shape as `check_spec`, plus per-step `changes` descriptions. On a step that no transition satisfies, returns `status: "failed"` with `available_actions` to help diagnose the mismatch. |
+
+The boolean toggles `allow_deadlock` and `check_liveness` are `Option<bool>` — omit them to defer to the cfg file (e.g., `CHECK_DEADLOCK FALSE` or `PROPERTY` directives), pass `true` / `false` to override the cfg. The `symmetry` field appends to any constants declared via cfg `SYMMETRY` rather than replacing them.
+
+`validate_spec` and `list_invariants` include a `warnings` array surfacing parser-tolerance warnings — when the parser fails to parse an operator body it silently skips that operator and emits a warning. The same array also surfaces unsupported temporal constructs (`<<A>>_v` diamond actions, `<>[]P` stable-eventually) that the fairness extractor drops. Without the warnings array, a typo in an invariant's body would let `check_spec` "pass" without ever checking that invariant.
+
+`check_spec` honors the cfg's `CONSTRAINT` directive (state-space pruning predicate) and accepts an inline `state_constraint: "<TLA+ expression>"` parameter. Constraints are evaluated on every state — states where the expression is false are dropped from the reachable set and not explored further. Use this to bound otherwise-explosive state spaces (e.g., `state_constraint: "Len(queue) <= 3"`) without modifying the spec.
+
+## Counterexample format
+
+Each state in a trace is `{ vars: { var_name: { display, json } } }`. The `display` field is the TLA+-formatted value (`"{1, 2, 3}"`, `"<<a, b>>"`); the `json` field is a typed JSON form preserving set/tuple/record/function structure via a `kind` tag.
+
+## Mid-session reload
+
+MCP clients spawn server processes at session startup. Rebuilding or reinstalling `tla-mcp` while a Claude Code session is already running will not hot-reload the new binary — restart the client (or open a new session) to pick up changes. Verifying outside an MCP client: `tla-mcp` invoked directly will exit with `ConnectionClosed` after stdin EOF, which is the correct behavior for a stdio server with no peer.
+
+## Observability
+
+See [`docs/MCP_OBSERVABILITY.md`](docs/MCP_OBSERVABILITY.md) for per-action stats, advisories, and the doc tracker.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A TLA+ model checker and interactive exploration tool written in Rust.
 
-tla-rs verifies TLA+ specifications by exploring all reachable states, checking invariants, and reporting counterexamples. Beyond pass/fail checking, it provides an interactive TUI for stepping through state spaces, scenario-driven exploration, property satisfaction analytics with depth breakdowns, and parameter sweeps for sensitivity analysis. The core library compiles to WebAssembly, so it can be embedded in browser applications. It's designed as a lightweight alternative to the official TLC model checker for specs that fit its supported subset.
+tla-rs verifies TLA+ specifications by exploring all reachable states, checking invariants, and reporting counterexamples. Beyond pass/fail checking it offers an interactive TUI for stepping through state spaces, scenario-driven exploration, property-satisfaction analytics, parameter sweeps, tested demo walkthroughs (with an optional in-browser explorer), and an MCP server for agentic clients. The core library compiles to WebAssembly for browser embedding. It's a lightweight alternative to the official TLC model checker for specs that fit its supported subset.
 
 ## Installation
 
@@ -10,7 +10,7 @@ tla-rs verifies TLA+ specifications by exploring all reachable states, checking 
 cargo build --release
 ```
 
-The binary will be at `target/release/tla`.
+The binary will be at `target/release/tla`. Prebuilt binaries and the `tla-mcp` server are available via Homebrew, an install script, or GitHub releases — see the [MCP Server guide](MCP.md#install).
 
 ## Quick Start
 
@@ -44,302 +44,24 @@ Constants accept integers (`42`), booleans (`TRUE`), strings (`"hello"`), and se
 | `--sweep NAME=V1;V2;...` | Sweep a constant across values, compare results |
 | `--scenario TEXT` | Explore a specific scenario (or `@file`) |
 | `-i` | Interactive TUI exploration mode |
+| `--present FILE` | Run a demo manifest (`.json`/`.toml`); TUI walkthrough, or `--validate` for a pass/fail report |
+| `--export-md FILE` | With `--present`: write a Markdown walkthrough |
+| `--export-html FILE` | With `--present`: write a self-contained HTML walkthrough |
+| `--explorable` | With `--export-html`: embed the wasm engine for in-browser state exploration |
 | `--json` | JSON output |
 | `-v` | Verbose output (depth breakdowns, etc.) |
 
-## Configuration Files
-
-tla-rs supports TLC-compatible `.cfg` files. If `Spec.cfg` exists next to `Spec.tla`, it is loaded automatically. Use `--config PATH` to specify an explicit path.
-
-```
-CONSTANT RM = {rm1, rm2, rm3}
-INIT TPInit
-NEXT TPNext
-INVARIANT TPTypeOK
-CHECK_DEADLOCK TRUE
-```
-
-Supported directives: `INIT`/`NEXT`, `SPECIFICATION` (temporal formula in `Init /\ [][Next]_vars` form), `CONSTANT`/`CONSTANTS`, `INVARIANT`/`INVARIANTS`, `PROPERTY`/`PROPERTIES`, `SYMMETRY`, and `CHECK_DEADLOCK`. CLI flags override cfg values.
-
-## Scenarios
-
-Drive the checker along specific execution paths using TLA+ expressions:
-
-```bash
-tla spec.tla --scenario "step: count' = count + 1
-step: count' = count + 1
-step: count' = count + 1"
-```
-
-Or load from a file with `--scenario @scenario.txt`. Each `step:` line is a TLA+ predicate over current (unprimed) and next (primed) state variables.
-
-```
-step: x' > x                    # x increases
-step: "s1" \in active'          # s1 becomes active
-step: pc'["p1"] = "critical"    # p1 enters critical section
-```
-
-## Analytics
-
-These flags are for understanding *how* a protocol fails, not just *whether* it fails.
-
-Without `--continue`, the checker stops at the first violation. With it, all violations are collected and counted per-invariant across the full state space:
-
-```bash
-tla spec.tla --allow-deadlock --continue
-```
-
-`--count-satisfying` measures what fraction of reachable states satisfy a predicate. Add `--verbose` to get per-depth breakdowns showing at which exploration depth violations start appearing:
-
-```bash
-tla spec.tla --allow-deadlock --continue \
-  --count-satisfying InvSafety --verbose
-```
-
-`--sweep` varies a constant across multiple values and produces a comparison table, useful for sensitivity analysis:
-
-```bash
-tla spec.tla --sweep 'N=2;3;4;5' --count-satisfying Inv --allow-deadlock
-```
-
-`--json` returns structured data including `properties` array with `depth_breakdown` per property.
-
-### The C-3PO Example
-
-C-3PO famously calculates "the possibility of successfully navigating an asteroid field is approximately 3,720 to 1." The spec `examples/c3po_asteroid_field.tla` models the Empire Strikes Back asteroid chase: variable-damage asteroid impacts, TIE fighter attacks, TIEs getting destroyed by asteroids, hiding in the space slug's cave, mynock damage, escaping the exogorth's mouth, and the only real escape — attaching to a Star Destroyer's hull and floating away with the garbage. No hyperspace: the hyperdrive is dead.
-
-The `Density` constant controls asteroid damage range (1..Density). Higher values create more damage variants per action, biasing the state space toward destruction.
-
-```bash
-tla examples/c3po_asteroid_field.tla -c 'Density=3' \
-  --allow-deadlock --continue \
-  --count-satisfying InvNeverTellMeTheOdds \
-  --count-satisfying Escaped --verbose
-```
-
-The depth breakdown shows destruction starting early and escape requiring a long sequence of correct decisions — surviving asteroids, hiding in the cave, taking mynock damage, escaping the slug, then waiting for all TIE fighters to be destroyed before drifting onto a Star Destroyer's hull.
-
-## Interactive Mode
-
-Launch the TUI with `-i` to step through state spaces manually. You can select and take transitions, backtrack, evaluate expressions in a REPL, trace variable changes across history, test hypotheses against all visited states, and toggle guard condition display. Actions with many variable changes expand inline so you can see exactly what each transition does.
-
-![Interactive mode — navigating the C-3PO asteroid field spec](falcon-escape.gif)
-
-Key bindings: `↑`/`↓` select actions, `Enter` takes the selected action, `→`/`Space` expands grouped changes, `←` collapses, `b` backtracks, `e` opens the REPL, `t` shows variable trace, `h` tests a hypothesis, `g` toggles guards, `w` random walks N steps, `u` steps until a condition holds, `s`/`l` save/load traces, `r` resets to initial state, `q` quits.
-
-```bash
-tla examples/c3po_asteroid_field.tla -c 'Density=3' --allow-deadlock -i
-```
-
-## Supported TLA+ Subset
-
-tla-rs implements the Naturals, Integers, Sequences, FiniteSets, TLC, Bags, and Bits standard modules. See `SYNTAX_STATUS.md` for the full operator-by-operator coverage table.
-
-The supported operator categories: logic (`/\`, `\/`, `~`, `=>`), comparison, arithmetic, sets (`\in`, `\union`, `\intersect`, `SUBSET`, `UNION`), functions (`[x \in S |-> e]`, `DOMAIN`, `EXCEPT`, `@@`), quantifiers (`\E`, `\A`, `CHOOSE`), records, tuples/sequences, `IF-THEN-ELSE`, `CASE`, `LET-IN`, primed variables, `UNCHANGED`, transitive closure, module instances (`INSTANCE` with qualified calls), and Unicode equivalents for all operators.
-
-### Module Instances
-
-Specs can use `INSTANCE` to import and compose modules:
-
-```tla
----- MODULE pingpong ----
-LOCAL INSTANCE Naturals
-
-VARIABLES server_to_client, client_to_server
-
-Data == [message: {"ping"}] \cup [message: {"pong"}]
-
-ServerToClientChannel(Id) == INSTANCE MChannel WITH channels <- server_to_client
-ClientToServerChannel(Id) == INSTANCE MChannel WITH channels <- client_to_server
-
-Next ==
-    \/ \E id \in ClientIds: ServerToClientChannel(id)!Send([message |-> "ping"])
-    \/ \E id \in ClientIds: ClientToServerChannel(id)!Recv([message |-> "pong"])
-====
-```
-
-Both static (`Alias == INSTANCE M WITH ...`) and parameterized (`Alias(p) == INSTANCE M WITH ...`) instances are supported. Library modules without Init/Next work as expected. The module file must be in the same directory as the spec.
-
-### Spec Structure
-
-```tla
----- MODULE Example ----
-EXTENDS Naturals
-
-CONSTANT N
-VARIABLES x, y
-
-Init == x = 0 /\ y = 0
-
-Next ==
-    \/ (x < N /\ x' = x + 1 /\ y' = y)
-    \/ (y < N /\ x' = x /\ y' = y + 1)
-
-TypeOK == x \in 0..N /\ y \in 0..N
-Inv == x + y <= 2 * N
-====
-```
-
-Invariants are detected by naming convention: definitions starting with `Inv`, `TypeOK`, or `NotSolved` are automatically checked.
-
-## Output
-
-On success:
-```
-Model checking complete. No errors found.
-
-  States explored: 1331
-  Transitions: 3630
-  Max depth: 31
-  Time: 0.019s
-```
-
-On invariant violation, you get a counterexample trace with state diffs marking changed variables. On deadlock, a trace to the deadlock state with a suggestion to use `--allow-deadlock`. Parse errors show source locations, and undefined variables suggest similar names.
-
-## State Graph Visualization
-
-```bash
-tla spec.tla --export-dot graph.dot
-tla spec.tla --export-dot graph.dot --dot-mode full
-dot -Tpng graph.dot -o graph.png
-```
-
-Four export modes are available via `--dot-mode`:
-
-| Mode | Description |
-|------|-------------|
-| `clean` (default) | All nodes, no self-loops, parallel edges merged into single labeled edges |
-| `full` | All nodes and all edges including self-loops, each edge separate |
-| `trace` | Only counterexample trace nodes and edges (falls back to full if no trace) |
-| `choices` | Trace path plus alternative transitions at each trace state; non-trace nodes shown dashed, alternative edges gray/dashed (falls back to full if no trace) |
-
-Error states are highlighted in red. Trace edges are red and thick in all modes.
-
-## WebAssembly
-
-The core library compiles to WASM for browser embedding:
-
-```bash
-cargo make wasm
-```
-
-This produces a `pkg/` directory with the WASM module and JS bindings. The WASM API provides `check_spec`, `check_spec_with_config`, `check_spec_with_cfg`, and `check_spec_with_options` — all returning JSON results with success status, state count, error traces, and optional DOT graph output.
-
-The `check_spec_with_options` API accepts a JSON options object:
-
-```js
-const result = JSON.parse(check_spec_with_options(specSource, JSON.stringify({
-  constants: { N: 3 },
-  max_states: 10000,
-  max_depth: 50,
-  allow_deadlock: true,
-  export_dot: true,
-  dot_mode: "choices",   // "full", "trace", "clean" (default), "choices"
-  cfg_source: "INIT Init\nNEXT Next\n"
-})));
-
-if (result.dot) {
-  // DOT graph string: "digraph StateGraph { ... }"
-}
-```
-
-| Option | Type | Description |
-|--------|------|-------------|
-| `constants` | object | Constant values (`{"N": 3, "Procs": ["a","b"]}`) |
-| `cfg_source` | string | TLC-style cfg file contents |
-| `max_states` | number | Maximum states to explore |
-| `max_depth` | number | Maximum trace depth |
-| `allow_deadlock` | bool | Allow states with no successors |
-| `export_dot` | bool | Include DOT graph in result |
-| `dot_mode` | string | DOT export mode: `full`, `trace`, `clean` (default), `choices` |
-
-## MCP Server
-
-`tla-mcp` exposes the model checker as a Model Context Protocol server over stdio, so agentic clients (Claude Code, Cursor, etc.) can call it as a first-class tool.
-
-### Install
-
-Several paths are supported — pick whichever fits your toolchain.
-
-**Homebrew (macOS, Linuxbrew)** — installs both `tla` and `tla-mcp`:
-
-```bash
-brew install fabracht/tla/tla-mcp
-```
-
-Requires the `homebrew-tla` tap to exist. The formula source lives at [`packaging/homebrew/tla-mcp.rb`](packaging/homebrew/tla-mcp.rb); [`packaging/homebrew/README.md`](packaging/homebrew/README.md) explains the one-time tap setup.
-
-**Install script (Linux, macOS)** — downloads a prebuilt binary and verifies its SHA256, no Rust toolchain required:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/fabracht/tla-rs/main/scripts/install.sh | bash
-```
-
-Pass flags to scope the install: `--bin tla-mcp` for just the MCP server, `--version v0.4.3` to pin a release (releases prior to v0.4.3 do not ship a `SHA256SUMS` asset and are rejected), `--dir /usr/local/bin` for a system-wide install (requires `sudo`).
-
-**Cargo (any platform with a Rust toolchain)**:
-
-```bash
-cargo install tla-checker --bin tla-mcp
-```
-
-**GitHub release downloads** — prebuilt binaries for Linux x86_64, macOS x86_64, macOS arm64, and Windows x86_64 are attached to every [release](https://github.com/fabracht/tla-rs/releases/latest) as `tla-<platform>` and `tla-mcp-<platform>`.
-
-**From a working copy**:
-
-```bash
-cargo install --path . --bin tla-mcp
-```
-
-### Register with your client
-
-**Claude Code (community plugin marketplace)** — once `tla-mcp` is on PATH:
-
-```
-/plugin marketplace add anthropics/claude-plugins-community
-/plugin install tla-rs@claude-community
-```
-
-**Manual registration (any MCP client)** — add to `~/.claude/mcp.json`, `claude_desktop_config.json`, or your client's equivalent:
-
-```json
-{
-  "mcpServers": {
-    "tla": {
-      "command": "tla-mcp"
-    }
-  }
-}
-```
-
-### Tools
-
-All tools return a `schema_version: "1"` field — the contract is frozen at version 1 and will be bumped explicitly on breaking changes.
-
-| Tool | Purpose |
-|------|---------|
-| `validate_spec` | Parse a `.tla` file and return a summary (vars, **constants with resolved values**, invariants, init/next presence). Returns a structured parse/config error with source span on failure. Inspect the `constants` array before every `check_spec` call — outlier values are the most common cause of timeouts. |
-| `list_invariants` | Return the detected invariants (definitions matching `Inv*`, `TypeOK*`, `NotSolved*`, plus anything declared in a cfg `INVARIANT` directive). |
-| `check_spec` | Run full model checking. **Requires** `max_states`, `max_depth`, AND `max_seconds` (no defaults — agents must budget all three upfront). The `max_seconds` budget is enforced during both BFS exploration and the liveness phase. Returns one of: `ok`, `invariant_violation` (with trace + invariant name + actions), `deadlock`, `liveness_violation` (with prefix + cycle), `limit_reached` (budget exhausted — not an error; `limit` is one of `max_states`/`max_depth`/`max_seconds`), or `error` (with structured phase + message + optional source span). |
-| `replay_scenario` | Walk a spec step-by-step through a guided scenario (text of `step: <TLA+ expression>` lines). Returns the same `StateSnapshot` shape as `check_spec`, plus per-step `changes` descriptions. On a step that no transition satisfies, returns `status: "failed"` with `available_actions` to help diagnose the mismatch. |
-
-The boolean toggles `allow_deadlock` and `check_liveness` are `Option<bool>` — omit them to defer to the cfg file (e.g., `CHECK_DEADLOCK FALSE` or `PROPERTY` directives), pass `true` / `false` to override the cfg. The `symmetry` field appends to any constants declared via cfg `SYMMETRY` rather than replacing them.
-
-`validate_spec` and `list_invariants` include a `warnings` array surfacing parser-tolerance warnings — when the parser fails to parse an operator body it silently skips that operator and emits a warning. The same array also surfaces unsupported temporal constructs (`<<A>>_v` diamond actions, `<>[]P` stable-eventually) that the fairness extractor drops. Without the warnings array, a typo in an invariant's body would let `check_spec` "pass" without ever checking that invariant.
-
-`check_spec` honors the cfg's `CONSTRAINT` directive (state-space pruning predicate) and accepts an inline `state_constraint: "<TLA+ expression>"` parameter. Constraints are evaluated on every state — states where the expression is false are dropped from the reachable set and not explored further. Use this to bound otherwise-explosive state spaces (e.g., `state_constraint: "Len(queue) <= 3"`) without modifying the spec.
-
-### Counterexample format
-
-Each state in a trace is `{ vars: { var_name: { display, json } } }`. The `display` field is the TLA+-formatted value (`"{1, 2, 3}"`, `"<<a, b>>"`); the `json` field is a typed JSON form preserving set/tuple/record/function structure via a `kind` tag.
-
-### Mid-session reload
-
-MCP clients spawn server processes at session startup. Rebuilding or reinstalling `tla-mcp` while a Claude Code session is already running will not hot-reload the new binary — restart the client (or open a new session) to pick up changes. Verifying outside an MCP client: `tla-mcp` invoked directly will exit with `ConnectionClosed` after stdin EOF, which is the correct behavior for a stdio server with no peer.
-
-## Limitations
-
-`Nat` and `Int` are bounded (-100 to 100 by default). Temporal operators `[]`, `<>`, `~>` are parsed but cannot be evaluated directly — use `--check-liveness` for fairness/liveness properties via SCC analysis. Unbounded quantifiers (`\E x : P` without `\in S`) and `Seq(S)` enumeration are not supported. Recursive operators must be declared with `RECURSIVE`.
+## Documentation
+
+| Guide | Contents |
+|-------|----------|
+| [CLI Guide](CLI_GUIDE.md) | Configuration files, scenarios, demo walkthroughs (incl. the `--explorable` browser explorer), interactive mode, analytics, output, and state-graph visualization |
+| [TLA+ Support](TLA_SUPPORT.md) | Supported operator subset, module instances, spec structure, and limitations |
+| [WebAssembly](WASM.md) | Browser-embeddable WASM API, including the live stepping bindings |
+| [MCP Server](MCP.md) | `tla-mcp` install, client registration, and tool reference |
+| [Syntax Status](SYNTAX_STATUS.md) | Operator-by-operator coverage table |
+| [Architecture](ARCHITECTURE.md) | Internal design |
+| [Practical TLA+ Guide](USER_GUIDE_TO_PRACTICAL_TLA.md) | Worked guidance for writing checkable specs |
 
 ## License
 

--- a/TLA_SUPPORT.md
+++ b/TLA_SUPPORT.md
@@ -1,0 +1,54 @@
+# Supported TLA+ Subset
+
+tla-rs implements the Naturals, Integers, Sequences, FiniteSets, TLC, Bags, and Bits standard modules. See [`SYNTAX_STATUS.md`](SYNTAX_STATUS.md) for the full operator-by-operator coverage table.
+
+The supported operator categories: logic (`/\`, `\/`, `~`, `=>`), comparison, arithmetic, sets (`\in`, `\union`, `\intersect`, `SUBSET`, `UNION`), functions (`[x \in S |-> e]`, `DOMAIN`, `EXCEPT`, `@@`), quantifiers (`\E`, `\A`, `CHOOSE`), records, tuples/sequences, `IF-THEN-ELSE`, `CASE`, `LET-IN`, primed variables, `UNCHANGED`, transitive closure, module instances (`INSTANCE` with qualified calls), and Unicode equivalents for all operators.
+
+## Module Instances
+
+Specs can use `INSTANCE` to import and compose modules:
+
+```tla
+---- MODULE pingpong ----
+LOCAL INSTANCE Naturals
+
+VARIABLES server_to_client, client_to_server
+
+Data == [message: {"ping"}] \cup [message: {"pong"}]
+
+ServerToClientChannel(Id) == INSTANCE MChannel WITH channels <- server_to_client
+ClientToServerChannel(Id) == INSTANCE MChannel WITH channels <- client_to_server
+
+Next ==
+    \/ \E id \in ClientIds: ServerToClientChannel(id)!Send([message |-> "ping"])
+    \/ \E id \in ClientIds: ClientToServerChannel(id)!Recv([message |-> "pong"])
+====
+```
+
+Both static (`Alias == INSTANCE M WITH ...`) and parameterized (`Alias(p) == INSTANCE M WITH ...`) instances are supported. Library modules without Init/Next work as expected. The module file must be in the same directory as the spec.
+
+## Spec Structure
+
+```tla
+---- MODULE Example ----
+EXTENDS Naturals
+
+CONSTANT N
+VARIABLES x, y
+
+Init == x = 0 /\ y = 0
+
+Next ==
+    \/ (x < N /\ x' = x + 1 /\ y' = y)
+    \/ (y < N /\ x' = x /\ y' = y + 1)
+
+TypeOK == x \in 0..N /\ y \in 0..N
+Inv == x + y <= 2 * N
+====
+```
+
+Invariants are detected by naming convention: definitions starting with `Inv`, `TypeOK`, or `NotSolved` are automatically checked.
+
+## Limitations
+
+`Nat` and `Int` are bounded (-100 to 100 by default). Temporal operators `[]`, `<>`, `~>` are parsed but cannot be evaluated directly — use `--check-liveness` for fairness/liveness properties via SCC analysis. Unbounded quantifiers (`\E x : P` without `\in S`) and `Seq(S)` enumeration are not supported. Recursive operators must be declared with `RECURSIVE`.

--- a/WASM.md
+++ b/WASM.md
@@ -1,0 +1,50 @@
+# WebAssembly
+
+The core library compiles to WASM for browser embedding:
+
+```bash
+cargo make wasm
+```
+
+This produces a `pkg/` directory with the WASM module and JS bindings. The WASM API provides `check_spec`, `check_spec_with_config`, `check_spec_with_cfg`, and `check_spec_with_options` — all returning JSON results with success status, state count, error traces, and optional DOT graph output.
+
+The `check_spec_with_options` API accepts a JSON options object:
+
+```js
+const result = JSON.parse(check_spec_with_options(specSource, JSON.stringify({
+  constants: { N: 3 },
+  max_states: 10000,
+  max_depth: 50,
+  allow_deadlock: true,
+  export_dot: true,
+  dot_mode: "choices",   // "full", "trace", "clean" (default), "choices"
+  cfg_source: "INIT Init\nNEXT Next\n"
+})));
+
+if (result.dot) {
+  // DOT graph string: "digraph StateGraph { ... }"
+}
+```
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `constants` | object | Constant values (`{"N": 3, "Procs": ["a","b"]}`) |
+| `cfg_source` | string | TLC-style cfg file contents |
+| `max_states` | number | Maximum states to explore |
+| `max_depth` | number | Maximum trace depth |
+| `allow_deadlock` | bool | Allow states with no successors |
+| `export_dot` | bool | Include DOT graph in result |
+| `dot_mode` | string | DOT export mode: `full`, `trace`, `clean` (default), `choices` |
+
+## Stepping API
+
+For step-by-step exploration there are four additional bindings, which power the [`--explorable` HTML export](CLI_GUIDE.md#demo-walkthroughs):
+
+| Binding | Returns |
+|---------|---------|
+| `explore_init(spec, cfg, constants)` | The initial states. |
+| `explore_next(spec, cfg, constants, state)` | The enabled transitions from a state, with action names and change deltas. |
+| `explore_eval(spec, cfg, constants, state, expr)` | The value of a TLA+ expression evaluated at a state. |
+| `explore_invariants(spec, cfg, constants, state)` | Each invariant's name and whether it holds at the state. |
+
+Each takes the spec source, an optional cfg source string, and a JSON constants object; the per-state bindings also take a JSON state. All return a JSON string carrying an `ok` flag (and an `error` message when `ok` is false). States round-trip through the typed JSON form produced by `explore_init`/`explore_next`, so the result of one call can be fed straight into the next.

--- a/src/demo/explorable.html
+++ b/src/demo/explorable.html
@@ -1,0 +1,426 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TLA+ demo walkthrough</title>
+<style>
+  :root {
+    --bg: #0f1115; --panel: #171a21; --line: #2a2f3a; --fg: #e6e9ef;
+    --dim: #8b93a3; --accent: #6ea8fe; --ok: #4ec98a; --bad: #ff6b6b;
+    --chg: #3a2f12; --chgline: #d8a534;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  }
+  header { padding: 16px 22px; border-bottom: 1px solid var(--line); display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap; }
+  header h1 { margin: 0; font-size: 19px; font-weight: 650; }
+  .tabs { display: flex; gap: 8px; }
+  .tab { background: var(--panel); color: var(--fg); border: 1px solid var(--line); border-radius: 7px; padding: 6px 14px; cursor: pointer; font-size: 13px; }
+  .tab:hover { border-color: var(--accent); }
+  .tab.active { border-color: var(--accent); background: #1d2330; }
+  nav#beat-list { display: flex; flex-wrap: wrap; gap: 8px; padding: 14px 22px; border-bottom: 1px solid var(--line); }
+  .beat-tab {
+    background: var(--panel); color: var(--fg); border: 1px solid var(--line);
+    border-radius: 7px; padding: 7px 12px; cursor: pointer; font-size: 13px;
+  }
+  .beat-tab:hover { border-color: var(--accent); }
+  .beat-tab.active { border-color: var(--accent); background: #1d2330; }
+  .beat-tab.fail { border-left: 3px solid var(--bad); }
+  .beat-tab.pass { border-left: 3px solid var(--ok); }
+  main { padding: 20px 22px 60px; max-width: 1100px; }
+  main h2 { margin: 4px 0 6px; font-size: 18px; }
+  .note { color: var(--dim); margin: 0 0 16px; max-width: 760px; }
+  .scenario { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 8px 10px; margin-bottom: 14px; }
+  .sline { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; color: var(--dim); padding: 2px 6px; border-radius: 4px; }
+  .sline.cur { color: var(--fg); background: #1d2330; }
+  .steps { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; flex-wrap: wrap; }
+  .steps button, .btn { background: var(--panel); color: var(--fg); border: 1px solid var(--line); border-radius: 6px; padding: 6px 12px; cursor: pointer; }
+  .steps button:hover, .btn:hover { border-color: var(--accent); }
+  .steps .pos { color: var(--dim); font-variant-numeric: tabular-nums; }
+  .cols { display: flex; gap: 16px; flex-wrap: wrap; }
+  .col { flex: 1 1 280px; background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 12px 14px; min-width: 260px; }
+  .vhead { font-weight: 650; margin-bottom: 4px; }
+  .label { color: var(--accent); font-family: ui-monospace, monospace; font-size: 13px; margin-bottom: 8px; }
+  table.state { width: 100%; border-collapse: collapse; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; }
+  table.state td { padding: 3px 6px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  table.state .vn { color: var(--dim); white-space: nowrap; }
+  table.state .vv { text-align: right; word-break: break-all; }
+  table.state tr.chg { background: var(--chg); }
+  table.state tr.chg .vv { color: var(--chgline); font-weight: 650; }
+  ul.asserts { list-style: none; margin: 12px 0 0; padding: 0; font-size: 13px; }
+  ul.asserts li { padding: 2px 0; }
+  code { font-family: ui-monospace, monospace; background: #1d2330; padding: 1px 5px; border-radius: 4px; }
+  .ok { color: var(--ok); }
+  .bad { color: var(--bad); }
+  .row { display: flex; gap: 16px; flex-wrap: wrap; align-items: flex-start; }
+  .actions { display: flex; flex-direction: column; gap: 6px; }
+  .action-btn { text-align: left; font-family: ui-monospace, monospace; font-size: 13px; }
+  .action-btn .an { color: var(--accent); font-weight: 650; }
+  .action-btn .ac { color: var(--chgline); }
+  .crumbs { font-family: ui-monospace, monospace; font-size: 12px; color: var(--dim); margin-bottom: 10px; word-break: break-word; }
+  .crumbs .cur { color: var(--fg); }
+  select, input[type=text] { background: #1d2330; color: var(--fg); border: 1px solid var(--line); border-radius: 6px; padding: 6px 8px; font: inherit; }
+  input[type=text] { width: 100%; font-family: ui-monospace, monospace; font-size: 13px; }
+  .repl-out { margin-top: 6px; font-family: ui-monospace, monospace; font-size: 13px; white-space: pre-wrap; word-break: break-word; }
+  .hint { color: var(--dim); font-size: 12px; }
+  footer { position: fixed; bottom: 0; left: 0; right: 0; padding: 8px 22px; background: var(--panel); border-top: 1px solid var(--line); color: var(--dim); font-size: 12px; }
+  .hidden { display: none; }
+</style>
+</head>
+<body>
+<header>
+  <h1 id="demo-title"></h1>
+  <div class="tabs">
+    <button class="tab active" id="tab-walk">Walkthrough</button>
+    <button class="tab" id="tab-explore">Explore</button>
+  </div>
+</header>
+
+<nav id="beat-list"></nav>
+<main id="beat-view"></main>
+
+<main id="explore-view" class="hidden"></main>
+
+<footer id="foot">← / → step &nbsp;·&nbsp; [ / ] beat &nbsp;·&nbsp; click a beat above</footer>
+
+<script type="module">
+/*WASM_GLUE*/
+
+const WASM_B64 = "/*WASM_B64*/";
+const DATA = /*DEMO_DATA*/;
+
+let engineReady = false;
+function ensureEngine() {
+  if (engineReady) return true;
+  try {
+    const bytes = Uint8Array.from(atob(WASM_B64), c => c.charCodeAt(0));
+    initSync({ module: bytes });
+    engineReady = true;
+  } catch (e) {
+    engineReady = false;
+    console.error("wasm init failed", e);
+  }
+  return engineReady;
+}
+
+function esc(s) {
+  return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/* ---------- Walkthrough (static, pre-computed beats) ---------- */
+let beatIdx = 0, step = 0;
+
+function maxStep(beat) {
+  return Math.max(0, ...beat.runs.map(r => r.trace.length - 1));
+}
+function badge(passed) {
+  return passed ? '<span class="ok">✓</span>' : '<span class="bad">✗</span>';
+}
+function renderBeatList() {
+  const nav = document.getElementById("beat-list");
+  nav.innerHTML = "";
+  DATA.beats.forEach((b, i) => {
+    const el = document.createElement("button");
+    el.className = "beat-tab " + (b.passed ? "pass" : "fail") + (i === beatIdx ? " active" : "");
+    el.textContent = (i + 1) + ". " + b.title + (b.passed ? "  ✓" : "  ✗");
+    el.onclick = () => { beatIdx = i; step = 0; renderWalk(); };
+    nav.appendChild(el);
+  });
+}
+function renderBeat() {
+  const beat = DATA.beats[beatIdx];
+  const top = maxStep(beat);
+  if (step > top) step = top;
+
+  let h = "";
+  h += "<h2>" + esc(beat.title) + " " + badge(beat.passed) + "</h2>";
+  if (beat.note) h += '<p class="note">' + esc(beat.note) + "</p>";
+
+  h += '<div class="scenario">';
+  beat.scenario.forEach((line, k) => {
+    h += '<div class="sline' + (k + 1 === step ? " cur" : "") + '">' + esc(line) + "</div>";
+  });
+  h += "</div>";
+
+  h += '<div class="steps">';
+  h += '<button id="prev">‹ prev</button>';
+  h += '<span class="pos">step ' + step + " / " + top + "</span>";
+  h += '<button id="next">next ›</button>';
+  h += "</div>";
+
+  h += '<div class="cols">';
+  beat.runs.forEach(run => {
+    h += '<div class="col">';
+    h += '<div class="vhead">' + esc(run.variant) + " " + badge(run.passed) + "</div>";
+    if (run.failure) h += '<div class="bad">error: ' + esc(run.failure) + "</div>";
+    const cur = run.trace[Math.min(step, run.trace.length - 1)];
+    const prev = step > 0 ? run.trace[Math.min(step - 1, run.trace.length - 1)] : null;
+    h += '<div class="label">' + esc(cur.label) + "</div>";
+    h += '<table class="state">';
+    run.vars.forEach(v => {
+      const val = cur.vars[v] !== undefined ? cur.vars[v] : "";
+      const changed = prev && prev.vars[v] !== val;
+      h += "<tr class=\"" + (changed ? "chg" : "") + "\">";
+      h += '<td class="vn">' + esc(v) + "</td>";
+      h += '<td class="vv">' + esc(val) + "</td></tr>";
+    });
+    h += "</table>";
+    if (run.assertions.length) {
+      h += '<ul class="asserts">';
+      run.assertions.forEach(a => {
+        let line = (a.passed ? "✓" : "✗") + " <code>" + esc(a.expectation) + "</code>";
+        if (!a.passed && a.detail) line += " — " + esc(a.detail);
+        h += '<li class="' + (a.passed ? "ok" : "bad") + '">' + line + "</li>";
+      });
+      h += "</ul>";
+    }
+    if (DATA.variants && DATA.variants[run.variant]) {
+      h += '<button class="btn explore-here" data-variant="' + esc(run.variant) +
+           '" data-step="' + step + '" style="margin-top:10px">Explore from this step ›</button>';
+    }
+    h += "</div>";
+  });
+  h += "</div>";
+
+  const view = document.getElementById("beat-view");
+  view.innerHTML = h;
+  document.getElementById("prev").onclick = () => { if (step > 0) { step--; renderWalk(); } };
+  document.getElementById("next").onclick = () => { if (step < maxStep(beat)) { step++; renderWalk(); } };
+  view.querySelectorAll(".explore-here").forEach(btn => {
+    btn.onclick = () => {
+      const variant = btn.getAttribute("data-variant");
+      const s = parseInt(btn.getAttribute("data-step"), 10);
+      const run = beat.runs.find(r => r.variant === variant);
+      const tr = run && run.trace[Math.min(s, run.trace.length - 1)];
+      seedExplorerFromBeat(variant, tr);
+    };
+  });
+}
+function renderWalk() {
+  document.getElementById("demo-title").textContent = DATA.title;
+  document.title = DATA.title;
+  renderBeatList();
+  renderBeat();
+}
+
+/* ---------- Explore (live wasm engine) ---------- */
+let exVariant = null;
+let exPath = [];     // [{label, payload}]
+let exError = null;
+
+function variantNames() {
+  return DATA.variants ? Object.keys(DATA.variants) : [];
+}
+function variantArgs(name) {
+  const v = DATA.variants[name];
+  return [v.spec, v.cfg || "", JSON.stringify(v.constants || {})];
+}
+function callJSON(fn, ...args) {
+  try { return JSON.parse(fn(...args)); }
+  catch (e) { return { ok: false, error: String(e) }; }
+}
+
+function startVariant(name) {
+  exVariant = name;
+  exPath = [];
+  exError = null;
+  if (!ensureEngine()) { exError = "WASM engine failed to initialize."; renderExplore(); return; }
+  const [spec, cfg, consts] = variantArgs(name);
+  const res = callJSON(explore_init, spec, cfg, consts);
+  if (!res.ok) { exError = res.error; renderExplore(); return; }
+  if (!res.states.length) { exError = "no initial states"; renderExplore(); return; }
+  exPath.push({ label: "Init", payload: res.states[0] });
+  renderExplore();
+}
+
+function seedExplorerFromBeat(variant, traceStep) {
+  showExplore();
+  exVariant = variant;
+  exError = null;
+  if (!ensureEngine()) { exError = "WASM engine failed to initialize."; renderExplore(); return; }
+  // Rebuild a payload from the trace step's display vars by round-tripping through the engine:
+  // re-run init then accept the trace's state as the starting point via its json if present.
+  if (traceStep && traceStep.json) {
+    exPath = [{ label: traceStep.label || "from beat", payload: { json: traceStep.json, display: traceStep.vars } }];
+  } else {
+    startVariant(variant);
+    return;
+  }
+  renderExplore();
+}
+
+function current() { return exPath[exPath.length - 1]; }
+
+function stateTable(payload, prevPayload) {
+  const vars = Object.keys(payload.display);
+  let h = '<table class="state">';
+  vars.forEach(v => {
+    const val = payload.display[v];
+    const changed = prevPayload && prevPayload.display[v] !== val;
+    h += '<tr class="' + (changed ? "chg" : "") + '">';
+    h += '<td class="vn">' + esc(v) + '</td><td class="vv">' + esc(val) + "</td></tr>";
+  });
+  h += "</table>";
+  return h;
+}
+
+function renderExplore() {
+  const view = document.getElementById("explore-view");
+  const names = variantNames();
+  let h = "";
+
+  h += '<div class="steps">';
+  h += '<label class="hint">variant&nbsp;</label><select id="ex-variant">';
+  names.forEach(n => {
+    h += '<option value="' + esc(n) + '"' + (n === exVariant ? " selected" : "") + ">" + esc(n) + "</option>";
+  });
+  h += "</select>";
+  h += '<button class="btn" id="ex-back">‹ back</button>';
+  h += '<button class="btn" id="ex-reset">reset to Init</button>';
+  h += "</div>";
+
+  if (exError) {
+    h += '<div class="bad">' + esc(exError) + "</div>";
+    view.innerHTML = h;
+    wireExploreControls();
+    return;
+  }
+  if (!exVariant || !exPath.length) {
+    h += '<p class="hint">Pick a variant to start exploring from its initial state.</p>';
+    view.innerHTML = h;
+    wireExploreControls();
+    return;
+  }
+
+  const cur = current();
+  const prev = exPath.length > 1 ? exPath[exPath.length - 2] : null;
+
+  h += '<div class="crumbs">';
+  h += exPath.map((p, i) => (i === exPath.length - 1
+    ? '<span class="cur">' + esc(p.label) + "</span>"
+    : esc(p.label))).join(" → ");
+  h += "</div>";
+
+  h += '<div class="row">';
+
+  // State + invariants column
+  h += '<div class="col">';
+  h += '<div class="vhead">State</div>';
+  h += stateTable(cur.payload, prev ? prev.payload : null);
+  const [spec, cfg, consts] = variantArgs(exVariant);
+  const inv = callJSON(explore_invariants, spec, cfg, consts, JSON.stringify(cur.payload.json));
+  if (inv.ok && inv.invariants.length) {
+    h += '<ul class="asserts">';
+    inv.invariants.forEach(i => {
+      if (i.error !== undefined) {
+        h += '<li class="bad">⚠ <code>' + esc(i.name) + "</code> — " + esc(i.error) + "</li>";
+      } else {
+        h += '<li class="' + (i.holds ? "ok" : "bad") + '">' + (i.holds ? "✓" : "✗") + " <code>" + esc(i.name) + "</code></li>";
+      }
+    });
+    h += "</ul>";
+  }
+  h += "</div>";
+
+  // Enabled actions column
+  h += '<div class="col">';
+  h += '<div class="vhead">Enabled actions</div>';
+  const nx = callJSON(explore_next, spec, cfg, consts, JSON.stringify(cur.payload.json));
+  if (!nx.ok) {
+    h += '<div class="bad">' + esc(nx.error) + "</div>";
+  } else if (!nx.transitions.length) {
+    h += '<div class="hint">(no successors — deadlock)</div>';
+  } else {
+    h += '<div class="actions">';
+    nx.transitions.forEach((t, i) => {
+      const name = t.action || "(unnamed)";
+      const chg = t.changes.join(", ");
+      h += '<button class="btn action-btn" data-i="' + i + '"><span class="an">→ ' + esc(name) + "</span>" +
+           (chg ? ' <span class="ac">' + esc(chg) + "</span>" : "") + "</button>";
+    });
+    h += "</div>";
+  }
+  h += "</div>";
+
+  // REPL column
+  h += '<div class="col">';
+  h += '<div class="vhead">Evaluate</div>';
+  h += '<input type="text" id="ex-repl" placeholder="TLA+ expression over current state, e.g. x + 1" />';
+  h += '<div class="repl-out" id="ex-repl-out"></div>';
+  h += '<div class="hint" style="margin-top:6px">Enter to evaluate. Unprimed vars = current state.</div>';
+  h += "</div>";
+
+  h += "</div>";
+
+  view.innerHTML = h;
+  wireExploreControls();
+
+  view.querySelectorAll(".action-btn").forEach(btn => {
+    btn.onclick = () => {
+      const i = parseInt(btn.getAttribute("data-i"), 10);
+      const t = nx.transitions[i];
+      exPath.push({ label: t.action || "step", payload: t.state });
+      renderExplore();
+    };
+  });
+
+  const repl = document.getElementById("ex-repl");
+  const out = document.getElementById("ex-repl-out");
+  repl.onkeydown = (e) => {
+    if (e.key !== "Enter") return;
+    const expr = repl.value.trim();
+    if (!expr) return;
+    const r = callJSON(explore_eval, spec, cfg, consts, JSON.stringify(cur.payload.json), expr);
+    if (r.ok) out.innerHTML = '<span class="ok">= ' + esc(r.value) + "</span>";
+    else out.innerHTML = '<span class="bad">' + esc(r.error) + "</span>";
+  };
+}
+
+function wireExploreControls() {
+  const sel = document.getElementById("ex-variant");
+  if (sel) sel.onchange = () => startVariant(sel.value);
+  const back = document.getElementById("ex-back");
+  if (back) back.onclick = () => { if (exPath.length > 1) { exPath.pop(); renderExplore(); } };
+  const reset = document.getElementById("ex-reset");
+  if (reset) reset.onclick = () => { if (exVariant) startVariant(exVariant); };
+}
+
+/* ---------- Tabs / navigation ---------- */
+function showWalk() {
+  document.getElementById("tab-walk").classList.add("active");
+  document.getElementById("tab-explore").classList.remove("active");
+  document.getElementById("beat-list").classList.remove("hidden");
+  document.getElementById("beat-view").classList.remove("hidden");
+  document.getElementById("explore-view").classList.add("hidden");
+  document.getElementById("foot").textContent = "← / → step  ·  [ / ] beat  ·  click a beat above";
+}
+function showExplore() {
+  document.getElementById("tab-walk").classList.remove("active");
+  document.getElementById("tab-explore").classList.add("active");
+  document.getElementById("beat-list").classList.add("hidden");
+  document.getElementById("beat-view").classList.add("hidden");
+  document.getElementById("explore-view").classList.remove("hidden");
+  document.getElementById("foot").textContent = "live exploration — click an action to step, back/reset to navigate";
+  if (!exVariant && variantNames().length) startVariant(variantNames()[0]);
+  else renderExplore();
+}
+
+document.getElementById("tab-walk").onclick = showWalk;
+document.getElementById("tab-explore").onclick = showExplore;
+
+document.addEventListener("keydown", e => {
+  if (!document.getElementById("explore-view").classList.contains("hidden")) return;
+  const beat = DATA.beats[beatIdx];
+  if (e.key === "ArrowRight") { if (step < maxStep(beat)) { step++; renderWalk(); } }
+  else if (e.key === "ArrowLeft") { if (step > 0) { step--; renderWalk(); } }
+  else if (e.key === "]") { beatIdx = (beatIdx + 1) % DATA.beats.length; step = 0; renderWalk(); }
+  else if (e.key === "[") { beatIdx = (beatIdx - 1 + DATA.beats.length) % DATA.beats.length; step = 0; renderWalk(); }
+});
+
+renderWalk();
+</script>
+</body>
+</html>

--- a/src/demo/html.rs
+++ b/src/demo/html.rs
@@ -35,6 +35,7 @@ pub fn render_html(manifest_dir: &Path, manifest: &Manifest) -> (String, bool) {
                             "label": step.label,
                             "changes": step.changes,
                             "vars": J::Object(vars),
+                            "json": crate::trace_io::state_to_json(&step.state, &run.vars),
                         })
                     })
                     .collect();
@@ -82,6 +83,139 @@ pub fn render_html(manifest_dir: &Path, manifest: &Manifest) -> (String, bool) {
         .replace("</", "<\\/");
 
     (TEMPLATE.replace("/*DEMO_DATA*/", &data_str), all_passed)
+}
+
+#[cfg(feature = "embed-wasm")]
+fn variant_constant_json(raw: &str) -> J {
+    match crate::config::parse_constant_value(raw) {
+        Some(value) => crate::trace_io::value_to_json(&value),
+        None => J::String(raw.to_string()),
+    }
+}
+
+#[cfg(feature = "embed-wasm")]
+fn build_variants(manifest_dir: &Path, manifest: &Manifest) -> J {
+    let mut map = Map::new();
+    for (name, variant) in &manifest.variants {
+        let spec = std::fs::read_to_string(manifest_dir.join(&variant.spec)).unwrap_or_default();
+        let cfg = match &variant.config {
+            Some(c) => std::fs::read_to_string(manifest_dir.join(c)).ok(),
+            None => {
+                std::fs::read_to_string(manifest_dir.join(&variant.spec).with_extension("cfg")).ok()
+            }
+        };
+        let constants: Map<String, J> = variant
+            .constants
+            .iter()
+            .map(|(k, raw)| (k.clone(), variant_constant_json(raw)))
+            .collect();
+        map.insert(
+            name.clone(),
+            json!({ "spec": spec, "cfg": cfg, "constants": J::Object(constants) }),
+        );
+    }
+    J::Object(map)
+}
+
+#[cfg(feature = "embed-wasm")]
+const EXPLORABLE_TEMPLATE: &str = include_str!("explorable.html");
+#[cfg(feature = "embed-wasm")]
+const WASM_BYTES: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/pkg/tla_checker_bg.wasm"
+));
+#[cfg(feature = "embed-wasm")]
+const WASM_GLUE: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/pkg/tla_checker.js"));
+
+#[cfg(feature = "embed-wasm")]
+pub fn render_explorable(
+    manifest_dir: &Path,
+    manifest: &Manifest,
+) -> Result<(String, bool), String> {
+    use base64::Engine;
+
+    let mut all_passed = true;
+    let mut beats: Vec<J> = Vec::new();
+    for (idx, beat) in manifest.beats.iter().enumerate() {
+        let report = run_beat(manifest_dir, manifest, beat);
+        all_passed &= report.passed();
+        let runs: Vec<J> = report
+            .runs
+            .iter()
+            .map(|run| {
+                let trace: Vec<J> = run
+                    .trace
+                    .iter()
+                    .map(|step| {
+                        let mut vars = Map::new();
+                        for (i, name) in run.vars.iter().enumerate() {
+                            if let Some(value) = step.state.values.get(i) {
+                                vars.insert(name.to_string(), J::String(format_value(value)));
+                            }
+                        }
+                        json!({
+                            "label": step.label,
+                            "changes": step.changes,
+                            "vars": J::Object(vars),
+                            "json": crate::trace_io::state_to_json(&step.state, &run.vars),
+                        })
+                    })
+                    .collect();
+                let assertions: Vec<J> = run
+                    .assertions
+                    .iter()
+                    .map(
+                        |a| json!({ "expectation": a.raw, "passed": a.passed, "detail": a.detail }),
+                    )
+                    .collect();
+                json!({
+                    "variant": run.variant,
+                    "passed": run.passed(),
+                    "failure": run.failure,
+                    "vars": run.vars.iter().map(|v| v.to_string()).collect::<Vec<_>>(),
+                    "trace": trace,
+                    "assertions": assertions,
+                })
+            })
+            .collect();
+        beats.push(json!({
+            "index": idx,
+            "title": report.title,
+            "note": report.note,
+            "passed": report.passed(),
+            "scenario": beat.scenario,
+            "runs": runs,
+        }));
+    }
+
+    let data = json!({
+        "title": manifest.title.clone().unwrap_or_else(|| "TLA+ demo".to_string()),
+        "beats": beats,
+        "variants": build_variants(manifest_dir, manifest),
+    });
+    let data_str = serde_json::to_string(&data)
+        .unwrap_or_else(|_| "{}".to_string())
+        .replace("</", "<\\/");
+    let glue = WASM_GLUE.replace("</", "<\\/");
+    let b64 = base64::engine::general_purpose::STANDARD.encode(WASM_BYTES);
+
+    let html = EXPLORABLE_TEMPLATE
+        .replace("/*WASM_GLUE*/", &glue)
+        .replace("/*WASM_B64*/", &b64)
+        .replace("/*DEMO_DATA*/", &data_str);
+    Ok((html, all_passed))
+}
+
+#[cfg(not(feature = "embed-wasm"))]
+pub fn render_explorable(
+    _manifest_dir: &Path,
+    _manifest: &Manifest,
+) -> Result<(String, bool), String> {
+    Err(
+        "explorable HTML export requires building with --features embed-wasm \
+         (run `cargo make wasm` first to produce pkg/tla_checker_bg.wasm and pkg/tla_checker.js)"
+            .to_string(),
+    )
 }
 
 #[cfg(test)]

--- a/src/demo/html.rs
+++ b/src/demo/html.rs
@@ -10,6 +10,25 @@ use super::manifest::Manifest;
 const TEMPLATE: &str = include_str!("walkthrough.html");
 
 pub fn render_html(manifest_dir: &Path, manifest: &Manifest) -> (String, bool) {
+    let (beats, all_passed) = build_beats_json(manifest_dir, manifest, false);
+
+    let data = json!({
+        "title": manifest.title.clone().unwrap_or_else(|| "TLA+ demo".to_string()),
+        "beats": beats,
+    });
+
+    let data_str = serde_json::to_string(&data)
+        .unwrap_or_else(|_| "{}".to_string())
+        .replace("</", "<\\/");
+
+    (TEMPLATE.replace("/*DEMO_DATA*/", &data_str), all_passed)
+}
+
+fn build_beats_json(
+    manifest_dir: &Path,
+    manifest: &Manifest,
+    include_state_json: bool,
+) -> (Vec<J>, bool) {
     let mut all_passed = true;
     let mut beats: Vec<J> = Vec::new();
 
@@ -31,12 +50,15 @@ pub fn render_html(manifest_dir: &Path, manifest: &Manifest) -> (String, bool) {
                                 vars.insert(name.to_string(), J::String(format_value(value)));
                             }
                         }
-                        json!({
+                        let mut entry = json!({
                             "label": step.label,
                             "changes": step.changes,
                             "vars": J::Object(vars),
-                            "json": crate::trace_io::state_to_json(&step.state, &run.vars),
-                        })
+                        });
+                        if include_state_json {
+                            entry["json"] = crate::trace_io::state_to_json(&step.state, &run.vars);
+                        }
+                        entry
                     })
                     .collect();
 
@@ -73,16 +95,7 @@ pub fn render_html(manifest_dir: &Path, manifest: &Manifest) -> (String, bool) {
         }));
     }
 
-    let data = json!({
-        "title": manifest.title.clone().unwrap_or_else(|| "TLA+ demo".to_string()),
-        "beats": beats,
-    });
-
-    let data_str = serde_json::to_string(&data)
-        .unwrap_or_else(|_| "{}".to_string())
-        .replace("</", "<\\/");
-
-    (TEMPLATE.replace("/*DEMO_DATA*/", &data_str), all_passed)
+    (beats, all_passed)
 }
 
 #[cfg(feature = "embed-wasm")]
@@ -134,59 +147,7 @@ pub fn render_explorable(
 ) -> Result<(String, bool), String> {
     use base64::Engine;
 
-    let mut all_passed = true;
-    let mut beats: Vec<J> = Vec::new();
-    for (idx, beat) in manifest.beats.iter().enumerate() {
-        let report = run_beat(manifest_dir, manifest, beat);
-        all_passed &= report.passed();
-        let runs: Vec<J> = report
-            .runs
-            .iter()
-            .map(|run| {
-                let trace: Vec<J> = run
-                    .trace
-                    .iter()
-                    .map(|step| {
-                        let mut vars = Map::new();
-                        for (i, name) in run.vars.iter().enumerate() {
-                            if let Some(value) = step.state.values.get(i) {
-                                vars.insert(name.to_string(), J::String(format_value(value)));
-                            }
-                        }
-                        json!({
-                            "label": step.label,
-                            "changes": step.changes,
-                            "vars": J::Object(vars),
-                            "json": crate::trace_io::state_to_json(&step.state, &run.vars),
-                        })
-                    })
-                    .collect();
-                let assertions: Vec<J> = run
-                    .assertions
-                    .iter()
-                    .map(
-                        |a| json!({ "expectation": a.raw, "passed": a.passed, "detail": a.detail }),
-                    )
-                    .collect();
-                json!({
-                    "variant": run.variant,
-                    "passed": run.passed(),
-                    "failure": run.failure,
-                    "vars": run.vars.iter().map(|v| v.to_string()).collect::<Vec<_>>(),
-                    "trace": trace,
-                    "assertions": assertions,
-                })
-            })
-            .collect();
-        beats.push(json!({
-            "index": idx,
-            "title": report.title,
-            "note": report.note,
-            "passed": report.passed(),
-            "scenario": beat.scenario,
-            "runs": runs,
-        }));
-    }
+    let (beats, all_passed) = build_beats_json(manifest_dir, manifest, true);
 
     let data = json!({
         "title": manifest.title.clone().unwrap_or_else(|| "TLA+ demo".to_string()),
@@ -245,5 +206,46 @@ mod tests {
         assert!(html.contains("const DATA ="));
         assert!(html.contains("Counter overflow demo"));
         assert!(html.contains("Three increments"));
+    }
+
+    #[cfg(feature = "embed-wasm")]
+    #[test]
+    fn explorable_html_embeds_engine_and_is_self_contained() {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_cases/demo");
+        let manifest = Manifest::load(&dir.join("Counter.demo.json")).unwrap();
+        let (html, all_passed) = render_explorable(&dir, &manifest).expect("explorable render");
+
+        assert!(all_passed);
+        assert!(!html.contains("/*WASM_GLUE*/"), "glue placeholder replaced");
+        assert!(!html.contains("/*WASM_B64*/"), "wasm placeholder replaced");
+        assert!(!html.contains("/*DEMO_DATA*/"), "data placeholder replaced");
+        assert!(
+            !html.contains("const WASM_B64 = \"\""),
+            "embedded wasm must be non-empty"
+        );
+        assert!(
+            html.contains("export function explore_init"),
+            "engine bindings must be inlined"
+        );
+        assert!(
+            !html.contains("http://"),
+            "must not reference external http"
+        );
+        assert!(
+            !html.contains("https://"),
+            "must not reference external https"
+        );
+    }
+
+    #[cfg(not(feature = "embed-wasm"))]
+    #[test]
+    fn explorable_render_requires_embed_wasm_feature() {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_cases/demo");
+        let manifest = Manifest::load(&dir.join("Counter.demo.json")).unwrap();
+        let err = render_explorable(&dir, &manifest).unwrap_err();
+        assert!(
+            err.contains("embed-wasm"),
+            "error should name the required feature: {err}"
+        );
     }
 }

--- a/src/demo/mod.rs
+++ b/src/demo/mod.rs
@@ -5,5 +5,5 @@ pub mod manifest;
 
 pub use beat::{AssertionResult, BeatReport, TraceStep, VariantRun, run_beat};
 pub use doc::render_doc;
-pub use html::render_html;
+pub use html::{render_explorable, render_html};
 pub use manifest::{Beat, Manifest, Variant};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@ pub mod span;
 pub mod stdlib;
 pub mod substitution;
 pub mod symmetry;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod trace_io;
 #[cfg(feature = "wasm")]
 pub mod wasm;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use tla_checker::checker::{
 };
 use tla_checker::config::{apply_config, parse_cfg, parse_constant_value, split_top_level};
 #[cfg(not(target_arch = "wasm32"))]
-use tla_checker::demo::{Manifest, render_doc, render_html, run_beat};
+use tla_checker::demo::{Manifest, render_doc, render_explorable, render_html, run_beat};
 use tla_checker::diagnostic::{ColorConfig, Diagnostic};
 use tla_checker::export::DotMode;
 #[cfg(not(target_arch = "wasm32"))]
@@ -109,7 +109,7 @@ fn run_present_export(manifest_path: &Path, out_path: &Path) -> ExitCode {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn run_present_export_html(manifest_path: &Path, out_path: &Path) -> ExitCode {
+fn run_present_export_html(manifest_path: &Path, out_path: &Path, explorable: bool) -> ExitCode {
     let manifest = match Manifest::load(manifest_path) {
         Ok(m) => m,
         Err(e) => {
@@ -118,7 +118,17 @@ fn run_present_export_html(manifest_path: &Path, out_path: &Path) -> ExitCode {
         }
     };
     let dir = manifest_path.parent().unwrap_or_else(|| Path::new("."));
-    let (html, all_passed) = render_html(dir, &manifest);
+    let (html, all_passed) = if explorable {
+        match render_explorable(dir, &manifest) {
+            Ok(result) => result,
+            Err(e) => {
+                eprintln!("error: {}", e);
+                return ExitCode::FAILURE;
+            }
+        }
+    } else {
+        render_html(dir, &manifest)
+    };
     if let Err(e) = fs::write(out_path, html) {
         eprintln!("failed to write {}: {}", out_path.display(), e);
         return ExitCode::FAILURE;
@@ -307,6 +317,8 @@ fn main() -> ExitCode {
     let mut export_md_path: Option<PathBuf> = None;
     #[cfg(not(target_arch = "wasm32"))]
     let mut export_html_path: Option<PathBuf> = None;
+    #[cfg(not(target_arch = "wasm32"))]
+    let mut explorable = false;
 
     let mut i = 1;
     while i < args.len() {
@@ -498,6 +510,10 @@ fn main() -> ExitCode {
                 export_html_path = Some(PathBuf::from(&args[i]));
             }
             #[cfg(not(target_arch = "wasm32"))]
+            "--explorable" => {
+                explorable = true;
+            }
+            #[cfg(not(target_arch = "wasm32"))]
             "--interactive" | "-i" => {
                 interactive_mode = true;
             }
@@ -602,6 +618,9 @@ fn main() -> ExitCode {
                 println!(
                     "  --export-html FILE         With --present: write a self-contained HTML walkthrough"
                 );
+                println!(
+                    "  --explorable               With --export-html: embed the wasm engine for ad-hoc state exploration"
+                );
                 println!("  --interactive, -i          Interactive TUI exploration mode");
                 println!("  --help, -h                 Show this help");
                 println!();
@@ -645,7 +664,7 @@ fn main() -> ExitCode {
     #[cfg(not(target_arch = "wasm32"))]
     if let Some(manifest_path) = present_path {
         if let Some(out) = export_html_path {
-            return run_present_export_html(&manifest_path, &out);
+            return run_present_export_html(&manifest_path, &out, explorable);
         }
         if let Some(out) = export_md_path {
             return run_present_export(&manifest_path, &out);

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -4,14 +4,17 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
-use crate::ast::{Env, Spec, Value};
+use crate::ast::{Env, Spec, State, Value};
 use crate::checker::{
     CheckResult, CheckStats, CheckerConfig, PrepareSpecError, check, format_eval_error,
-    format_trace,
+    format_trace, format_value,
 };
 use crate::config::{apply_config, parse_cfg};
+use crate::eval::{Definitions, eval, init_states, make_primed_names, next_states};
 use crate::export::DotMode;
-use crate::parser::parse;
+use crate::parser::{parse, parse_expr};
+use crate::scenario::compute_changes;
+use crate::trace_io::{json_to_state, state_to_json, value_to_json};
 
 #[derive(Serialize, Deserialize, Default)]
 struct WasmCheckOptions {
@@ -429,6 +432,204 @@ fn result_to_wasm(
     }
 }
 
+fn err_json(msg: &str) -> String {
+    serde_json::json!({ "ok": false, "error": msg }).to_string()
+}
+
+fn prepare_explorer(
+    spec_source: &str,
+    cfg_source: &str,
+    constants_json: &str,
+) -> Result<(Spec, Env, Definitions), String> {
+    let mut spec = parse(spec_source).map_err(|e| format!("{e:?}"))?;
+
+    let mut domains = Env::new();
+    let mut config = CheckerConfig::default();
+    if !cfg_source.trim().is_empty() {
+        let cfg = parse_cfg(cfg_source)?;
+        apply_config(&cfg, &mut spec, &mut domains, &mut config, &[], &[], false)?;
+    }
+    apply_constants_json(&mut domains, constants_json);
+
+    #[cfg(target_arch = "wasm32")]
+    let prepared = crate::checker::prepare_spec(&spec, &domains);
+    #[cfg(not(target_arch = "wasm32"))]
+    let prepared = crate::checker::prepare_spec(&spec, &domains, None, true);
+
+    let (env, defs) = prepared.map_err(|e| format!("{e:?}"))?;
+    Ok((spec, env, defs))
+}
+
+fn state_payload(state: &State, vars: &[Arc<str>]) -> serde_json::Value {
+    let mut display = serde_json::Map::new();
+    for (i, var) in vars.iter().enumerate() {
+        if let Some(val) = state.values.get(i) {
+            display.insert(
+                var.to_string(),
+                serde_json::Value::String(format_value(val)),
+            );
+        }
+    }
+    serde_json::json!({
+        "json": state_to_json(state, vars),
+        "display": display,
+    })
+}
+
+fn state_with_env(env: &Env, state: &State, vars: &[Arc<str>]) -> Env {
+    let mut out = env.clone();
+    for (i, var) in vars.iter().enumerate() {
+        if let Some(val) = state.values.get(i) {
+            out.insert(var.clone(), val.clone());
+        }
+    }
+    out
+}
+
+#[wasm_bindgen]
+pub fn explore_init(spec_source: &str, cfg_source: &str, constants_json: &str) -> String {
+    let (spec, env, defs) = match prepare_explorer(spec_source, cfg_source, constants_json) {
+        Ok(t) => t,
+        Err(e) => return err_json(&e),
+    };
+    let Some(init) = &spec.init else {
+        return err_json("spec has no Init");
+    };
+    let states = match init_states(init, &spec.vars, &env, &defs) {
+        Ok(s) => s,
+        Err(e) => return err_json(&format_eval_error(&e)),
+    };
+    let payloads: Vec<_> = states
+        .iter()
+        .map(|s| state_payload(s, &spec.vars))
+        .collect();
+    serde_json::json!({
+        "ok": true,
+        "vars": spec.vars.iter().map(|v| v.to_string()).collect::<Vec<_>>(),
+        "states": payloads,
+    })
+    .to_string()
+}
+
+#[wasm_bindgen]
+pub fn explore_next(
+    spec_source: &str,
+    cfg_source: &str,
+    constants_json: &str,
+    state_json: &str,
+) -> String {
+    let (spec, mut env, defs) = match prepare_explorer(spec_source, cfg_source, constants_json) {
+        Ok(t) => t,
+        Err(e) => return err_json(&e),
+    };
+    let Some(next) = &spec.next else {
+        return err_json("spec has no Next");
+    };
+    let parsed: serde_json::Value = match serde_json::from_str(state_json) {
+        Ok(v) => v,
+        Err(e) => return err_json(&format!("invalid state JSON: {e}")),
+    };
+    let Some(current) = json_to_state(&parsed, &spec.vars) else {
+        return err_json("could not parse state");
+    };
+
+    let primed = make_primed_names(&spec.vars);
+    let transitions = match next_states(next, &current, &spec.vars, &primed, &mut env, &defs) {
+        Ok(t) => t,
+        Err(e) => return err_json(&format_eval_error(&e)),
+    };
+
+    let out: Vec<_> = transitions
+        .iter()
+        .map(|t| {
+            serde_json::json!({
+                "action": t.action.as_ref().map(|a| a.to_string()),
+                "state": state_payload(&t.state, &spec.vars),
+                "changes": compute_changes(&current, &t.state, &spec.vars),
+            })
+        })
+        .collect();
+    serde_json::json!({ "ok": true, "transitions": out }).to_string()
+}
+
+#[wasm_bindgen]
+pub fn explore_eval(
+    spec_source: &str,
+    cfg_source: &str,
+    constants_json: &str,
+    state_json: &str,
+    expr_source: &str,
+) -> String {
+    let (spec, env, defs) = match prepare_explorer(spec_source, cfg_source, constants_json) {
+        Ok(t) => t,
+        Err(e) => return err_json(&e),
+    };
+    let parsed: serde_json::Value = match serde_json::from_str(state_json) {
+        Ok(v) => v,
+        Err(e) => return err_json(&format!("invalid state JSON: {e}")),
+    };
+    let Some(current) = json_to_state(&parsed, &spec.vars) else {
+        return err_json("could not parse state");
+    };
+    let expr = match parse_expr(expr_source) {
+        Ok(e) => e,
+        Err(e) => return err_json(&format!("parse error: {}", e.message)),
+    };
+    let mut eval_env = state_with_env(&env, &current, &spec.vars);
+    match eval(&expr, &mut eval_env, &defs) {
+        Ok(value) => serde_json::json!({
+            "ok": true,
+            "value": format_value(&value),
+            "json": value_to_json(&value),
+        })
+        .to_string(),
+        Err(e) => err_json(&format_eval_error(&e)),
+    }
+}
+
+#[wasm_bindgen]
+pub fn explore_invariants(
+    spec_source: &str,
+    cfg_source: &str,
+    constants_json: &str,
+    state_json: &str,
+) -> String {
+    let (spec, env, defs) = match prepare_explorer(spec_source, cfg_source, constants_json) {
+        Ok(t) => t,
+        Err(e) => return err_json(&e),
+    };
+    let parsed: serde_json::Value = match serde_json::from_str(state_json) {
+        Ok(v) => v,
+        Err(e) => return err_json(&format!("invalid state JSON: {e}")),
+    };
+    let Some(current) = json_to_state(&parsed, &spec.vars) else {
+        return err_json("could not parse state");
+    };
+
+    let results: Vec<_> = spec
+        .invariants
+        .iter()
+        .enumerate()
+        .map(|(i, inv)| {
+            let name = spec
+                .invariant_names
+                .get(i)
+                .and_then(|n| n.as_ref())
+                .map(|n| n.to_string())
+                .unwrap_or_else(|| format!("Inv{i}"));
+            let mut eval_env = state_with_env(&env, &current, &spec.vars);
+            match eval(inv, &mut eval_env, &defs) {
+                Ok(Value::Bool(b)) => serde_json::json!({ "name": name, "holds": b }),
+                Ok(_) => {
+                    serde_json::json!({ "name": name, "error": "invariant is not a boolean" })
+                }
+                Err(e) => serde_json::json!({ "name": name, "error": format_eval_error(&e) }),
+            }
+        })
+        .collect();
+    serde_json::json!({ "ok": true, "invariants": results }).to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -722,5 +923,92 @@ Next == x' = x
         let result = run(spec, serde_json::json!({}));
         assert!(!result.success);
         assert_eq!(result.error_type.as_deref(), Some("AssumeError"));
+    }
+
+    fn json(s: &str) -> serde_json::Value {
+        serde_json::from_str(s).expect("valid json")
+    }
+
+    #[test]
+    fn explore_init_returns_initial_state() {
+        let out = json(&explore_init(COUNTER_SPEC, "", "{}"));
+        assert_eq!(out["ok"], true, "{out}");
+        assert_eq!(out["vars"], serde_json::json!(["count"]));
+        assert_eq!(out["states"].as_array().unwrap().len(), 1);
+        assert_eq!(out["states"][0]["json"]["count"], 0);
+        assert_eq!(out["states"][0]["display"]["count"], "0");
+    }
+
+    #[test]
+    fn explore_next_lists_named_successors() {
+        let out = json(&explore_next(COUNTER_SPEC, "", "{}", r#"{"count": 0}"#));
+        assert_eq!(out["ok"], true, "{out}");
+        let ts = out["transitions"].as_array().unwrap();
+        assert!(ts.iter().any(|t| t["state"]["json"]["count"] == 1));
+        assert!(ts.iter().any(|t| {
+            t["changes"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|c| c.as_str().unwrap().contains("count"))
+        }));
+    }
+
+    #[test]
+    fn explore_eval_evaluates_against_state() {
+        let out = json(&explore_eval(
+            COUNTER_SPEC,
+            "",
+            "{}",
+            r#"{"count": 2}"#,
+            "count + 1",
+        ));
+        assert_eq!(out["ok"], true, "{out}");
+        assert_eq!(out["value"], "3");
+    }
+
+    #[test]
+    fn explore_eval_reports_parse_error() {
+        let out = json(&explore_eval(
+            COUNTER_SPEC,
+            "",
+            "{}",
+            r#"{"count": 0}"#,
+            "count +",
+        ));
+        assert_eq!(out["ok"], false);
+        assert!(out["error"].as_str().unwrap().contains("parse error"));
+    }
+
+    #[test]
+    fn explore_invariants_evaluates_at_state() {
+        let holds = json(&explore_invariants(
+            COUNTER_SPEC,
+            "",
+            "{}",
+            r#"{"count": 2}"#,
+        ));
+        assert_eq!(holds["ok"], true, "{holds}");
+        assert_eq!(holds["invariants"][0]["name"], "Inv");
+        assert_eq!(holds["invariants"][0]["holds"], true);
+
+        let fails = json(&explore_invariants(
+            COUNTER_SPEC,
+            "",
+            "{}",
+            r#"{"count": 9}"#,
+        ));
+        assert_eq!(fails["invariants"][0]["holds"], false);
+    }
+
+    #[test]
+    fn explore_with_constants_cfg() {
+        let out = json(&explore_init(
+            COUNTER_WITH_MAX_SPEC,
+            "CONSTANT MAX = 5\n",
+            "{}",
+        ));
+        assert_eq!(out["ok"], true, "{out}");
+        assert_eq!(out["states"][0]["json"]["count"], 0);
     }
 }


### PR DESCRIPTION
## Summary
- `tla --present <manifest> --export-html <file> --explorable` embeds the wasm engine in the exported HTML, turning the offline walkthrough into a live in-browser state explorer (step through enabled actions, live invariant ✓/✗ per state, and a TLA+ REPL over the current state)
- Engine is base64-inlined and instantiated synchronously, so the file stays fully self-contained and works over `file://`
- New WASM bindings: `explore_init` / `explore_next` / `explore_eval` / `explore_invariants` (un-gated `trace_io` for wasm so JS can round-trip state)
- Gated behind the new `embed-wasm` cargo feature (requires `cargo make wasm` first to produce the inlined `pkg/` artifacts); the default `--export-html` path is unchanged and stays tiny
- Release workflow now builds released `tla` with `--features embed-wasm` (new `build-wasm` job produces `pkg/` once, pinned `wasm-bindgen-cli` 0.2.108; `tla-mcp` stays lean without the feature) so curl/brew binaries support `--explorable`
- Version 0.5.2 → 0.5.3, CHANGELOG updated

## Test plan
- [x] builds clean: default / `wasm` / `wasm,embed-wasm` / `wasm32-unknown-unknown`
- [x] `cargo clippy` clean on all feature combos; 276 default tests + 199 wasm-feature tests pass (incl. 6 new explorer binding tests)
- [x] browser-verified (Counter + TimeIntegrity demos): `explore_init` (Init state), `explore_next` (stepping + enabled actions recompute), `explore_eval` (REPL `x*10+5` = 15), `explore_invariants` (`✓ TypeOK  ✓ InvSeeded` panel); zero console errors; output self-contained (no remote loads)
- Limitation: file-based `INSTANCE` modules are not available in-browser (single-file specs only)