### PR TITLE
derive wasm-bindgen-cli version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,13 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --version 0.2.108 --locked
-
       - name: Build wasm engine
         run: |
           cargo rustc --lib --release --target wasm32-unknown-unknown --features wasm --crate-type cdylib
+          WB_VERSION=$(cargo tree --features wasm | grep -oE 'wasm-bindgen v[0-9.]+' | head -1 | sed -E 's/^wasm-bindgen v//')
+          if [ -z "$WB_VERSION" ]; then echo "could not determine resolved wasm-bindgen version"; exit 1; fi
+          echo "Installing wasm-bindgen-cli $WB_VERSION to match the resolved dependency"
+          cargo install wasm-bindgen-cli --version "$WB_VERSION" --locked
           wasm-bindgen --target web --out-dir pkg target/wasm32-unknown-unknown/release/tla_checker.wasm
 
       - name: Upload wasm pkg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.5.4] - 2026-05-28
+
+### Fixed
+
+- Release workflow: the `Build WASM engine` job pinned `wasm-bindgen-cli` to a hardcoded version that mismatched the `wasm-bindgen` dependency CI resolved (the repo has no committed `Cargo.lock`), which failed the binary build and skipped the GitHub release for 0.5.3. The CLI version is now derived from the resolved dependency. The 0.5.3 crate was published to crates.io and npm; this release ships the prebuilt `tla`/`tla-mcp` binaries (with the embedded explorable-HTML engine) and the GitHub release that 0.5.3 missed.
+
 ## [0.5.3] - 2026-05-28
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- The `build-wasm` release job pinned `wasm-bindgen-cli` to a hardcoded `0.2.108`, but CI resolves `wasm-bindgen` to the latest `0.2.x` (no committed `Cargo.lock`) — `0.2.122` — so `wasm-bindgen` failed with a schema-version mismatch, failing the v0.5.3 binary build and skipping the GitHub release.
- Fix: derive the CLI version from the resolved dependency (`cargo tree`) and install that exact version, removing the hardcoded pin.
- Bump 0.5.3 → 0.5.4. The 0.5.3 crate published to crates.io and npm; 0.5.4 re-runs the binary + GitHub-release build (with the embedded explorable-HTML engine) that 0.5.3 missed.

## Test plan
- [x] extraction command verified locally (`cargo tree --features wasm | grep ...` yields the resolved version)
- [x] workflow YAML validates; pre-commit fmt + clippy pass
- [ ] confirmed by the v0.5.4 release run (build-wasm → binaries → GitHub release all green)