### PR TITLE
support structural membership in record-type sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.3] - 2026-06-01
+
+### Added
+
+- Structural membership for record-type sets. `r \in [f1: T1, f2: T2, ...]` and the type-invariant idiom `vars \subseteq [f1: T1, ...]` are now checked structurally instead of by enumerating the right-hand side, so field types may be infinite — most importantly `Seq(T)`. Membership verifies the value is a record with exactly those fields and that each field value belongs to its type set, recursively (so `SUBSET S`, `[D -> R]`, and `Seq(T)` field types all compose). This unblocks the standard TLA+ type invariant for specs with sequence-valued record fields (e.g. message-queue models), which previously failed with "Seq(S) cannot be enumerated". `\notin` is handled symmetrically.
+
 ## [0.6.2] - 2026-06-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"

--- a/TLA_SUPPORT.md
+++ b/TLA_SUPPORT.md
@@ -49,6 +49,8 @@ Inv == x + y <= 2 * N
 
 Invariants are detected by naming convention: definitions starting with `Inv`, `TypeOK`, or `NotSolved` are automatically checked.
 
+The standard type-invariant idiom `vars \subseteq [f1: T1, f2: T2, ...]` (and the pointwise `r \in [f1: T1, ...]`) is checked structurally — the record-type set is never enumerated, so field types may be infinite, e.g. `queue: Seq(MsgId)`. Membership verifies that the value is a record with exactly those fields and that each field value belongs to its type set (recursively, so `SUBSET S`, `[D -> R]`, and `Seq(T)` field types all work).
+
 ## Limitations
 
 `Nat` and `Int` are bounded (-100 to 100 by default). Temporal operators `[]`, `<>`, `~>` are parsed but cannot be evaluated directly — use `--check-liveness` for fairness/liveness properties via SCC analysis. Unbounded quantifiers (`\E x : P` without `\in S`) and `Seq(S)` enumeration are not supported. Recursive operators must be declared with `RECURSIVE`.

--- a/src/eval/context.rs
+++ b/src/eval/context.rs
@@ -247,6 +247,10 @@ pub fn eval_with_context(
                 }
                 return Ok(Value::Bool(false));
             }
+            if matches!(set.as_ref(), Expr::RecordSet(_)) {
+                let ev = eval_with_context(elem, env, defs, ctx)?;
+                return Ok(Value::Bool(in_set_symbolic(&ev, set, env, defs)?));
+            }
             let ev = eval_with_context(elem, env, defs, ctx)?;
             let sv = eval_set(set, env, defs)?;
             Ok(Value::Bool(sv.contains(&ev)))
@@ -292,6 +296,10 @@ pub fn eval_with_context(
                     return Ok(Value::Bool(false));
                 }
                 return Ok(Value::Bool(true));
+            }
+            if matches!(set.as_ref(), Expr::RecordSet(_)) {
+                let ev = eval_with_context(elem, env, defs, ctx)?;
+                return Ok(Value::Bool(!in_set_symbolic(&ev, set, env, defs)?));
             }
             let ev = eval_with_context(elem, env, defs, ctx)?;
             let sv = eval_set(set, env, defs)?;

--- a/src/eval/core.rs
+++ b/src/eval/core.rs
@@ -11,7 +11,7 @@ use super::global_state::{
 };
 use super::helpers::{
     apply_fn_value, cartesian_product_records, eval_bool, eval_fn, eval_int, eval_record, eval_set,
-    eval_tuple, fn_as_tuple, get_nested, in_set_symbolic, update_nested,
+    eval_tuple, fn_as_tuple, get_nested, in_set_symbolic, is_structural_set_expr, update_nested,
 };
 use super::recursive::eval_fn_def_recursive;
 use crate::ast::{Env, Expr, Value};
@@ -170,6 +170,10 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                 }
                 return Ok(Value::Bool(false));
             }
+            if matches!(set.as_ref(), Expr::RecordSet(_)) {
+                let ev = eval(elem, env, defs)?;
+                return Ok(Value::Bool(in_set_symbolic(&ev, set, env, defs)?));
+            }
             let ev = eval(elem, env, defs)?;
             let sv = eval_set(set, env, defs)?;
             Ok(Value::Bool(sv.contains(&ev)))
@@ -225,6 +229,10 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
                     return Ok(Value::Bool(false));
                 }
                 return Ok(Value::Bool(true));
+            }
+            if matches!(set.as_ref(), Expr::RecordSet(_)) {
+                let ev = eval(elem, env, defs)?;
+                return Ok(Value::Bool(!in_set_symbolic(&ev, set, env, defs)?));
             }
             let ev = eval(elem, env, defs)?;
             let sv = eval_set(set, env, defs)?;
@@ -471,6 +479,15 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
         }
 
         Expr::Subset(l, r) => {
+            if is_structural_set_expr(r) {
+                let ls = eval_set(l, env, defs)?;
+                for elem in &ls {
+                    if !in_set_symbolic(elem, r, env, defs)? {
+                        return Ok(Value::Bool(false));
+                    }
+                }
+                return Ok(Value::Bool(true));
+            }
             let ls = eval_set(l, env, defs)?;
             let rs = eval_set(r, env, defs)?;
             Ok(Value::Bool(ls.is_subset(&rs)))

--- a/src/eval/helpers.rs
+++ b/src/eval/helpers.rs
@@ -65,6 +65,13 @@ pub(crate) fn eval_int(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result
     }
 }
 
