### PR TITLE
speed up state-space generation ~2.5x via cheaper value representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.6.0] - 2026-05-29
+
+### Changed
+
+- Performance: state-space generation is substantially faster with identical results. Measured speedups (min of 3 runs): Two-Phase Commit ~2.5x (5 RMs 1.26s->0.50s, 6 RMs 9.22s->3.51s), N-Queens ~1.5x (N=4 0.59s->0.38s), and ~1.6x on the 409k-state TimeIntegrity example (63.9s->39.6s). Allocation churn roughly halved (dhat on N-Queens N=4: 7.74M->3.56M allocations). State counts and counterexample traces are bit-identical across all example and test specs. Four changes drove it: recursive function-application evaluation (no per-call vector), reference-counted collection values, skipping redundant candidate re-inference for actions whose primed variables are independent, and interning identifier and primed-variable names.
+
+### Breaking
+
+- The public `Value` enum now stores its collection payloads behind `Arc`: `Set(Arc<BTreeSet<Value>>)`, `Fn(Arc<BTreeMap<Value, Value>>)`, `Record(Arc<BTreeMap<Arc<str>, Value>>)`, and `Tuple(Arc<Vec<Value>>)`. Cloning a `Value` is now a reference-count bump rather than a deep copy. Pattern matches that bind these payloads now bind `&Arc<...>` (most read-only uses are unaffected via `Deref`); code that mutated or moved out the inner collection should use `Arc::make_mut` / `Arc::unwrap_or_clone`. New constructors `Value::set`, `Value::func`, `Value::record`, and `Value::tuple` wrap a plain collection.
+
 ## [0.5.5] - 2026-05-28
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.5.5"
+version = "0.6.0"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"