+pub(crate) fn is_structural_set_expr(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Powerset(_) | Expr::FunctionSet(_, _) | Expr::SeqSet(_) | Expr::RecordSet(_)
+    )
+}
+
 pub(crate) fn in_set_symbolic(
     val: &Value,
     set_expr: &Expr,
@@ -112,6 +119,26 @@ pub(crate) fn in_set_symbolic(
                 for e in &seq {
                     if !domain.contains(e) {
                         return Ok(false);
+                    }
+                }
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }
+        Expr::RecordSet(fields) => {
+            if let Value::Record(r) = val {
+                if r.len() != fields.len() {
+                    return Ok(false);
+                }
+                for (name, type_expr) in fields {
+                    match r.get(name) {
+                        Some(field_val) => {
+                            if !in_set_symbolic(field_val, type_expr, env, defs)? {
+                                return Ok(false);
+                            }
+                        }
+                        None => return Ok(false),
                     }
                 }
                 Ok(true)

--- a/test_cases/should_pass/record_set_membership.tla
+++ b/test_cases/should_pass/record_set_membership.tla
@@ -1,0 +1,30 @@
+---- MODULE record_set_membership ----
+EXTENDS Naturals, Sequences
+
+MsgId == {10, 20}
+PortId == {1, 2}
+
+VARIABLE ports
+
+PortRec == [ id : PortId, queue : Seq(MsgId) ]
+
+Init == ports = { [id |-> 1, queue |-> << >>],
+                  [id |-> 2, queue |-> << >>] }
+
+Push(p, m) ==
+    ports' = (ports \ {p}) \cup { [id |-> p.id, queue |-> Append(p.queue, m)] }
+
+Next == \E p \in ports, m \in MsgId :
+    /\ Len(p.queue) < 2
+    /\ Push(p, m)
+
+TypeOK == ports \subseteq PortRec
+
+InvMembership ==
+    /\ [id |-> 1, queue |-> << >>] \in PortRec
+    /\ [id |-> 2, queue |-> <<10, 20>>] \in PortRec
+    /\ [id |-> 9, queue |-> << >>] \notin PortRec
+    /\ [id |-> 1, queue |-> <<99>>] \notin PortRec
+    /\ [id |-> 1] \notin PortRec
+
+====

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -388,6 +388,18 @@ fn test_lazy_subset_membership() {
 }
 
 #[test]
+fn test_record_set_membership() {
+    let path = Path::new("test_cases/should_pass/record_set_membership.tla");
+    let result = check_spec_file_allow_deadlock(path);
+    assert!(
+        matches!(result, CheckResult::Ok(_)),
+        "record_set_membership.tla should pass (structural membership in [f: T] \
+         record-type sets with an infinite Seq(T) field, via \\in / \\notin / \\subseteq), got: {:?}",
+        result
+    );
+}
+
+#[test]
 fn test_symmetry_reduces_states() {
     let path = Path::new("test_cases/benchmark/symmetric_procs.tla");
     let input = fs::read_to_string(path).expect("failed to read spec file");


### PR DESCRIPTION
Closes #21.

> ⚠️ **Stacked on #56** (base is `cfg-constant-literals`, not `main`) so the diff is scoped to this change. Retarget to `main` once #56 merges.

## Problem

The standard TLA+ type-invariant idiom

```tla
TypeOK == ports \subseteq [ id : PortId, queue : Seq(MsgId) ]
```

failed with `Seq(S) cannot be enumerated (infinite set)`, because evaluating `\in`/`\subseteq` over a record-type set tried to materialize the right-hand side — and `Seq(MsgId)` is infinite. This blocks type invariants for any spec with a sequence-valued (or otherwise infinite-typed) record field — extremely common (message queues, logs, Raft, etc.).

## Fix

Check record-type-set membership **structurally** instead of by enumeration — the same approach TLC uses:

1. `in_set_symbolic` (`eval/helpers.rs`) gains a `RecordSet` arm: the value must be a record with exactly the declared fields, and each field value must be a symbolic member of its type set. It recurses, so infinite field types (`Seq(T)`, `[D -> R]`, `SUBSET S`) compose.
2. `\in` / `\notin` route a `RecordSet` RHS through `in_set_symbolic` in **both** evaluators — `eval_inner` (`core.rs`) and `eval_with_context` (`context.rs`). (The bug initially looked fixed via `\subseteq` but `\in` still threw — there are two evaluator paths and the context one was the one invariants actually use.)
3. `\subseteq` (`Expr::Subset`) checks each LHS element via `in_set_symbolic` when the RHS is a structural set expr (`is_structural_set_expr`: powerset / function-set / seq-set / record-set), so the RHS is never materialized.

## Tests

- `test_cases/should_pass/record_set_membership.tla` + oracle test: a message-port-style spec with a `queue: Seq(MsgId)` field, asserting `\subseteq`, `\in`, and `\notin` (the `\notin` conjuncts cover the discriminating cases — wrong element type, missing field, extra field, bad id).
- Manually verified discrimination end-to-end (wrong field type / missing field / extra field / out-of-domain id all correctly excluded).
- Full suite green (185 lib + 65 oracle + 37 integration), clippy clean.

`TLA_SUPPORT.md` updated; version bumped to 0.6.3 with a CHANGELOG entry.

Out of scope (unchanged): `\subset` (proper subset) against an infinite type set, and refinement (#22).