--- a/benches/model_checking.rs
+++ b/benches/model_checking.rs
@@ -49,7 +49,7 @@ fn bench_symmetric_procs(c: &mut Criterion) {
         .collect();
 
     let mut env = Env::new();
-    env.insert(Arc::from("Proc"), Value::Set(proc_set));
+    env.insert(Arc::from("Proc"), Value::set(proc_set));
 
     let mut group = c.benchmark_group("symmetric_procs");
 
@@ -106,7 +106,7 @@ fn bench_tcommit(c: &mut Criterion) {
             .collect();
 
         let mut env = Env::new();
-        env.insert(Arc::from("RM"), Value::Set(rm_set));
+        env.insert(Arc::from("RM"), Value::set(rm_set));
 
         group.bench_with_input(BenchmarkId::new("rm_count", rm_count), &env, |b, env| {
             b.iter(|| {
@@ -165,7 +165,7 @@ fn validate_benchmarks() {
         .map(|s| Value::Str(Arc::from(*s)))
         .collect();
     let mut env = Env::new();
-    env.insert(Arc::from("Ids"), Value::Set(id_set));
+    env.insert(Arc::from("Ids"), Value::set(id_set));
     let config = CheckerConfig {
         allow_deadlock: true,
         quiet: true,
@@ -226,7 +226,7 @@ fn create_test_state(var_count: usize, set_size: usize) -> State {
     let values: Vec<Value> = (0..var_count)
         .map(|_| {
             let set: BTreeSet<Value> = (0..set_size).map(|j| Value::Int(j as i64)).collect();
-            Value::Set(set)
+            Value::set(set)
         })
         .collect();
     State { values }
@@ -239,7 +239,7 @@ fn bench_eval_operations(c: &mut Criterion) {
 
     for size in [5, 10, 15] {
         let set: BTreeSet<Value> = create_test_set(size);
-        let base_expr = Expr::Lit(Value::Set(set));
+        let base_expr = Expr::Lit(Value::set(set));
         let powerset_expr = Expr::Powerset(Box::new(base_expr));
 
         group.bench_with_input(
@@ -276,7 +276,7 @@ fn bench_eval_operations(c: &mut Criterion) {
         let mut env_to_clone = Env::new();
         for i in 0..var_count {
             let set: BTreeSet<Value> = create_test_set(10);
-            env_to_clone.insert(Arc::from(format!("var{}", i)), Value::Set(set));
+            env_to_clone.insert(Arc::from(format!("var{}", i)), Value::set(set));
         }
 
         group.bench_with_input(
@@ -304,7 +304,7 @@ fn bench_symmetry_canonicalize(c: &mut Criterion) {
         let values: Vec<Value> = (0..var_count)
             .map(|i| {
                 let subset: BTreeSet<Value> = sym_set.iter().take((i % 5) + 1).cloned().collect();
-                Value::Set(subset)
+                Value::set(subset)
             })
             .collect();
         let state = State { values };
@@ -412,7 +412,7 @@ fn bench_twophase(c: &mut Criterion) {
             .collect();
 
         let mut env = Env::new();
-        env.insert(Arc::from("RM"), Value::Set(rm_set));
+        env.insert(Arc::from("RM"), Value::set(rm_set));
 
         group.bench_with_input(BenchmarkId::new("rm_count", rm_count), &env, |b, env| {
             b.iter(|| {
@@ -509,7 +509,7 @@ fn bench_parameterized_instance(c: &mut Criterion) {
     for (ids, label) in configs {
         let id_set: BTreeSet<Value> = ids.iter().map(|s| Value::Str(Arc::from(*s))).collect();
         let mut env = Env::new();
-        env.insert(Arc::from("Ids"), Value::Set(id_set));
+        env.insert(Arc::from("Ids"), Value::set(id_set));
 
         group.bench_with_input(BenchmarkId::new("ids", label), &env, |b, env| {
             b.iter(|| {
@@ -570,7 +570,7 @@ fn bench_instance_overhead(c: &mut Criterion) {
         .collect();
 
     let mut instance_env = Env::new();
-    instance_env.insert(Arc::from("Ids"), Value::Set(id_set));
+    instance_env.insert(Arc::from("Ids"), Value::set(id_set));
 
     let inline_env = Env::new();
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -6,10 +6,28 @@ pub enum Value {
     Bool(bool),
     Int(i64),
     Str(Arc<str>),
-    Set(BTreeSet<Value>),
-    Fn(BTreeMap<Value, Value>),
-    Record(BTreeMap<Arc<str>, Value>),
-    Tuple(Vec<Value>),
+    Set(Arc<BTreeSet<Value>>),
+    Fn(Arc<BTreeMap<Value, Value>>),
+    Record(Arc<BTreeMap<Arc<str>, Value>>),
+    Tuple(Arc<Vec<Value>>),
+}
+
+impl Value {
+    pub fn set(s: BTreeSet<Value>) -> Self {
+        Value::Set(Arc::new(s))
+    }
+
+    pub fn func(m: BTreeMap<Value, Value>) -> Self {
+        Value::Fn(Arc::new(m))
+    }
+
+    pub fn record(m: BTreeMap<Arc<str>, Value>) -> Self {
+        Value::Record(Arc::new(m))
+    }
+
+    pub fn tuple(v: Vec<Value>) -> Self {
+        Value::Tuple(Arc::new(v))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -346,7 +346,7 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
     let mut symmetry = SymmetryConfig::new();
     for sym_const in &config.symmetric_constants {
         if let Some(Value::Set(elements)) = domains.get(sym_const) {
-            symmetry.add_symmetric_set(elements.clone());
+            symmetry.add_symmetric_set(elements.as_ref().clone());
         } else if !config.quiet {
             let available: Vec<_> = spec.constants.iter().map(|c| c.as_ref()).collect();
             eprintln!(
@@ -1858,7 +1858,7 @@ mod tests {
         let state = State {
             values: vec![
                 Value::Int(42),
-                Value::Set([Value::Int(1), Value::Int(2)].into()),
+                Value::set([Value::Int(1), Value::Int(2)].into()),
             ],
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -224,7 +224,7 @@ fn parse_constant_value_from_tokens(tokens: &[Token], pos: &mut usize) -> Result
             let mut set = BTreeSet::new();
             if *pos < tokens.len() && tokens[*pos] == Token::RBrace {
                 *pos += 1;
-                return Ok(Value::Set(set));
+                return Ok(Value::set(set));
             }
             loop {
                 let val = parse_constant_value_from_tokens(tokens, pos)?;
@@ -242,7 +242,7 @@ fn parse_constant_value_from_tokens(tokens: &[Token], pos: &mut usize) -> Result
                     return Err(format!("expected ',' or '}}', got {:?}", tokens[*pos]));
                 }
             }
-            Ok(Value::Set(set))
+            Ok(Value::set(set))
         }
         Token::Ident(s) => {
             let val = Value::Str(Arc::from(s.as_str()));
@@ -315,7 +315,7 @@ pub fn parse_constant_value(s: &str) -> Option<Value> {
     if s.starts_with('{') && s.ends_with('}') {
         let inner = s[1..s.len() - 1].trim();
         if inner.is_empty() {
-            return Some(Value::Set(BTreeSet::new()));
+            return Some(Value::set(BTreeSet::new()));
         }
         let mut set = BTreeSet::new();
         for part in split_top_level(inner, ',') {
@@ -325,7 +325,7 @@ pub fn parse_constant_value(s: &str) -> Option<Value> {
                 return None;
             }
         }
-        return Some(Value::Set(set));
+        return Some(Value::set(set));
     }
     if !s.is_empty() && s.chars().all(|c| c.is_alphanumeric() || c == '_') {
         return Some(Value::Str(s.into()));
@@ -714,7 +714,7 @@ mod tests {
         expected_set.insert(Value::Str("rm1".into()));
         expected_set.insert(Value::Str("rm2".into()));
         expected_set.insert(Value::Str("rm3".into()));
-        assert_eq!(cfg.constants[0].1, Value::Set(expected_set));
+        assert_eq!(cfg.constants[0].1, Value::set(expected_set));
         assert_eq!(cfg.constants[1].1, Value::Int(5));
         assert_eq!(cfg.constants[2].1, Value::Bool(true));
     }
@@ -730,7 +730,7 @@ mod tests {
     fn parse_constant_empty_set() {
         let input = "CONSTANT\nS = {}";
         let cfg = parse_cfg(input).unwrap();
-        assert_eq!(cfg.constants[0].1, Value::Set(BTreeSet::new()));
+        assert_eq!(cfg.constants[0].1, Value::set(BTreeSet::new()));
     }
 
     #[test]
@@ -892,7 +892,7 @@ mod tests {
         let mut expected = BTreeSet::new();
         expected.insert(Value::Str("a".into()));
         expected.insert(Value::Str("b".into()));
-        assert_eq!(parse_constant_value("{a,b}"), Some(Value::Set(expected)));
+        assert_eq!(parse_constant_value("{a,b}"), Some(Value::set(expected)));
     }
 
     #[test]
@@ -920,7 +920,7 @@ mod tests {
         expected.insert(Value::Str("a".into()));
         expected.insert(Value::Str("b".into()));
         expected.insert(Value::Str("c".into()));
-        assert_eq!(cfg.constants[0].1, Value::Set(expected));
+        assert_eq!(cfg.constants[0].1, Value::set(expected));
     }
 
     #[test]
@@ -930,7 +930,7 @@ mod tests {
         let mut expected = BTreeSet::new();
         expected.insert(Value::Str(r#"hello\"world"#.into()));
         expected.insert(Value::Str("ok".into()));
-        assert_eq!(cfg.constants[0].1, Value::Set(expected));
+        assert_eq!(cfg.constants[0].1, Value::set(expected));
     }
 
     #[test]

--- a/src/eval/candidates.rs
+++ b/src/eval/candidates.rs
@@ -233,6 +233,51 @@ pub(crate) fn infer_all_candidates(
     Ok(result)
 }
 
+pub(crate) fn action_needs_refinement(expr: &Expr, defs: &Definitions) -> bool {
+    !candidate_sources_independent(expr, defs)
+}
+
+fn candidate_sources_independent(expr: &Expr, defs: &Definitions) -> bool {
+    match expr {
+        Expr::Eq(l, r) => match (l.as_ref(), r.as_ref()) {
+            (Expr::Prime(_), _) => !contains_prime_ref(r, defs),
+            (_, Expr::Prime(_)) => !contains_prime_ref(l, defs),
+            _ => !contains_prime_ref(l, defs) && !contains_prime_ref(r, defs),
+        },
+        Expr::In(elem, set) => match elem.as_ref() {
+            Expr::Prime(_) => !contains_prime_ref(set, defs),
+            _ => !contains_prime_ref(elem, defs) && !contains_prime_ref(set, defs),
+        },
+        Expr::And(l, r) | Expr::Or(l, r) | Expr::Implies(l, r) | Expr::Equiv(l, r) => {
+            candidate_sources_independent(l, defs) && candidate_sources_independent(r, defs)
+        }
+        Expr::Exists(_, domain, body) | Expr::Forall(_, domain, body) => {
+            !contains_prime_ref(domain, defs) && candidate_sources_independent(body, defs)
+        }
+        Expr::If(cond, then_br, else_br) => {
+            !contains_prime_ref(cond, defs)
+                && candidate_sources_independent(then_br, defs)
+                && candidate_sources_independent(else_br, defs)
+        }
+        Expr::Case(branches) => branches
+            .iter()
+            .all(|(g, r)| !contains_prime_ref(g, defs) && candidate_sources_independent(r, defs)),
+        Expr::Let(_, binding, body) => {
+            !contains_prime_ref(binding, defs) && candidate_sources_independent(body, defs)
+        }
+        Expr::LabeledAction(_, action) => candidate_sources_independent(action, defs),
+        Expr::FnCall(name, args) => {
+            args.iter().all(|a| !contains_prime_ref(a, defs))
+                && match defs.get(name) {
+                    Some((_, body)) => candidate_sources_independent(body, defs),
+                    None => !contains_prime_ref(expr, defs),
+                }
+        }
+        Expr::Unchanged(_) => true,
+        _ => !contains_prime_ref(expr, defs),
+    }
+}
+
 pub(crate) fn restore_env(env: &mut Env, saved: Vec<(Arc<str>, Option<Value>)>) {
     for (param, prev) in saved {
         match prev {

--- a/src/eval/candidates.rs
+++ b/src/eval/candidates.rs
@@ -107,29 +107,29 @@ fn apply_update(base: &Value, keys: &[Value], new_val: Value) -> Option<Value> {
         Value::Fn(f) => {
             let key = &keys[0];
             if keys.len() == 1 {
-                let mut new_f = f.clone();
+                let mut new_f = f.as_ref().clone();
                 new_f.insert(key.clone(), new_val);
-                Some(Value::Fn(new_f))
+                Some(Value::func(new_f))
             } else {
                 let inner = f.get(key)?;
                 let updated_inner = apply_update(inner, &keys[1..], new_val)?;
-                let mut new_f = f.clone();
+                let mut new_f = f.as_ref().clone();
                 new_f.insert(key.clone(), updated_inner);
-                Some(Value::Fn(new_f))
+                Some(Value::func(new_f))
             }
         }
         Value::Record(rec) => {
             if let Value::Str(field) = &keys[0] {
                 if keys.len() == 1 {
-                    let mut new_rec = rec.clone();
+                    let mut new_rec = rec.as_ref().clone();
                     new_rec.insert(field.clone(), new_val);
-                    Some(Value::Record(new_rec))
+                    Some(Value::record(new_rec))
                 } else {
                     let inner = rec.get(field)?;
                     let updated_inner = apply_update(inner, &keys[1..], new_val)?;
-                    let mut new_rec = rec.clone();
+                    let mut new_rec = rec.as_ref().clone();
                     new_rec.insert(field.clone(), updated_inner);
-                    Some(Value::Record(new_rec))
+                    Some(Value::record(new_rec))
                 }
             } else {
                 None
@@ -142,15 +142,15 @@ fn apply_update(base: &Value, keys: &[Value], new_val: Value) -> Option<Value> {
                 }
                 let idx = *idx as usize;
                 if keys.len() == 1 {
-                    let mut new_tup = tup.clone();
+                    let mut new_tup = tup.as_ref().clone();
                     new_tup[idx - 1] = new_val;
-                    Some(Value::Tuple(new_tup))
+                    Some(Value::tuple(new_tup))
                 } else {
                     let inner = tup.get(idx - 1)?;
                     let updated_inner = apply_update(inner, &keys[1..], new_val)?;
-                    let mut new_tup = tup.clone();
+                    let mut new_tup = tup.as_ref().clone();
                     new_tup[idx - 1] = updated_inner;
-                    Some(Value::Tuple(new_tup))
+                    Some(Value::tuple(new_tup))
                 }
             } else {
                 None

--- a/src/eval/combinatorics.rs
+++ b/src/eval/combinatorics.rs
@@ -28,7 +28,7 @@ pub(crate) fn enumerate_subbags(
     results: &mut BTreeSet<Value>,
 ) {
     if idx >= elements.len() {
-        results.insert(Value::Fn(current));
+        results.insert(Value::func(current));
         return;
     }
     let (elem, max_count) = &elements[idx];
@@ -177,7 +177,7 @@ pub(crate) fn generate_subsets_with_constraint(
     for k in min_k..=max_k.min(n) {
         for combo in k_combinations(elements, k) {
             let subset: BTreeSet<Value> = combo.into_iter().collect();
-            result.insert(Value::Set(subset));
+            result.insert(Value::set(subset));
         }
     }
     result

--- a/src/eval/context.rs
+++ b/src/eval/context.rs
@@ -238,7 +238,7 @@ pub fn eval_with_context(
                 let ev = eval_with_context(elem, env, defs, ctx)?;
                 if let Value::Tuple(seq) = ev {
                     let domain = eval_set(domain_expr, env, defs)?;
-                    for e in &seq {
+                    for e in seq.iter() {
                         if !domain.contains(e) {
                             return Ok(Value::Bool(false));
                         }
@@ -284,7 +284,7 @@ pub fn eval_with_context(
                 let ev = eval_with_context(elem, env, defs, ctx)?;
                 if let Value::Tuple(seq) = ev {
                     let domain = eval_set(domain_expr, env, defs)?;
-                    for e in &seq {
+                    for e in seq.iter() {
                         if !domain.contains(e) {
                             return Ok(Value::Bool(true));
                         }

--- a/src/eval/context.rs
+++ b/src/eval/context.rs
@@ -1,7 +1,7 @@
 use super::core::eval;
 use super::error::{EvalError, Result};
 use super::global_state::EvalContext;
-use super::helpers::{apply_fn_value, eval_set, flatten_fnapp_chain, in_set_symbolic};
+use super::helpers::{apply_fn_value, eval_set, in_set_symbolic};
 use super::state::is_action_enabled;
 use super::{Definitions, ResolvedInstances};
 use crate::ast::{Env, Expr, Value};
@@ -318,19 +318,9 @@ pub fn eval_with_context(
                 }
                 return result;
             }
-            let (base, keys) = flatten_fnapp_chain(expr);
-            if keys.is_empty() {
-                let fval = eval_with_context(f, env, defs, ctx)?;
-                let av = eval_with_context(arg, env, defs, ctx)?;
-                apply_fn_value(fval, av)
-            } else {
-                let mut current = eval_with_context(base, env, defs, ctx)?;
-                for key_expr in keys {
-                    let key = eval_with_context(key_expr, env, defs, ctx)?;
-                    current = apply_fn_value(current, key)?;
-                }
-                Ok(current)
-            }
+            let fval = eval_with_context(f, env, defs, ctx)?;
+            let av = eval_with_context(arg, env, defs, ctx)?;
+            apply_fn_value(fval, av)
         }
         Expr::Eq(l, r) => {
             let lv = eval_with_context(l, env, defs, ctx)?;

--- a/src/eval/core.rs
+++ b/src/eval/core.rs
@@ -143,7 +143,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             if let Expr::Powerset(inner) = set.as_ref() {
                 let ev = eval(elem, env, defs)?;
                 if let Value::Set(s) = ev {
-                    for member in &s {
+                    for member in s.iter() {
                         if !in_set_symbolic(member, inner, env, defs)? {
                             return Ok(Value::Bool(false));
                         }
@@ -155,7 +155,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             if let Expr::SeqSet(domain_expr) = set.as_ref() {
                 let ev = eval(elem, env, defs)?;
                 let seq = match &ev {
-                    Value::Tuple(t) => Some(t.clone()),
+                    Value::Tuple(t) => Some(t.as_ref().clone()),
                     Value::Fn(f) => fn_as_tuple(f),
                     _ => None,
                 };
@@ -199,7 +199,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             if let Expr::Powerset(inner) = set.as_ref() {
                 let ev = eval(elem, env, defs)?;
                 if let Value::Set(s) = ev {
-                    for member in &s {
+                    for member in s.iter() {
                         if !in_set_symbolic(member, inner, env, defs)? {
                             return Ok(Value::Bool(true));
                         }
@@ -211,7 +211,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             if let Expr::SeqSet(domain_expr) = set.as_ref() {
                 let ev = eval(elem, env, defs)?;
                 let seq = match &ev {
-                    Value::Tuple(t) => Some(t.clone()),
+                    Value::Tuple(t) => Some(t.as_ref().clone()),
                     Value::Fn(f) => fn_as_tuple(f),
                     _ => None,
                 };
@@ -287,7 +287,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                             && t2.len() == 2
                             && t1[1] == t2[0]
                         {
-                            let new_pair = Value::Tuple(vec![t1[0].clone(), t2[1].clone()]);
+                            let new_pair = Value::tuple(vec![t1[0].clone(), t2[1].clone()]);
                             if !result.contains(&new_pair) {
                                 result.insert(new_pair);
                                 changed = true;
@@ -296,7 +296,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                     }
                 }
             }
-            Ok(Value::Set(result))
+            Ok(Value::set(result))
         }
 
         Expr::ReflexiveTransitiveClosure(rel_expr) => {
@@ -313,7 +313,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                             && t2.len() == 2
                             && t1[1] == t2[0]
                         {
-                            let new_pair = Value::Tuple(vec![t1[0].clone(), t2[1].clone()]);
+                            let new_pair = Value::tuple(vec![t1[0].clone(), t2[1].clone()]);
                             if !result.contains(&new_pair) {
                                 result.insert(new_pair);
                                 changed = true;
@@ -326,11 +326,11 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                 if let Value::Tuple(t) = pair
                     && t.len() == 2
                 {
-                    result.insert(Value::Tuple(vec![t[0].clone(), t[0].clone()]));
-                    result.insert(Value::Tuple(vec![t[1].clone(), t[1].clone()]));
+                    result.insert(Value::tuple(vec![t[0].clone(), t[0].clone()]));
+                    result.insert(Value::tuple(vec![t[1].clone(), t[1].clone()]));
                 }
             }
-            Ok(Value::Set(result))
+            Ok(Value::set(result))
         }
 
         Expr::ActionCompose(_, _) => Err(EvalError::domain_error(
@@ -380,14 +380,14 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             for e in elems {
                 set.insert(eval(e, env, defs)?);
             }
-            Ok(Value::Set(set))
+            Ok(Value::set(set))
         }
 
         Expr::SetRange(lo, hi) => {
             let l = eval_int(lo, env, defs)?;
             let h = eval_int(hi, env, defs)?;
             let set: BTreeSet<Value> = (l..=h).map(Value::Int).collect();
-            Ok(Value::Set(set))
+            Ok(Value::set(set))
         }
 
         Expr::SetFilter(var, domain, predicate) => {
@@ -396,7 +396,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             {
                 let base_set = eval_set(inner, env, defs)?;
                 let elements: Vec<_> = base_set.into_iter().collect();
-                return Ok(Value::Set(generate_subsets_with_constraint(
+                return Ok(Value::set(generate_subsets_with_constraint(
                     &elements, constraint,
                 )));
             }
@@ -418,7 +418,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                     env.remove(var);
                 }
             }
-            Ok(Value::Set(result))
+            Ok(Value::set(result))
         }
 
         Expr::SetMap(var, domain, body) => {
@@ -437,25 +437,25 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                     env.remove(var);
                 }
             }
-            Ok(Value::Set(result))
+            Ok(Value::set(result))
         }
 
         Expr::Union(l, r) => {
             let ls = eval_set(l, env, defs)?;
             let rs = eval_set(r, env, defs)?;
-            Ok(Value::Set(ls.union(&rs).cloned().collect()))
+            Ok(Value::set(ls.union(&rs).cloned().collect()))
         }
 
         Expr::Intersect(l, r) => {
             let ls = eval_set(l, env, defs)?;
             let rs = eval_set(r, env, defs)?;
-            Ok(Value::Set(ls.intersection(&rs).cloned().collect()))
+            Ok(Value::set(ls.intersection(&rs).cloned().collect()))
         }
 
         Expr::SetMinus(l, r) => {
             let ls = eval_set(l, env, defs)?;
             let rs = eval_set(r, env, defs)?;
-            Ok(Value::Set(ls.difference(&rs).cloned().collect()))
+            Ok(Value::set(ls.difference(&rs).cloned().collect()))
         }
 
         Expr::Cartesian(l, r) => {
@@ -464,10 +464,10 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             let mut result = BTreeSet::new();
             for lv in &ls {
                 for rv in &rs {
-                    result.insert(Value::Tuple(vec![lv.clone(), rv.clone()]));
+                    result.insert(Value::tuple(vec![lv.clone(), rv.clone()]));
                 }
             }
-            Ok(Value::Set(result))
+            Ok(Value::set(result))
         }
 
         Expr::Subset(l, r) => {
@@ -500,9 +500,9 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                         subset.insert(elem.clone());
                     }
                 }
-                result.insert(Value::Set(subset));
+                result.insert(Value::set(subset));
             }
-            Ok(Value::Set(result))
+            Ok(Value::set(result))
         }
 
         Expr::Cardinality(e) => {
@@ -520,7 +520,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             let mut result = BTreeSet::new();
             for val in outer {
                 if let Value::Set(inner) = val {
-                    for v in inner {
+                    for v in Arc::unwrap_or_clone(inner) {
                         result.insert(v);
                     }
                 } else {
@@ -532,7 +532,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                     });
                 }
             }
-            Ok(Value::Set(result))
+            Ok(Value::set(result))
         }
 
         Expr::Exists(var, domain, body) => {
@@ -650,7 +650,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             let dom_vec: Vec<_> = dom.into_iter().collect();
             let placeholder_name: Arc<str> = "".into();
             let result = eval_fn_def_recursive(&placeholder_name, var, &dom_vec, body, env, defs)?;
-            Ok(Value::Fn(result))
+            Ok(Value::func(result))
         }
 
         Expr::FnCall(name, args) => {
@@ -774,15 +774,16 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             let lv = eval(left, env, defs)?;
             let rv = eval(right, env, defs)?;
             match (lv, rv) {
-                (Value::Fn(mut lf), Value::Fn(rf)) => {
-                    for (k, v) in rf {
+                (Value::Fn(lf), Value::Fn(rf)) => {
+                    let mut lf = Arc::unwrap_or_clone(lf);
+                    for (k, v) in Arc::unwrap_or_clone(rf) {
                         lf.entry(k).or_insert(v);
                     }
-                    Ok(Value::Fn(lf))
+                    Ok(Value::func(lf))
                 }
                 (l, r) => Err(EvalError::TypeMismatch {
                     expected: "Fn @@ Fn",
-                    got: Value::Tuple(vec![l, r]),
+                    got: Value::tuple(vec![l, r]),
                     context: Some("function merge"),
                     span: None,
                 }),
@@ -794,7 +795,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             let v = eval(val, env, defs)?;
             let mut f = BTreeMap::new();
             f.insert(k, v);
-            Ok(Value::Fn(f))
+            Ok(Value::func(f))
         }
 
         Expr::CustomOp(name, _left, _right) => Err(EvalError::domain_error(format!(
@@ -828,13 +829,13 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                 match &mut result {
                     Value::Record(rec) => {
                         if let [Value::Str(field)] = key_vals.as_slice() {
-                            rec.insert(field.clone(), v);
+                            Arc::make_mut(rec).insert(field.clone(), v);
                         } else {
                             return Err(EvalError::domain_error("invalid record update path"));
                         }
                     }
                     Value::Fn(fv) => {
-                        update_nested(fv, &key_vals, v)?;
+                        update_nested(Arc::make_mut(fv), &key_vals, v)?;
                     }
                     _ => {
                         return Err(EvalError::domain_error(
@@ -858,12 +859,12 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             match fv {
                 Value::Fn(fmap) => {
                     let dom: BTreeSet<Value> = fmap.keys().cloned().collect();
-                    Ok(Value::Set(dom))
+                    Ok(Value::set(dom))
                 }
                 Value::Tuple(seq) => {
                     let dom: BTreeSet<Value> =
                         (1..=seq.len()).map(|i| Value::Int(i as i64)).collect();
-                    Ok(Value::Set(dom))
+                    Ok(Value::set(dom))
                 }
                 other => Err(EvalError::type_mismatch_ctx(
                     "Fn or Sequence",
@@ -902,9 +903,9 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             let functions = enumerate_functions(&keys, &cod);
             let set: BTreeSet<Value> = functions
                 .into_iter()
-                .map(|f| fn_as_tuple(&f).map(Value::Tuple).unwrap_or(Value::Fn(f)))
+                .map(|f| fn_as_tuple(&f).map(Value::tuple).unwrap_or(Value::func(f)))
                 .collect();
-            Ok(Value::Set(set))
+            Ok(Value::set(set))
         }
 
         Expr::RecordLit(fields) => {
@@ -912,7 +913,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             for (name, expr) in fields {
                 rec.insert(name.clone(), eval(expr, env, defs)?);
             }
-            Ok(Value::Record(rec))
+            Ok(Value::record(rec))
         }
 
         Expr::RecordSet(fields) => {
@@ -922,7 +923,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                 field_domains.push((name.clone(), domain.into_iter().collect()));
             }
             let result = cartesian_product_records(&field_domains);
-            Ok(Value::Set(result.into_iter().map(Value::Record).collect()))
+            Ok(Value::set(result.into_iter().map(Value::record).collect()))
         }
 
         Expr::RecordAccess(rec, field) => {
@@ -937,7 +938,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             for e in elems {
                 tup.push(eval(e, env, defs)?);
             }
-            Ok(Value::Tuple(tup))
+            Ok(Value::tuple(tup))
         }
 
         Expr::TupleAccess(tup, idx) => {
@@ -982,21 +983,21 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             if tv.is_empty() {
                 return Err(EvalError::domain_error("Tail of empty sequence"));
             }
-            Ok(Value::Tuple(tv[1..].to_vec()))
+            Ok(Value::tuple(tv[1..].to_vec()))
         }
 
         Expr::Append(seq, elem) => {
             let mut tv = eval_tuple(seq, env, defs)?;
             let ev = eval(elem, env, defs)?;
             tv.push(ev);
-            Ok(Value::Tuple(tv))
+            Ok(Value::tuple(tv))
         }
 
         Expr::Concat(seq1, seq2) => {
             let mut tv1 = eval_tuple(seq1, env, defs)?;
             let tv2 = eval_tuple(seq2, env, defs)?;
             tv1.extend(tv2);
-            Ok(Value::Tuple(tv1))
+            Ok(Value::tuple(tv1))
         }
 
         Expr::SubSeq(seq, start, end) => {
@@ -1007,7 +1008,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                 return Err(EvalError::domain_error("SubSeq index out of bounds"));
             }
             let subseq = tv.get((s - 1)..e).unwrap_or(&[]).to_vec();
-            Ok(Value::Tuple(subseq))
+            Ok(Value::tuple(subseq))
         }
 
         Expr::SelectSeq(seq, test) => {
@@ -1041,7 +1042,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                     result.push(elem);
                 }
             }
-            Ok(Value::Tuple(result))
+            Ok(Value::tuple(result))
         }
 
         Expr::SeqSet(_) => Err(EvalError::domain_error(
@@ -1098,8 +1099,8 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                 )));
             }
             let perms = permutations(&elements);
-            let result: BTreeSet<Value> = perms.into_iter().map(Value::Tuple).collect();
-            Ok(Value::Set(result))
+            let result: BTreeSet<Value> = perms.into_iter().map(Value::tuple).collect();
+            Ok(Value::set(result))
         }
 
         Expr::SortSeq(seq_expr, cmp_expr) => {
@@ -1128,7 +1129,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                     "SortSeq comparator must be a LAMBDA expression",
                 ));
             }
-            Ok(Value::Tuple(result))
+            Ok(Value::tuple(result))
         }
 
         Expr::PrintT(val) => {
@@ -1225,7 +1226,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
         Expr::BagToSet(bag_expr) => {
             let f = eval_fn(bag_expr, env, defs)?;
             let dom: BTreeSet<Value> = f.keys().cloned().collect();
-            Ok(Value::Set(dom))
+            Ok(Value::set(dom))
         }
 
         Expr::SetToBag(set_expr) => {
@@ -1234,7 +1235,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             for elem in s {
                 bag.insert(elem, Value::Int(1));
             }
-            Ok(Value::Fn(bag))
+            Ok(Value::func(bag))
         }
 
         Expr::BagIn(elem_expr, bag_expr) => {
@@ -1247,7 +1248,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             }
         }
 
-        Expr::EmptyBag => Ok(Value::Fn(BTreeMap::new())),
+        Expr::EmptyBag => Ok(Value::func(BTreeMap::new())),
 
         Expr::BagAdd(left, right) => {
             let b1 = eval_fn(left, env, defs)?;
@@ -1267,7 +1268,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                     .unwrap_or(0);
                 result.insert(elem, Value::Int(c1 + c2));
             }
-            Ok(Value::Fn(result))
+            Ok(Value::func(result))
         }
 
         Expr::BagSub(left, right) => {
@@ -1291,7 +1292,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                     result.insert(elem.clone(), Value::Int(diff));
                 }
             }
-            Ok(Value::Fn(result))
+            Ok(Value::func(result))
         }
 
         Expr::BagUnion(bags_expr) => {
@@ -1299,7 +1300,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             let mut result: BTreeMap<Value, Value> = BTreeMap::new();
             for bag_val in bags_set {
                 if let Value::Fn(bag) = bag_val {
-                    for (elem, count) in bag {
+                    for (elem, count) in Arc::unwrap_or_clone(bag) {
                         let c_new = if let Value::Int(n) = count { n } else { 0 };
                         let c_old = result
                             .get(&elem)
@@ -1322,7 +1323,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                     });
                 }
             }
-            Ok(Value::Fn(result))
+            Ok(Value::func(result))
         }
 
         Expr::SqSubseteq(left, right) => {
@@ -1366,7 +1367,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
             }
             let mut result_set = BTreeSet::new();
             enumerate_subbags(&elements, 0, BTreeMap::new(), &mut result_set);
-            Ok(Value::Set(result_set))
+            Ok(Value::set(result_set))
         }
 
         Expr::BagOfAll(expr, bag_expr) => {
@@ -1408,7 +1409,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                     "BagOfAll requires a LAMBDA expression",
                 ));
             }
-            Ok(Value::Fn(result))
+            Ok(Value::func(result))
         }
 
         Expr::BagCardinality(bag_expr) => {
@@ -1448,7 +1449,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                 let dom_vec: Vec<_> = dom.into_iter().collect();
                 let fn_result =
                     eval_fn_def_recursive(var, param, &dom_vec, fn_body, env, &local_defs)?;
-                let prev = env.insert(var.clone(), Value::Fn(fn_result));
+                let prev = env.insert(var.clone(), Value::func(fn_result));
                 let result = eval(body, env, &local_defs);
                 match prev {
                     Some(old) => {

--- a/src/eval/core.rs
+++ b/src/eval/core.rs
@@ -11,7 +11,7 @@ use super::global_state::{
 };
 use super::helpers::{
     apply_fn_value, cartesian_product_records, eval_bool, eval_fn, eval_int, eval_record, eval_set,
-    eval_tuple, flatten_fnapp_chain, fn_as_tuple, get_nested, in_set_symbolic, update_nested,
+    eval_tuple, fn_as_tuple, get_nested, in_set_symbolic, update_nested,
 };
 use super::recursive::eval_fn_def_recursive;
 use crate::ast::{Env, Expr, Value};
@@ -636,19 +636,9 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                 }
                 return result;
             }
-            let (base, keys) = flatten_fnapp_chain(expr);
-            if keys.is_empty() {
-                let fval = eval(f, env, defs)?;
-                let av = eval(arg, env, defs)?;
-                apply_fn_value(fval, av)
-            } else {
-                let mut current = eval(base, env, defs)?;
-                for key_expr in keys {
-                    let key = eval(key_expr, env, defs)?;
-                    current = apply_fn_value(current, key)?;
-                }
-                Ok(current)
-            }
+            let fval = eval(f, env, defs)?;
+            let av = eval(arg, env, defs)?;
+            apply_fn_value(fval, av)
         }
 
         Expr::Lambda(_params, _body) => Err(EvalError::domain_error(

--- a/src/eval/core.rs
+++ b/src/eval/core.rs
@@ -63,7 +63,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
         }
 
         Expr::Prime(name) => {
-            let primed: Arc<str> = format!("{}'", name).into();
+            let primed = crate::intern::primed_name(name);
             env.get(&primed)
                 .cloned()
                 .ok_or_else(|| EvalError::undefined_var_with_env(primed, env, defs))
@@ -1491,7 +1491,7 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                 let current = env
                     .get(var)
                     .ok_or_else(|| EvalError::undefined_var_with_env(var.clone(), env, defs))?;
-                let primed: Arc<str> = format!("{}'", var).into();
+                let primed = crate::intern::primed_name(var);
                 let next = env
                     .get(&primed)
                     .ok_or_else(|| EvalError::undefined_var_with_env(primed, env, defs))?;

--- a/src/eval/diagnostics.rs
+++ b/src/eval/diagnostics.rs
@@ -45,7 +45,7 @@ fn explain_invariant_impl(
     match expr {
         Expr::Forall(var, domain, body) => {
             if let Ok(Value::Set(elements)) = eval(domain, env, defs) {
-                for elem in elements {
+                for elem in elements.iter() {
                     env.insert(var.clone(), elem.clone());
                     if let Ok(Value::Bool(false)) = eval(body, env, defs) {
                         info.failing_bindings.push((var.to_string(), elem.clone()));

--- a/src/eval/enumerate.rs
+++ b/src/eval/enumerate.rs
@@ -3,7 +3,7 @@ use super::ast_utils::{
     collect_conjuncts, collect_disjuncts_with_labels, contains_prime_ref, format_expr_brief,
     infer_action_name,
 };
-use super::candidates::infer_all_candidates;
+use super::candidates::{action_needs_refinement, infer_all_candidates};
 use super::error::Result;
 #[cfg(feature = "profiling")]
 use super::global_state::PROFILING_STATS;
@@ -206,32 +206,34 @@ fn enumerate_next_with_refinement(
 
     let mut all_candidates = infer_all_candidates(next, env, ctx.vars, ctx.defs)?;
 
-    for (i, primed) in ctx.primed_vars.iter().enumerate() {
-        if let Some(first) = all_candidates[i].first() {
-            env.insert(primed.clone(), first.clone());
+    if action_needs_refinement(next, ctx.defs) {
+        for (i, primed) in ctx.primed_vars.iter().enumerate() {
+            if let Some(first) = all_candidates[i].first() {
+                env.insert(primed.clone(), first.clone());
+            }
         }
-    }
 
-    let mut changed = true;
-    let mut iterations = 0;
-    while changed && iterations < 3 {
-        changed = false;
-        iterations += 1;
+        let mut changed = true;
+        let mut iterations = 0;
+        while changed && iterations < 3 {
+            changed = false;
+            iterations += 1;
 
-        let new_all = infer_all_candidates(next, env, ctx.vars, ctx.defs)?;
-        for (i, new_candidates) in new_all.into_iter().enumerate() {
-            if new_candidates != all_candidates[i] {
-                all_candidates[i] = new_candidates;
-                changed = true;
-                if let Some(first) = all_candidates[i].first() {
-                    env.insert(ctx.primed_vars[i].clone(), first.clone());
+            let new_all = infer_all_candidates(next, env, ctx.vars, ctx.defs)?;
+            for (i, new_candidates) in new_all.into_iter().enumerate() {
+                if new_candidates != all_candidates[i] {
+                    all_candidates[i] = new_candidates;
+                    changed = true;
+                    if let Some(first) = all_candidates[i].first() {
+                        env.insert(ctx.primed_vars[i].clone(), first.clone());
+                    }
                 }
             }
         }
-    }
 
-    for primed in ctx.primed_vars {
-        env.remove(primed);
+        for primed in ctx.primed_vars {
+            env.remove(primed);
+        }
     }
 
     enumerate_combinations(next, env, ctx, 0, &all_candidates, &action, results)

--- a/src/eval/helpers.rs
+++ b/src/eval/helpers.rs
@@ -74,7 +74,7 @@ pub(crate) fn in_set_symbolic(
     match set_expr {
         Expr::Powerset(inner) => {
             if let Value::Set(s) = val {
-                for member in s {
+                for member in s.iter() {
                     if !in_set_symbolic(member, inner, env, defs)? {
                         return Ok(false);
                     }
@@ -103,7 +103,7 @@ pub(crate) fn in_set_symbolic(
         }
         Expr::SeqSet(domain_expr) => {
             let seq = match val {
-                Value::Tuple(t) => Some(t.clone()),
+                Value::Tuple(t) => Some(t.as_ref().clone()),
                 Value::Fn(f) => fn_as_tuple(f),
                 _ => None,
             };
@@ -128,7 +128,7 @@ pub(crate) fn in_set_symbolic(
 
 pub(crate) fn eval_set(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<BTreeSet<Value>> {
     match eval(expr, env, defs)? {
-        Value::Set(s) => Ok(s),
+        Value::Set(s) => Ok(Arc::unwrap_or_clone(s)),
         other => Err(EvalError::TypeMismatch {
             expected: "Set",
             got: other,
@@ -144,7 +144,7 @@ pub(crate) fn eval_fn(
     defs: &Definitions,
 ) -> Result<BTreeMap<Value, Value>> {
     match eval(expr, env, defs)? {
-        Value::Fn(f) => Ok(f),
+        Value::Fn(f) => Ok(Arc::unwrap_or_clone(f)),
         other => Err(EvalError::TypeMismatch {
             expected: "Fn",
             got: other,
@@ -160,7 +160,7 @@ pub(crate) fn eval_record(
     defs: &Definitions,
 ) -> Result<BTreeMap<Arc<str>, Value>> {
     match eval(expr, env, defs)? {
-        Value::Record(r) => Ok(r),
+        Value::Record(r) => Ok(Arc::unwrap_or_clone(r)),
         other => Err(EvalError::TypeMismatch {
             expected: "Record",
             got: other,
@@ -184,7 +184,7 @@ pub(crate) fn fn_as_tuple(f: &BTreeMap<Value, Value>) -> Option<Vec<Value>> {
 
 pub(crate) fn eval_tuple(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Vec<Value>> {
     match eval(expr, env, defs)? {
-        Value::Tuple(t) => Ok(t),
+        Value::Tuple(t) => Ok(Arc::unwrap_or_clone(t)),
         Value::Fn(f) => fn_as_tuple(&f).ok_or(EvalError::TypeMismatch {
             expected: "Tuple",
             got: Value::Fn(f),
@@ -259,8 +259,8 @@ pub(crate) fn update_nested(
         ))
     })?;
     match inner {
-        Value::Fn(inner_fn) => update_nested(inner_fn, &keys[1..], val),
-        Value::Record(rec) => update_nested_record(rec, &keys[1..], val),
+        Value::Fn(inner_fn) => update_nested(Arc::make_mut(inner_fn), &keys[1..], val),
+        Value::Record(rec) => update_nested_record(Arc::make_mut(rec), &keys[1..], val),
         _ => Err(EvalError::TypeMismatch {
             expected: "Fn or Record",
             got: inner.clone(),
@@ -289,8 +289,8 @@ fn update_nested_record(
         .get_mut(field)
         .ok_or_else(|| EvalError::domain_error(format!("field '{}' not found in record", field)))?;
     match inner {
-        Value::Fn(inner_fn) => update_nested(inner_fn, &keys[1..], val),
-        Value::Record(inner_rec) => update_nested_record(inner_rec, &keys[1..], val),
+        Value::Fn(inner_fn) => update_nested(Arc::make_mut(inner_fn), &keys[1..], val),
+        Value::Record(inner_rec) => update_nested_record(Arc::make_mut(inner_rec), &keys[1..], val),
         _ => Err(EvalError::TypeMismatch {
             expected: "Fn or Record",
             got: inner.clone(),

--- a/src/eval/helpers.rs
+++ b/src/eval/helpers.rs
@@ -6,20 +6,6 @@ use crate::checker::format_value;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
-pub(crate) fn flatten_fnapp_chain(expr: &Expr) -> (&Expr, Vec<&Expr>) {
-    let mut keys = Vec::new();
-    let mut current = expr;
-    while let Expr::FnApp(f, arg) = current {
-        if matches!(f.as_ref(), Expr::Lambda(..)) {
-            break;
-        }
-        keys.push(arg.as_ref());
-        current = f.as_ref();
-    }
-    keys.reverse();
-    (current, keys)
-}
-
 pub(crate) fn apply_fn_value(fval: Value, key: Value) -> Result<Value> {
     match fval {
         Value::Fn(fv) => fv.get(&key).cloned().ok_or_else(|| {

--- a/src/eval/init.rs
+++ b/src/eval/init.rs
@@ -109,8 +109,8 @@ fn infer_init_candidates(
                     && name == var
                     && let Ok(Value::Set(s)) = eval(set, env, defs)
                 {
-                    for val in s {
-                        candidates.insert(val);
+                    for val in s.iter() {
+                        candidates.insert(val.clone());
                     }
                 }
             }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -201,7 +201,7 @@ mod tests {
         )
         .unwrap();
         let expected: BTreeSet<Value> = [Value::Int(1), Value::Int(2), Value::Int(3)].into();
-        assert_eq!(result, Value::Set(expected));
+        assert_eq!(result, Value::set(expected));
     }
 
     #[test]
@@ -210,7 +210,7 @@ mod tests {
         let mut env = Env::new();
         let result = eval(&set_range(lit_int(1), lit_int(3)), &mut env, &d).unwrap();
         let expected: BTreeSet<Value> = [Value::Int(1), Value::Int(2), Value::Int(3)].into();
-        assert_eq!(result, Value::Set(expected));
+        assert_eq!(result, Value::set(expected));
     }
 
     #[test]
@@ -468,7 +468,7 @@ mod tests {
         let mut env = Env::new();
         let expr = Expr::TupleLit(vec![lit_int(10), lit_int(20)]);
         let result = eval(&expr, &mut env, &d).unwrap();
-        assert_eq!(result, Value::Tuple(vec![Value::Int(10), Value::Int(20)]));
+        assert_eq!(result, Value::tuple(vec![Value::Int(10), Value::Int(20)]));
     }
 
     #[test]

--- a/src/eval/recursive.rs
+++ b/src/eval/recursive.rs
@@ -159,7 +159,7 @@ pub(crate) fn eval_with_memo(
             let rv = eval_with_memo(r, env, defs, fn_name, fn_param, fn_domain, memo)?;
             match (lv, rv) {
                 (Value::Set(a), Value::Set(b)) => {
-                    Ok(Value::Set(a.difference(&b).cloned().collect()))
+                    Ok(Value::set(a.difference(&b).cloned().collect()))
                 }
                 (a, b) => Err(EvalError::domain_error(format!(
                     "set minus requires Set \\ Set, got {} \\ {}",
@@ -176,7 +176,7 @@ pub(crate) fn eval_with_memo(
                     e, env, defs, fn_name, fn_param, fn_domain, memo,
                 )?);
             }
-            Ok(Value::Set(result))
+            Ok(Value::set(result))
         }
 
         Expr::Var(name) => {

--- a/src/eval/state.rs
+++ b/src/eval/state.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 pub fn make_primed_names(vars: &[Arc<str>]) -> Vec<Arc<str>> {
-    vars.iter().map(|v| Arc::from(format!("{}'", v))).collect()
+    vars.iter().map(|v| crate::intern::primed_name(v)).collect()
 }
 
 pub fn next_states(

--- a/src/interactive/render.rs
+++ b/src/interactive/render.rs
@@ -204,7 +204,7 @@ fn format_nested_changes(
     let mut changes = Vec::new();
     match (old_val, new_val) {
         (Value::Fn(old_map), Value::Fn(new_map)) => {
-            for (k, new_v) in new_map {
+            for (k, new_v) in new_map.iter() {
                 let key_str = format_value(k);
                 let new_path = format!("{}[{}]", path, key_str);
                 match old_map.get(k) {
@@ -217,7 +217,7 @@ fn format_nested_changes(
                     _ => {}
                 }
             }
-            for (k, v) in old_map {
+            for (k, v) in old_map.iter() {
                 if !new_map.contains_key(k) {
                     let key_str = format_value(k);
                     let new_path = format!("{}[{}]", path, key_str);
@@ -226,7 +226,7 @@ fn format_nested_changes(
             }
         }
         (Value::Record(old_rec), Value::Record(new_rec)) => {
-            for (k, new_v) in new_rec {
+            for (k, new_v) in new_rec.iter() {
                 let new_path = format!("{}.{}", path, k);
                 match old_rec.get(k) {
                     Some(old_v) if old_v != new_v => {

--- a/src/interactive/state.rs
+++ b/src/interactive/state.rs
@@ -293,7 +293,7 @@ impl ExplorerState {
     ) {
         match (old_val, new_val) {
             (Value::Fn(old_map), Value::Fn(new_map)) => {
-                for (k, v) in new_map {
+                for (k, v) in new_map.iter() {
                     let key_str = format_value(k);
                     let new_path = format!("{}[{}]", path, key_str);
                     match old_map.get(k) {
@@ -310,7 +310,7 @@ impl ExplorerState {
                             self.var_changes.push(VarChange {
                                 state_idx,
                                 path: new_path,
-                                old_value: Value::Set(std::collections::BTreeSet::new()),
+                                old_value: Value::set(std::collections::BTreeSet::new()),
                                 new_value: v.clone(),
                                 action: action.clone(),
                             });
@@ -326,14 +326,14 @@ impl ExplorerState {
                             state_idx,
                             path: new_path,
                             old_value: old_map.get(k).cloned().unwrap_or(Value::Bool(false)),
-                            new_value: Value::Set(std::collections::BTreeSet::new()),
+                            new_value: Value::set(std::collections::BTreeSet::new()),
                             action: action.clone(),
                         });
                     }
                 }
             }
             (Value::Record(old_rec), Value::Record(new_rec)) => {
-                for (k, v) in new_rec {
+                for (k, v) in new_rec.iter() {
                     let new_path = format!("{}.{}", path, k);
                     match old_rec.get(k) {
                         Some(old_v) if old_v != v => {

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -1,0 +1,30 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+thread_local! {
+    static NAMES: RefCell<HashMap<Box<str>, Arc<str>>> = RefCell::new(HashMap::new());
+    static PRIMED: RefCell<HashMap<Box<str>, Arc<str>>> = RefCell::new(HashMap::new());
+}
+
+pub fn intern(s: &str) -> Arc<str> {
+    NAMES.with(|m| {
+        if let Some(existing) = m.borrow().get(s) {
+            return existing.clone();
+        }
+        let interned: Arc<str> = Arc::from(s);
+        m.borrow_mut().insert(Box::from(s), interned.clone());
+        interned
+    })
+}
+
+pub fn primed_name(base: &str) -> Arc<str> {
+    PRIMED.with(|m| {
+        if let Some(existing) = m.borrow().get(base) {
+            return existing.clone();
+        }
+        let interned: Arc<str> = Arc::from(format!("{}'", base));
+        m.borrow_mut().insert(Box::from(base), interned.clone());
+        interned
+    })
+}

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -1,9 +1,9 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 thread_local! {
-    static NAMES: RefCell<HashMap<Box<str>, Arc<str>>> = RefCell::new(HashMap::new());
+    static NAMES: RefCell<HashSet<Arc<str>>> = RefCell::new(HashSet::new());
     static PRIMED: RefCell<HashMap<Box<str>, Arc<str>>> = RefCell::new(HashMap::new());
 }
 
@@ -13,7 +13,7 @@ pub fn intern(s: &str) -> Arc<str> {
             return existing.clone();
         }
         let interned: Arc<str> = Arc::from(s);
-        m.borrow_mut().insert(Box::from(s), interned.clone());
+        m.borrow_mut().insert(interned.clone());
         interned
     })
 }
@@ -27,4 +27,9 @@ pub fn primed_name(base: &str) -> Arc<str> {
         m.borrow_mut().insert(Box::from(base), interned.clone());
         interned
     })
+}
+
+pub fn clear() {
+    NAMES.with(|m| m.borrow_mut().clear());
+    PRIMED.with(|m| m.borrow_mut().clear());
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -838,7 +838,7 @@ impl<'a> Lexer<'a> {
                 "HIDE" => Token::By,
                 "DEFS" => Token::ProofDef,
                 "ONLY" => Token::By,
-                _ => Token::Ident(ident.into()),
+                _ => Token::Ident(crate::intern::intern(ident)),
             };
             return Ok(tok);
         }
@@ -1316,7 +1316,7 @@ impl<'a> Lexer<'a> {
                 "HIDE" => Token::By,
                 "DEFS" => Token::ProofDef,
                 "ONLY" => Token::By,
-                _ => Token::Ident(ident.into()),
+                _ => Token::Ident(crate::intern::intern(ident)),
             };
             return Ok(tok);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod export;
 pub mod graph;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod interactive;
+pub mod intern;
 pub mod lexer;
 pub mod liveness;
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/liveness.rs
+++ b/src/liveness.rs
@@ -131,7 +131,7 @@ fn action_matches(
         if let Some(val) = current.values.get(i) {
             env.insert(var.clone(), val.clone());
         }
-        let primed: Arc<str> = format!("{}'", var).into();
+        let primed = crate::intern::primed_name(var);
         if let Some(val) = next.values.get(i) {
             env.insert(primed, val.clone());
         }

--- a/src/mcp/runner.rs
+++ b/src/mcp/runner.rs
@@ -40,6 +40,7 @@ pub fn prepare(
     config_path: Option<&str>,
     user_constants: &BTreeMap<String, String>,
 ) -> Result<LoadedSpec, StructuredError> {
+    crate::intern::clear();
     let path = PathBuf::from(spec_path);
     let contents = fs::read_to_string(&path)
         .map_err(|e| StructuredError::io(format!("failed to read {}: {}", spec_path, e)))?;
@@ -545,6 +546,7 @@ fn beat_report_to_summary(index: usize, report: &BeatReport) -> BeatSummary {
 }
 
 pub fn validate_demo(input: &ValidateDemoInput) -> ValidateDemoOutput {
+    crate::intern::clear();
     let manifest = match Manifest::load(Path::new(&input.manifest_path)) {
         Ok(m) => m,
         Err(e) => {
@@ -589,6 +591,7 @@ pub fn validate_demo(input: &ValidateDemoInput) -> ValidateDemoOutput {
 }
 
 pub fn append_beat(input: &AppendBeatInput) -> AppendBeatOutput {
+    crate::intern::clear();
     let manifest_path = Path::new(&input.manifest_path);
     let mut manifest = match Manifest::load(manifest_path) {
         Ok(m) => m,
@@ -677,6 +680,7 @@ pub fn append_beat(input: &AppendBeatInput) -> AppendBeatOutput {
 }
 
 pub fn export_demo_doc(input: &ExportDemoDocInput) -> ExportDemoDocOutput {
+    crate::intern::clear();
     let manifest = match Manifest::load(Path::new(&input.manifest_path)) {
         Ok(m) => m,
         Err(e) => {
@@ -716,6 +720,7 @@ pub fn export_demo_doc(input: &ExportDemoDocInput) -> ExportDemoDocOutput {
 }
 
 pub fn export_demo_html(input: &ExportDemoHtmlInput) -> ExportDemoHtmlOutput {
+    crate::intern::clear();
     let manifest = match Manifest::load(Path::new(&input.manifest_path)) {
         Ok(m) => m,
         Err(e) => {

--- a/src/mcp/schema.rs
+++ b/src/mcp/schema.rs
@@ -421,7 +421,7 @@ fn value_to_json(value: &Value) -> serde_json::Value {
         }
         Value::Record(fields) => {
             let mut field_map = Map::new();
-            for (k, v) in fields {
+            for (k, v) in fields.iter() {
                 field_map.insert(k.to_string(), value_to_json(v));
             }
             let mut obj = Map::new();

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -201,7 +201,7 @@ fn build_scenario_env(current: &State, next: &State, constants: &Env, vars: &[Ar
             env.insert(var.clone(), val.clone());
         }
         if let Some(val) = next.values.get(i) {
-            let primed_name: Arc<str> = format!("{}'", var).into();
+            let primed_name = crate::intern::primed_name(var);
             env.insert(primed_name, val.clone());
         }
     }

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -7,7 +7,7 @@ pub fn load_builtins(env: &mut Env) {
     let boolean: BTreeSet<Value> = [Value::Bool(false), Value::Bool(true)]
         .into_iter()
         .collect();
-    env.insert(Arc::from("BOOLEAN"), Value::Set(boolean));
+    env.insert(Arc::from("BOOLEAN"), Value::set(boolean));
 }
 
 pub fn is_stdlib_module(name: &str) -> bool {
@@ -32,13 +32,13 @@ pub fn load_module(name: &str, env: &mut Env) {
 
 fn load_naturals(env: &mut Env) {
     let nat: BTreeSet<Value> = (0..=100).map(Value::Int).collect();
-    env.insert(Arc::from("Nat"), Value::Set(nat));
+    env.insert(Arc::from("Nat"), Value::set(nat));
 }
 
 fn load_integers(env: &mut Env) {
     load_naturals(env);
     let int: BTreeSet<Value> = (-100..=100).map(Value::Int).collect();
-    env.insert(Arc::from("Int"), Value::Set(int));
+    env.insert(Arc::from("Int"), Value::set(int));
 }
 
 fn load_sequences(_env: &mut Env) {}

--- a/src/symmetry.rs
+++ b/src/symmetry.rs
@@ -82,7 +82,7 @@ impl SymmetryConfig {
 
         match value {
             Value::Set(s) => {
-                for elem in s {
+                for elem in s.iter() {
                     self.collect_elements_in_order(elem, sym_set, seen, ordering);
                 }
             }
@@ -100,7 +100,7 @@ impl SymmetryConfig {
                 }
             }
             Value::Tuple(t) => {
-                for elem in t {
+                for elem in t.iter() {
                     self.collect_elements_in_order(elem, sym_set, seen, ordering);
                 }
             }
@@ -129,7 +129,7 @@ impl SymmetryConfig {
                     .iter()
                     .map(|e| self.apply_mapping_to_value(e, mapping))
                     .collect();
-                Value::Set(mapped)
+                Value::set(mapped)
             }
             Value::Fn(f) => {
                 let mapped: BTreeMap<_, _> = f
@@ -141,21 +141,21 @@ impl SymmetryConfig {
                         )
                     })
                     .collect();
-                Value::Fn(mapped)
+                Value::func(mapped)
             }
             Value::Record(r) => {
                 let mapped: BTreeMap<_, _> = r
                     .iter()
                     .map(|(k, v)| (k.clone(), self.apply_mapping_to_value(v, mapping)))
                     .collect();
-                Value::Record(mapped)
+                Value::record(mapped)
             }
             Value::Tuple(t) => {
                 let mapped: Vec<_> = t
                     .iter()
                     .map(|e| self.apply_mapping_to_value(e, mapping))
                     .collect();
-                Value::Tuple(mapped)
+                Value::tuple(mapped)
             }
         }
     }
@@ -215,7 +215,7 @@ mod tests {
         votes.insert(str_val("p1"), Value::Int(0));
         votes.insert(str_val("p3"), Value::Int(0));
         let state = State {
-            values: vec![Value::Fn(votes)],
+            values: vec![Value::func(votes)],
         };
 
         let canonical = config.canonicalize(&state);
@@ -254,7 +254,7 @@ mod tests {
 
         let inner_set = BTreeSet::from([str_val("y")]);
         let state = State {
-            values: vec![Value::Set(inner_set)],
+            values: vec![Value::set(inner_set)],
         };
 
         let canonical = config.canonicalize(&state);

--- a/src/trace_io.rs
+++ b/src/trace_io.rs
@@ -37,7 +37,7 @@ pub fn json_to_value(j: &serde_json::Value) -> Option<Value> {
         serde_json::Value::Array(arr) => {
             let set: std::collections::BTreeSet<Value> =
                 arr.iter().filter_map(json_to_value).collect();
-            Some(Value::Set(set))
+            Some(Value::set(set))
         }
         serde_json::Value::Object(obj) => {
             if let Some(fn_arr) = obj.get("__fn") {
@@ -51,7 +51,7 @@ pub fn json_to_value(j: &serde_json::Value) -> Option<Value> {
                         Some((k, v))
                     })
                     .collect();
-                return Some(Value::Fn(map));
+                return Some(Value::func(map));
             }
             if let Some(tuple_arr) = obj.get("__tuple") {
                 let elems: Vec<Value> = tuple_arr
@@ -59,13 +59,13 @@ pub fn json_to_value(j: &serde_json::Value) -> Option<Value> {
                     .iter()
                     .filter_map(json_to_value)
                     .collect();
-                return Some(Value::Tuple(elems));
+                return Some(Value::tuple(elems));
             }
             let fields: BTreeMap<Arc<str>, Value> = obj
                 .iter()
                 .filter_map(|(k, v)| Some((Arc::from(k.as_str()), json_to_value(v)?)))
                 .collect();
-            Some(Value::Record(fields))
+            Some(Value::record(fields))
         }
         serde_json::Value::Null => None,
     }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -300,14 +300,14 @@ fn json_to_value(v: serde_json::Value) -> Value {
         serde_json::Value::Array(arr) => {
             let set: std::collections::BTreeSet<Value> =
                 arr.into_iter().map(json_to_value).collect();
-            Value::Set(set)
+            Value::set(set)
         }
         serde_json::Value::Object(obj) => {
             let rec: BTreeMap<Arc<str>, Value> = obj
                 .into_iter()
                 .map(|(k, v)| (Arc::from(k), json_to_value(v)))
                 .collect();
-            Value::Record(rec)
+            Value::record(rec)
         }
         serde_json::Value::Null => Value::Bool(false),
     }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -269,6 +269,7 @@ pub fn check_spec_with_options(spec_source: &str, options_json: &str) -> String 
 }
 
 fn check_internal(inputs: WasmInputs) -> WasmCheckResult {
+    crate::intern::clear();
     let WasmInputs {
         spec,
         domains,
@@ -441,6 +442,7 @@ fn prepare_explorer(
     cfg_source: &str,
     constants_json: &str,
 ) -> Result<(Spec, Env, Definitions), String> {
+    crate::intern::clear();
     let mut spec = parse(spec_source).map_err(|e| format!("{e:?}"))?;
 
     let mut domains = Env::new();

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -399,7 +399,7 @@ fn test_symmetry_reduces_states() {
         .collect();
 
     let mut domains = Env::new();
-    domains.insert(Arc::from("Proc"), Value::Set(proc_set));
+    domains.insert(Arc::from("Proc"), Value::set(proc_set));
 
     let config_no_sym = CheckerConfig {
         allow_deadlock: true,
@@ -513,7 +513,7 @@ fn test_official_twophase() {
         .collect();
 
     let mut domains = Env::new();
-    domains.insert(Arc::from("RM"), Value::Set(rm_set));
+    domains.insert(Arc::from("RM"), Value::set(rm_set));
 
     let config = CheckerConfig {
         allow_deadlock: true,
@@ -865,7 +865,7 @@ fn test_cfg_cli_constant_overrides_cfg() {
     let mut rm_set = BTreeSet::new();
     rm_set.insert(Value::Str("r1".into()));
     rm_set.insert(Value::Str("r2".into()));
-    let cli_constants = vec![(Arc::from("RM"), Value::Set(rm_set))];
+    let cli_constants = vec![(Arc::from("RM"), Value::set(rm_set))];
 
     let mut domains = Env::new();
     let mut config = CheckerConfig {
@@ -1018,7 +1018,7 @@ fn test_constant_override_user_wins() {
     custom_set.insert(Value::Str("c".into()));
 
     let mut domains = Env::new();
-    domains.insert(Arc::from("BOOLEAN"), Value::Set(custom_set));
+    domains.insert(Arc::from("BOOLEAN"), Value::set(custom_set));
 
     let config = CheckerConfig {
         allow_deadlock: true,


### PR DESCRIPTION
## Summary

Profiler-guided optimization of state-space generation. **~2.5x faster on protocol specs, ~1.5x on constraint specs, with bit-identical results** — no algorithm or semantic changes.

Profiling showed ~75% of CPU went to allocating, cloning, dropping, and comparing `Value` collections (only ~11% in actual model-checking logic). The bottleneck was the data representation — every successor deep-copied entire `BTreeSet`/`BTreeMap`s — not the algorithm or lack of parallelism.

## Changes (each verified independently)

1. **Evaluate function applications recursively** — removes a per-call `Vec` allocation in the `FnApp` hot path.
2. **Reference-count collection values** — `Value::Set/Fn/Record/Tuple` now wrap their payloads in `Arc`, so cloning a `Value` is a refcount bump instead of a deep copy (the largest win). Mutation uses copy-on-write (`Arc::make_mut`); extraction uses `Arc::unwrap_or_clone` (moves when unshared).
3. **Skip redundant candidate re-inference** — `infer_all_candidates` ran twice per state via a refinement loop; it's now skipped for actions whose primed variables don't depend on each other (a conservative static check). Bit-identical candidate sets, so results are unchanged.
4. **Intern identifier and primed-variable names** — the lexer created a fresh `Arc<str>` per identifier occurrence (defeating `Env`'s pointer-equality fast path), and `Expr::Prime` evaluation allocated a `String` on every primed-variable read. Both are now interned/cached. The intern tables are thread-local and cleared at each MCP/wasm request boundary, so they stay bounded to a single spec's identifiers rather than growing over a long-lived server's lifetime.

## Benchmarks (min of 3 runs)

| Spec | Before | After | Speedup |
|------|--------|-------|---------|
| Two-Phase Commit, 5 RMs (8,832 states) | 1.26s | 0.50s | 2.51x |
| Two-Phase Commit, 6 RMs (50,816 states) | 9.22s | 3.51s | 2.63x |
| N-Queens, N=4 (785 states) | 0.59s | 0.38s | 1.53x |
| N-Queens, N=5 (capped) | 18.4s | 11.7s | 1.57x |
| TimeIntegrity (409,461 states) | 63.9s | 39.6s | 1.61x |

Allocation churn roughly halved (dhat, N-Queens N=4): 7.74M -> 3.56M allocations, 1.09 GB -> 516 MB.

## Breaking change (library API)

The public `Value` enum now stores collection payloads behind `Arc` (`Set(Arc<BTreeSet<Value>>)`, etc.). Read-only pattern matches are unaffected (`Deref`); code that mutated or moved out the inner collection should use `Arc::make_mut` / `Arc::unwrap_or_clone`. New constructors `Value::set/func/record/tuple` wrap a plain collection. Version bumped to **0.6.0** accordingly.

## Verification

- `cargo test` (default) and `cargo test --features wasm` pass (278 / 301 tests), including the oracle suite that asserts exact reachable-state counts.
- clippy `-D warnings` clean (default + wasm); fmt clean; wasm32 build, `tla-mcp` binary, and all feature combinations (dhat / embed-wasm / profiling) compile.
- Behavioral regression check: every `.tla` under `examples/` and `test_cases/` (119 specs) run on the pre-change and post-change binaries and diffed — all outputs byte-identical (verdicts, state counts, counterexample traces); zero crashes.
- MCP server (`tla-mcp`) initialize / tools/list / `check_spec` verified; result matches the CLI.

