### PR TITLE
enforce WF_vars fairness and expand quantified fairness/leads-to properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Liveness checking now enforces `WF_vars`/`SF_vars` fairness against the actual recurring cycle instead of reporting it as a violation. Previously a fair action that was continuously enabled but never taken produced a spurious `liveness_violation`, and a fairness check applied to the whole SCC missed unfair sub-cycles nested inside a larger SCC, so a `~>` property that holds under weak fairness could still be reported as violated.
+- Liveness checking now enforces `WF_vars`/`SF_vars` fairness against the actual recurring cycles instead of reporting them as violations. Previously a fair action that was continuously enabled but never taken produced a spurious `liveness_violation`, and a fairness check applied to the whole SCC missed unfair sub-cycles nested inside a larger SCC, so a `~>` property that holds under weak fairness could still be reported as violated. The checker now also inspects every violating sub-cycle within an SCC rather than only the first: a genuine fair counterexample is no longer missed when an unfair sub-cycle happens to be found first in the same SCC.
 - Quantified fairness `\A s \in S : WF_vars(A(s))` (and the strong-fairness form) is now expanded into per-element constraints using the resolved constants, rather than leaking `WF_vars` into the initial-state predicate and aborting evaluation.
 - A universally quantified leads-to property such as `\A s \in S : P(s) ~> Q(s)` now parses with the quantifier body extending across `~>` and is expanded into per-element properties, instead of failing with `undefined variable`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.6.5] - 2026-07-05
+
+### Fixed
+
+- Liveness checking now enforces `WF_vars`/`SF_vars` fairness against the actual recurring cycle instead of reporting it as a violation. Previously a fair action that was continuously enabled but never taken produced a spurious `liveness_violation`, and a fairness check applied to the whole SCC missed unfair sub-cycles nested inside a larger SCC, so a `~>` property that holds under weak fairness could still be reported as violated.
+- Quantified fairness `\A s \in S : WF_vars(A(s))` (and the strong-fairness form) is now expanded into per-element constraints using the resolved constants, rather than leaking `WF_vars` into the initial-state predicate and aborting evaluation.
+- A universally quantified leads-to property such as `\A s \in S : P(s) ~> Q(s)` now parses with the quantifier body extending across `~>` and is expanded into per-element properties, instead of failing with `undefined variable`.
+
 ## [0.6.4] - 2026-06-03
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -311,63 +311,92 @@ pub struct Spec {
     pub invariant_names: Vec<Option<Arc<str>>>,
     pub fairness: Vec<FairnessConstraint>,
     pub liveness_properties: Vec<Expr>,
+    pub quantified_temporal: Vec<(Arc<str>, Expr, Expr)>,
 }
 
 impl Spec {
     pub fn extract_fairness_and_liveness(&mut self, expr: &Expr) -> Vec<String> {
         let mut warnings = Vec::new();
-        self.extract_fairness_and_liveness_inner(expr, &mut warnings);
+        collect_temporal(
+            expr,
+            &mut self.fairness,
+            &mut self.liveness_properties,
+            &mut self.quantified_temporal,
+            &mut warnings,
+        );
         warnings
     }
+}
 
-    fn extract_fairness_and_liveness_inner(&mut self, expr: &Expr, warnings: &mut Vec<String>) {
-        match expr {
-            Expr::WeakFairness(var, action) => {
-                self.fairness.push(FairnessConstraint::Weak(
-                    Expr::Var(var.clone()),
-                    (**action).clone(),
-                ));
-            }
-            Expr::StrongFairness(var, action) => {
-                self.fairness.push(FairnessConstraint::Strong(
-                    Expr::Var(var.clone()),
-                    (**action).clone(),
-                ));
-            }
-            Expr::Eventually(inner) => {
-                if matches!(inner.as_ref(), Expr::Always(_)) {
-                    warnings.push(
-                        "temporal pattern <>[]P (stable-eventually) is not supported by the liveness checker — dropping its inner expression".to_string(),
-                    );
-                } else {
-                    self.liveness_properties.push((**inner).clone());
-                }
-            }
-            Expr::LeadsTo(p, q) => {
-                self.liveness_properties
-                    .push(Expr::LeadsTo(p.clone(), q.clone()));
-            }
-            Expr::And(l, r) | Expr::Or(l, r) => {
-                self.extract_fairness_and_liveness_inner(l, warnings);
-                self.extract_fairness_and_liveness_inner(r, warnings);
-            }
-            Expr::Always(inner) => {
-                if let Expr::Eventually(p) = inner.as_ref() {
-                    self.liveness_properties.push((**p).clone());
-                } else {
-                    self.extract_fairness_and_liveness_inner(inner, warnings);
-                }
-            }
-            Expr::BoxAction(inner, _) => {
-                self.extract_fairness_and_liveness_inner(inner, warnings);
-            }
-            Expr::DiamondAction(_, _) => {
-                warnings.push(
-                    "temporal operator <<A>>_v (diamond action) is not currently extracted into fairness or liveness — dropping".to_string(),
-                );
-            }
-            _ => {}
+pub fn expr_contains_temporal(expr: &Expr) -> bool {
+    match expr {
+        Expr::WeakFairness(_, _)
+        | Expr::StrongFairness(_, _)
+        | Expr::Eventually(_)
+        | Expr::LeadsTo(_, _)
+        | Expr::DiamondAction(_, _) => true,
+        Expr::And(l, r) | Expr::Or(l, r) => expr_contains_temporal(l) || expr_contains_temporal(r),
+        Expr::Always(inner) => expr_contains_temporal(inner),
+        Expr::Forall(_, _, body) | Expr::Exists(_, _, body) => expr_contains_temporal(body),
+        _ => false,
+    }
+}
+
+pub fn collect_temporal(
+    expr: &Expr,
+    fairness: &mut Vec<FairnessConstraint>,
+    liveness: &mut Vec<Expr>,
+    quantified: &mut Vec<(Arc<str>, Expr, Expr)>,
+    warnings: &mut Vec<String>,
+) {
+    match expr {
+        Expr::WeakFairness(var, action) => {
+            fairness.push(FairnessConstraint::Weak(
+                Expr::Var(var.clone()),
+                (**action).clone(),
+            ));
         }
+        Expr::StrongFairness(var, action) => {
+            fairness.push(FairnessConstraint::Strong(
+                Expr::Var(var.clone()),
+                (**action).clone(),
+            ));
+        }
+        Expr::Eventually(inner) => {
+            if matches!(inner.as_ref(), Expr::Always(_)) {
+                warnings.push(
+                    "temporal pattern <>[]P (stable-eventually) is not supported by the liveness checker — dropping its inner expression".to_string(),
+                );
+            } else {
+                liveness.push((**inner).clone());
+            }
+        }
+        Expr::LeadsTo(p, q) => {
+            liveness.push(Expr::LeadsTo(p.clone(), q.clone()));
+        }
+        Expr::And(l, r) | Expr::Or(l, r) => {
+            collect_temporal(l, fairness, liveness, quantified, warnings);
+            collect_temporal(r, fairness, liveness, quantified, warnings);
+        }
+        Expr::Always(inner) => {
+            if let Expr::Eventually(p) = inner.as_ref() {
+                liveness.push((**p).clone());
+            } else {
+                collect_temporal(inner, fairness, liveness, quantified, warnings);
+            }
+        }
+        Expr::BoxAction(inner, _) => {
+            collect_temporal(inner, fairness, liveness, quantified, warnings);
+        }
+        Expr::Forall(var, domain, body) if expr_contains_temporal(body) => {
+            quantified.push((var.clone(), (**domain).clone(), (**body).clone()));
+        }
+        Expr::DiamondAction(_, _) => {
+            warnings.push(
+                "temporal operator <<A>>_v (diamond action) is not currently extracted into fairness or liveness — dropping".to_string(),
+            );
+        }
+        _ => {}
     }
 }
 

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -950,19 +950,15 @@ fn check_liveness_properties(
         );
     }
 
-    for property in &spec.liveness_properties {
+    let (fairness, liveness_properties) = expand_quantified_temporal(spec, domains, defs)?;
+
+    for property in &liveness_properties {
         if time_exceeded() {
             return Ok(LivenessCheckOutcome::TimeExceeded);
         }
         for scc in &sccs {
-            if !liveness::check_fairness_in_scc(
-                &graph,
-                scc,
-                &spec.fairness,
-                &spec.vars,
-                domains,
-                defs,
-            )? {
+            if !liveness::check_fairness_in_scc(&graph, scc, &fairness, &spec.vars, domains, defs)?
+            {
                 continue;
             }
 
@@ -975,14 +971,9 @@ fn check_liveness_properties(
 
             if let Some(cycle_indices) = violating_states {
                 let cycle_scc = crate::scc::SCC::new(cycle_indices.clone(), false);
-                if !spec.fairness.is_empty()
+                if !fairness.is_empty()
                     && !liveness::check_fairness_in_scc(
-                        &graph,
-                        &cycle_scc,
-                        &spec.fairness,
-                        &spec.vars,
-                        domains,
-                        defs,
+                        &graph, &cycle_scc, &fairness, &spec.vars, domains, defs,
                     )?
                 {
                     continue;
@@ -1001,12 +992,7 @@ fn check_liveness_properties(
                         .collect(),
                     property: prop_desc,
                     fairness_info: liveness::fairness_info_for_scc(
-                        &graph,
-                        &cycle_scc,
-                        &spec.fairness,
-                        &spec.vars,
-                        domains,
-                        defs,
+                        &graph, &cycle_scc, &fairness, &spec.vars, domains, defs,
                     )?,
                 };
                 return Ok(LivenessCheckOutcome::Violation(violation));
@@ -1015,6 +1001,51 @@ fn check_liveness_properties(
     }
 
     Ok(LivenessCheckOutcome::Ok)
+}
+
+fn expand_quantified_temporal(
+    spec: &Spec,
+    domains: &Env,
+    defs: &Definitions,
+) -> Result<(Vec<crate::ast::FairnessConstraint>, Vec<Expr>), EvalError> {
+    let mut fairness = spec.fairness.clone();
+    let mut liveness_properties: Vec<Expr> = Vec::new();
+    let mut pending = spec.quantified_temporal.clone();
+
+    for property in &spec.liveness_properties {
+        match property {
+            Expr::Forall(var, domain, body) if crate::ast::expr_contains_temporal(body) => {
+                pending.push((var.clone(), (**domain).clone(), (**body).clone()));
+            }
+            _ => liveness_properties.push(property.clone()),
+        }
+    }
+
+    while let Some((var, domain, body)) = pending.pop() {
+        let mut env = domains.clone();
+        let elements = match eval(&domain, &mut env, defs)? {
+            Value::Set(set) => set,
+            other => {
+                return Err(EvalError::domain_error(format!(
+                    "quantified fairness/liveness domain must evaluate to a set, got {other:?}"
+                )));
+            }
+        };
+        for element in elements.iter() {
+            let subs = [(var.clone(), Expr::Lit(element.clone()))];
+            let concrete = crate::substitution::substitute_expr(&body, &subs);
+            let mut warnings = Vec::new();
+            crate::ast::collect_temporal(
+                &concrete,
+                &mut fairness,
+                &mut liveness_properties,
+                &mut pending,
+                &mut warnings,
+            );
+        }
+    }
+
+    Ok((fairness, liveness_properties))
 }
 
 pub fn format_trace(trace: &[State], vars: &[Arc<str>]) -> String {
@@ -1605,6 +1636,7 @@ mod tests {
             invariant_names: vec![None],
             fairness: vec![],
             liveness_properties: vec![],
+            quantified_temporal: vec![],
         };
 
         let domains = Env::new();
@@ -1641,6 +1673,7 @@ mod tests {
             invariant_names: vec![None],
             fairness: vec![],
             liveness_properties: vec![],
+            quantified_temporal: vec![],
         };
 
         let domains = Env::new();
@@ -1683,6 +1716,7 @@ mod tests {
             invariant_names: vec![None],
             fairness: vec![],
             liveness_properties: vec![],
+            quantified_temporal: vec![],
         };
 
         let domains = Env::new();
@@ -1723,6 +1757,7 @@ mod tests {
             invariant_names: vec![None],
             fairness: vec![],
             liveness_properties: vec![],
+            quantified_temporal: vec![],
         };
 
         let domains = Env::new();
@@ -1776,6 +1811,7 @@ mod tests {
             invariant_names: vec![None, None],
             fairness: vec![],
             liveness_properties: vec![],
+            quantified_temporal: vec![],
         };
 
         let domains = Env::new();
@@ -1810,6 +1846,7 @@ mod tests {
             invariant_names: vec![None],
             fairness: vec![],
             liveness_properties: vec![],
+            quantified_temporal: vec![],
         };
 
         let domains = Env::new();
@@ -1846,6 +1883,7 @@ mod tests {
             invariant_names: vec![None],
             fairness: vec![],
             liveness_properties: vec![],
+            quantified_temporal: vec![],
         };
 
         let result = check(&spec, &Env::new(), &CheckerConfig::default());
@@ -1900,6 +1938,7 @@ mod tests {
             invariant_names: vec![None],
             fairness: vec![],
             liveness_properties: vec![],
+            quantified_temporal: vec![],
         };
 
         let result1 = check(&spec1, &Env::new(), &CheckerConfig::default());
@@ -1943,6 +1982,7 @@ mod tests {
             invariant_names: vec![None],
             fairness: vec![],
             liveness_properties: vec![],
+            quantified_temporal: vec![],
         };
 
         let result2 = check(&spec2, &Env::new(), &CheckerConfig::default());

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -950,21 +950,6 @@ fn check_liveness_properties(
         );
     }
 
-    if !spec.fairness.is_empty()
-        && let Some(scc_idx) =
-            liveness::find_violating_scc(&graph, &sccs, &spec.fairness, &spec.vars, domains, defs)?
-    {
-        let violation = liveness::build_counterexample(
-            &graph,
-            &sccs[scc_idx],
-            &spec.fairness,
-            &spec.vars,
-            domains,
-            defs,
-        )?;
-        return Ok(LivenessCheckOutcome::Violation(violation));
-    }
-
     for property in &spec.liveness_properties {
         if time_exceeded() {
             return Ok(LivenessCheckOutcome::TimeExceeded);
@@ -989,6 +974,20 @@ fn check_liveness_properties(
             };
 
             if let Some(cycle_indices) = violating_states {
+                let cycle_scc = crate::scc::SCC::new(cycle_indices.clone(), false);
+                if !spec.fairness.is_empty()
+                    && !liveness::check_fairness_in_scc(
+                        &graph,
+                        &cycle_scc,
+                        &spec.fairness,
+                        &spec.vars,
+                        domains,
+                        defs,
+                    )?
+                {
+                    continue;
+                }
+
                 let prop_desc = match property {
                     Expr::LeadsTo(_, _) => format!("{:?}", property),
                     _ => format!("<>{:?}", property),
@@ -1001,7 +1000,14 @@ fn check_liveness_properties(
                         .filter_map(|&idx| graph.get_state(idx).cloned())
                         .collect(),
                     property: prop_desc,
-                    fairness_info: vec![],
+                    fairness_info: liveness::fairness_info_for_scc(
+                        &graph,
+                        &cycle_scc,
+                        &spec.fairness,
+                        &spec.vars,
+                        domains,
+                        defs,
+                    )?,
                 };
                 return Ok(LivenessCheckOutcome::Violation(violation));
             }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -962,14 +962,14 @@ fn check_liveness_properties(
                 continue;
             }
 
-            let violating_states = match property {
+            let violating_cycles = match property {
                 Expr::LeadsTo(p, q) => {
                     liveness::check_leads_to(&graph, scc, p, q, domains, defs, &spec.vars)?
                 }
                 _ => liveness::check_eventually(&graph, scc, property, domains, defs, &spec.vars)?,
             };
 
-            if let Some(cycle_indices) = violating_states {
+            for cycle_indices in violating_cycles {
                 let cycle_scc = crate::scc::SCC::new(cycle_indices.clone(), false);
                 if !fairness.is_empty()
                     && !liveness::check_fairness_in_scc(

--- a/src/config.rs
+++ b/src/config.rs
@@ -776,6 +776,7 @@ fn collect_init(expr: &Expr) -> Option<Expr> {
         | Expr::Eventually(_)
         | Expr::LeadsTo(_, _)
         | Expr::Always(_) => None,
+        Expr::Forall(_, _, body) if crate::ast::expr_contains_temporal(body) => None,
         Expr::And(l, r) => match (collect_init(l), collect_init(r)) {
             (Some(a), Some(b)) => Some(Expr::And(Box::new(a), Box::new(b))),
             (a, None) => a,
@@ -1195,6 +1196,7 @@ mod tests {
             fairness: vec![],
             assumes: vec![],
             liveness_properties: vec![],
+            quantified_temporal: vec![],
             constants: vec![],
         };
         spec.definitions.insert(
@@ -1237,6 +1239,7 @@ mod tests {
             fairness: vec![],
             assumes: vec![],
             liveness_properties: vec![],
+            quantified_temporal: vec![],
             constants: vec![],
         };
 
@@ -1288,6 +1291,7 @@ mod tests {
             fairness: vec![],
             assumes: vec![],
             liveness_properties: vec![],
+            quantified_temporal: vec![],
             constants: vec![],
         };
 
@@ -1347,6 +1351,7 @@ mod tests {
             fairness: vec![],
             assumes: vec![],
             liveness_properties: vec![],
+            quantified_temporal: vec![],
             constants: vec![],
         };
 

--- a/src/liveness.rs
+++ b/src/liveness.rs
@@ -159,9 +159,9 @@ pub fn check_eventually(
     constants: &Env,
     defs: &Definitions,
     vars: &[Arc<str>],
-) -> Result<Option<Vec<usize>>> {
+) -> Result<Vec<Vec<usize>>> {
     if scc.is_trivial {
-        return Ok(None);
+        return Ok(Vec::new());
     }
 
     let mut not_p_states: HashSet<usize> = HashSet::new();
@@ -191,16 +191,15 @@ pub fn check_eventually(
     }
 
     if not_p_states.is_empty() {
-        return Ok(None);
+        return Ok(Vec::new());
     }
 
     let sub_sccs = crate::scc::compute_sccs_in_subset(graph, &not_p_states);
-    for sub in sub_sccs {
-        if !sub.is_trivial {
-            return Ok(Some(sub.states));
-        }
-    }
-    Ok(None)
+    Ok(sub_sccs
+        .into_iter()
+        .filter(|sub| !sub.is_trivial)
+        .map(|sub| sub.states)
+        .collect())
 }
 
 pub fn check_leads_to(
@@ -211,9 +210,9 @@ pub fn check_leads_to(
     constants: &Env,
     defs: &Definitions,
     vars: &[Arc<str>],
-) -> Result<Option<Vec<usize>>> {
+) -> Result<Vec<Vec<usize>>> {
     if scc.is_trivial {
-        return Ok(None);
+        return Ok(Vec::new());
     }
 
     let mut p_and_not_q_states: Vec<usize> = Vec::new();
@@ -263,70 +262,39 @@ pub fn check_leads_to(
     }
 
     if p_and_not_q_states.is_empty() || not_q_states.is_empty() {
-        return Ok(None);
+        return Ok(Vec::new());
     }
 
     let sub_sccs = crate::scc::compute_sccs_in_subset(graph, &not_q_states);
-    let mut state_to_subscc: std::collections::HashMap<usize, usize> =
-        std::collections::HashMap::new();
-    let mut nontrivial_sccs: Vec<Vec<usize>> = Vec::new();
-    for sub in sub_sccs {
-        if !sub.is_trivial {
-            let scc_idx = nontrivial_sccs.len();
-            for &s in &sub.states {
-                state_to_subscc.insert(s, scc_idx);
-            }
-            nontrivial_sccs.push(sub.states);
-        }
-    }
+    let nontrivial_sccs: Vec<Vec<usize>> = sub_sccs
+        .into_iter()
+        .filter(|sub| !sub.is_trivial)
+        .map(|sub| sub.states)
+        .collect();
 
     if nontrivial_sccs.is_empty() {
-        return Ok(None);
+        return Ok(Vec::new());
     }
 
-    let all_targets: HashSet<usize> = state_to_subscc.keys().copied().collect();
-
+    let mut reachable: HashSet<usize> = HashSet::new();
+    let mut queue: std::collections::VecDeque<usize> = std::collections::VecDeque::new();
     for &start in &p_and_not_q_states {
-        if let Some(reached) =
-            reaches_target_state_within_subset(graph, start, &all_targets, &not_q_states)
-        {
-            let scc_idx = state_to_subscc[&reached];
-            return Ok(Some(nontrivial_sccs[scc_idx].clone()));
+        if not_q_states.contains(&start) && reachable.insert(start) {
+            queue.push_back(start);
         }
     }
-
-    Ok(None)
-}
-
-fn reaches_target_state_within_subset(
-    graph: &StateGraph,
-    start: usize,
-    targets: &HashSet<usize>,
-    allowed: &HashSet<usize>,
-) -> Option<usize> {
-    if !allowed.contains(&start) {
-        return None;
-    }
-    if targets.contains(&start) {
-        return Some(start);
-    }
-    let mut visited: HashSet<usize> = HashSet::new();
-    let mut queue: std::collections::VecDeque<usize> = std::collections::VecDeque::new();
-    visited.insert(start);
-    queue.push_back(start);
     while let Some(node) = queue.pop_front() {
         for edge in graph.successors(node) {
-            let next = edge.target;
-            if !allowed.contains(&next) || !visited.insert(next) {
-                continue;
+            if not_q_states.contains(&edge.target) && reachable.insert(edge.target) {
+                queue.push_back(edge.target);
             }
-            if targets.contains(&next) {
-                return Some(next);
-            }
-            queue.push_back(next);
         }
     }
-    None
+
+    Ok(nontrivial_sccs
+        .into_iter()
+        .filter(|states| states.iter().any(|s| reachable.contains(s)))
+        .collect())
 }
 
 pub fn fairness_info_for_scc(

--- a/src/liveness.rs
+++ b/src/liveness.rs
@@ -329,67 +329,28 @@ fn reaches_target_state_within_subset(
     None
 }
 
-pub fn find_violating_scc(
-    graph: &StateGraph,
-    sccs: &[SCC],
-    fairness: &[FairnessConstraint],
-    vars: &[Arc<str>],
-    constants: &Env,
-    defs: &Definitions,
-) -> Result<Option<usize>> {
-    for (i, scc) in sccs.iter().enumerate() {
-        if !scc.is_trivial && !check_fairness_in_scc(graph, scc, fairness, vars, constants, defs)? {
-            return Ok(Some(i));
-        }
-    }
-    Ok(None)
-}
-
-pub fn build_counterexample(
+pub fn fairness_info_for_scc(
     graph: &StateGraph,
     scc: &SCC,
     fairness: &[FairnessConstraint],
     vars: &[Arc<str>],
     constants: &Env,
     defs: &Definitions,
-) -> Result<LivenessViolation> {
-    let first_scc_state = scc.states[0];
-    let prefix = graph.reconstruct_trace(first_scc_state);
-
-    let cycle: Vec<State> = scc
-        .states
-        .iter()
-        .filter_map(|&idx| graph.get_state(idx).cloned())
-        .collect();
-
+) -> Result<Vec<(String, bool)>> {
     let mut fairness_info = Vec::new();
     for constraint in fairness {
-        match constraint {
-            FairnessConstraint::Weak(_, action) => {
-                let enabled = scc_any_enabled(graph, scc, action, vars, constants, defs)?;
-                let taken = scc_has_action_edge(graph, scc, action, vars, constants, defs)?;
-                fairness_info.push((
-                    format!("WF(action): enabled={}, taken={}", enabled, taken),
-                    taken,
-                ));
-            }
-            FairnessConstraint::Strong(_, action) => {
-                let enabled = scc_any_enabled(graph, scc, action, vars, constants, defs)?;
-                let taken = scc_has_action_edge(graph, scc, action, vars, constants, defs)?;
-                fairness_info.push((
-                    format!("SF(action): enabled={}, taken={}", enabled, taken),
-                    taken,
-                ));
-            }
-        }
+        let (label, action) = match constraint {
+            FairnessConstraint::Weak(_, action) => ("WF", action),
+            FairnessConstraint::Strong(_, action) => ("SF", action),
+        };
+        let enabled = scc_any_enabled(graph, scc, action, vars, constants, defs)?;
+        let taken = scc_has_action_edge(graph, scc, action, vars, constants, defs)?;
+        fairness_info.push((
+            format!("{}(action): enabled={}, taken={}", label, enabled, taken),
+            taken,
+        ));
     }
-
-    Ok(LivenessViolation {
-        prefix,
-        cycle,
-        property: "fairness violation".into(),
-        fairness_info,
-    })
+    Ok(fairness_info)
 }
 
 #[cfg(test)]

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -247,6 +247,7 @@ mod tests {
             invariant_names: vec![],
             fairness: vec![],
             liveness_properties: vec![],
+            quantified_temporal: vec![],
         };
 
         let mut registry = ModuleRegistry::new();
@@ -278,6 +279,7 @@ mod tests {
             invariant_names: vec![],
             fairness: vec![],
             liveness_properties: vec![],
+            quantified_temporal: vec![],
         };
 
         let (resolved, parameterized) = resolve_instances(&spec, &registry).unwrap();

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -272,6 +272,11 @@ impl Parser {
                     let right = self.parse_quantifier_or()?;
                     left = Expr::Equiv(Box::new(left), Box::new(right));
                 }
+                Token::LeadsTo => {
+                    self.advance();
+                    let right = self.parse_quantifier_or()?;
+                    left = Expr::LeadsTo(Box::new(left), Box::new(right));
+                }
                 _ => break,
             }
         }

--- a/src/parser/lexing.rs
+++ b/src/parser/lexing.rs
@@ -21,6 +21,7 @@ pub struct Parser {
     pub(super) instances: Vec<InstanceDecl>,
     pub(super) fairness: Vec<FairnessConstraint>,
     pub(super) liveness_properties: Vec<Expr>,
+    pub(super) quantified_temporal: Vec<(Arc<str>, Expr, Expr)>,
     pub(super) warnings: Vec<Spanned<String>>,
     pub(super) fresh_counter: u64,
 }
@@ -43,6 +44,7 @@ impl Parser {
             instances: Vec::new(),
             fairness: Vec::new(),
             liveness_properties: Vec::new(),
+            quantified_temporal: Vec::new(),
             warnings: Vec::new(),
             fresh_counter: 0,
         })

--- a/src/parser/spec.rs
+++ b/src/parser/spec.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::ast::{Expr, FairnessConstraint, Spec};
+use crate::ast::{Expr, Spec};
 use crate::lexer::Token;
 
 use super::error::{ParseError, Result};
@@ -247,58 +247,24 @@ impl Parser {
             invariant_names,
             fairness: self.fairness.clone(),
             liveness_properties: self.liveness_properties.clone(),
+            quantified_temporal: self.quantified_temporal.clone(),
         })
     }
 
     fn extract_fairness_and_liveness(&mut self, expr: &Expr) {
-        match expr {
-            Expr::WeakFairness(var, action) => {
-                self.fairness.push(FairnessConstraint::Weak(
-                    Expr::Var(var.clone()),
-                    (**action).clone(),
-                ));
-            }
-            Expr::StrongFairness(var, action) => {
-                self.fairness.push(FairnessConstraint::Strong(
-                    Expr::Var(var.clone()),
-                    (**action).clone(),
-                ));
-            }
-            Expr::Eventually(inner) => {
-                if matches!(inner.as_ref(), Expr::Always(_)) {
-                    self.warnings.push(crate::span::Spanned::new(
-                        "temporal pattern <>[]P (stable-eventually) is not supported by the liveness checker — dropping its inner expression".to_string(),
-                        crate::span::Span::default(),
-                    ));
-                } else {
-                    self.liveness_properties.push((**inner).clone());
-                }
-            }
-            Expr::LeadsTo(p, q) => {
-                self.liveness_properties
-                    .push(Expr::LeadsTo(p.clone(), q.clone()));
-            }
-            Expr::And(l, r) | Expr::Or(l, r) => {
-                self.extract_fairness_and_liveness(l);
-                self.extract_fairness_and_liveness(r);
-            }
-            Expr::Always(inner) => {
-                if let Expr::Eventually(p) = inner.as_ref() {
-                    self.liveness_properties.push((**p).clone());
-                } else {
-                    self.extract_fairness_and_liveness(inner);
-                }
-            }
-            Expr::BoxAction(inner, _) => {
-                self.extract_fairness_and_liveness(inner);
-            }
-            Expr::DiamondAction(_, _) => {
-                self.warnings.push(crate::span::Spanned::new(
-                    "temporal operator <<A>>_v (diamond action) is not currently extracted into fairness or liveness — dropping".to_string(),
-                    crate::span::Span::default(),
-                ));
-            }
-            _ => {}
+        let mut warnings = Vec::new();
+        crate::ast::collect_temporal(
+            expr,
+            &mut self.fairness,
+            &mut self.liveness_properties,
+            &mut self.quantified_temporal,
+            &mut warnings,
+        );
+        for warning in warnings {
+            self.warnings.push(crate::span::Spanned::new(
+                warning,
+                crate::span::Span::default(),
+            ));
         }
     }
 

--- a/tests/mcp_integration.rs
+++ b/tests/mcp_integration.rs
@@ -742,6 +742,58 @@ fn check_spec_does_not_report_leads_to_violation_when_subscc_unreachable() {
 }
 
 #[test]
+fn check_spec_enforces_wf_vars_for_unfair_cycle_inside_larger_scc() {
+    let dir = std::env::temp_dir().join("tla_mcp_wf_embedded_cycle");
+    std::fs::create_dir_all(&dir).unwrap();
+    let spec_path = dir.join("Hold.tla");
+    let cfg_path = dir.join("Hold.cfg");
+    std::fs::write(
+        &spec_path,
+        "---- MODULE Hold ----\n\
+         EXTENDS Naturals\n\
+         VARIABLES x, y\n\
+         vars == << x, y >>\n\
+         Init == x = \"free\" /\\ y = 0\n\
+         Hold   == x = \"free\" /\\ x' = \"held\" /\\ y' = y\n\
+         Tick   == x = \"held\" /\\ y' = (y + 1) % 2 /\\ x' = \"held\"\n\
+         Expire == x = \"held\" /\\ x' = \"free\" /\\ y' = 0\n\
+         Next == Hold \\/ Tick \\/ Expire\n\
+         Spec == Init /\\ [][Next]_vars /\\ WF_vars(Expire)\n\
+         Live == (x = \"held\") ~> (x = \"free\")\n\
+         ====\n",
+    )
+    .unwrap();
+    std::fs::write(&cfg_path, "SPECIFICATION Spec\nPROPERTY Live\n").unwrap();
+
+    let input = CheckSpecInput {
+        spec_path: spec_path.to_string_lossy().into_owned(),
+        max_states: 100,
+        max_depth: 50,
+        max_seconds: 30,
+        constants: BTreeMap::new(),
+        symmetry: None,
+        allow_deadlock: None,
+        check_liveness: Some(true),
+        count_satisfying: vec![],
+        continue_on_violation: false,
+        state_constraint: None,
+        config_path: None,
+    };
+    let out = runner::check_spec(&input);
+    let _ = std::fs::remove_file(&spec_path);
+    let _ = std::fs::remove_file(&cfg_path);
+    let _ = std::fs::remove_dir(&dir);
+
+    match out.outcome {
+        CheckOutcome::Ok { .. } => {}
+        other => panic!(
+            "WF_vars(Expire) forbids the held-forever cycle, so Live must hold; got {:?}",
+            other
+        ),
+    }
+}
+
+#[test]
 fn validate_spec_surfaces_resolved_constants() {
     let input = ValidateSpecInput {
         spec_path: pass_spec("base_counter"),

--- a/tests/mcp_integration.rs
+++ b/tests/mcp_integration.rs
@@ -794,6 +794,84 @@ fn check_spec_enforces_wf_vars_for_unfair_cycle_inside_larger_scc() {
 }
 
 #[test]
+fn check_spec_expands_quantified_fairness_and_leads_to_property() {
+    let dir = std::env::temp_dir().join("tla_mcp_quantified_temporal");
+    std::fs::create_dir_all(&dir).unwrap();
+    let spec_path = dir.join("Seats.tla");
+    let cfg_path = dir.join("Seats.cfg");
+    let module = "---- MODULE Seats ----\n\
+         EXTENDS Naturals\n\
+         CONSTANT Seats\n\
+         VARIABLES status, tick\n\
+         vars == << status, tick >>\n\
+         Init == status = [s \\in Seats |-> \"free\"] /\\ tick = 0\n\
+         Hold(s)   == status[s] = \"free\" /\\ status' = [status EXCEPT ![s] = \"held\"] /\\ tick' = tick\n\
+         Tick      == tick' = (tick + 1) % 2 /\\ status' = status\n\
+         Expire(s) == status[s] = \"held\" /\\ status' = [status EXCEPT ![s] = \"free\"] /\\ tick' = 0\n\
+         Next == Tick \\/ (\\E s \\in Seats : Hold(s) \\/ Expire(s))\n\
+         FAIR_SPEC\n\
+         Released(s) == status[s] = \"free\"\n\
+         SeatReleases == \\A s \\in Seats : (status[s] = \"held\") ~> Released(s)\n\
+         ====\n";
+
+    let run = |fair: bool| {
+        let spec_line = if fair {
+            "Spec == Init /\\ [][Next]_vars /\\ (\\A s \\in Seats : WF_vars(Expire(s)))"
+        } else {
+            "Spec == Init /\\ [][Next]_vars"
+        };
+        std::fs::write(&spec_path, module.replace("FAIR_SPEC", spec_line)).unwrap();
+        std::fs::write(
+            &cfg_path,
+            "CONSTANT Seats = {s1, s2}\nSPECIFICATION Spec\nPROPERTY SeatReleases\n",
+        )
+        .unwrap();
+        let input = CheckSpecInput {
+            spec_path: spec_path.to_string_lossy().into_owned(),
+            max_states: 200,
+            max_depth: 50,
+            max_seconds: 30,
+            constants: BTreeMap::new(),
+            symmetry: None,
+            allow_deadlock: None,
+            check_liveness: Some(true),
+            count_satisfying: vec![],
+            continue_on_violation: false,
+            state_constraint: None,
+            config_path: None,
+        };
+        runner::check_spec(&input).outcome
+    };
+
+    let with_fairness = run(true);
+    let without_fairness = run(false);
+    let _ = std::fs::remove_file(&spec_path);
+    let _ = std::fs::remove_file(&cfg_path);
+    let _ = std::fs::remove_dir(&dir);
+
+    match with_fairness {
+        CheckOutcome::Ok { .. } => {}
+        other => panic!(
+            "quantified WF_vars(Expire(s)) must make the per-seat leads-to hold; got {:?}",
+            other
+        ),
+    }
+    match without_fairness {
+        CheckOutcome::LivenessViolation { property, .. } => {
+            assert!(
+                property.contains("LeadsTo"),
+                "expected the quantified property expanded to a per-seat leads-to, got {}",
+                property
+            );
+        }
+        other => panic!(
+            "without fairness a seat can stay held forever, so SeatReleases must be violated; got {:?}",
+            other
+        ),
+    }
+}
+
+#[test]
 fn validate_spec_surfaces_resolved_constants() {
     let input = ValidateSpecInput {
         spec_path: pass_spec("base_counter"),

--- a/tests/mcp_integration.rs
+++ b/tests/mcp_integration.rs
@@ -872,6 +872,62 @@ fn check_spec_expands_quantified_fairness_and_leads_to_property() {
 }
 
 #[test]
+fn check_spec_reports_fair_sub_cycle_when_an_unfair_sub_cycle_shares_the_scc() {
+    let dir = std::env::temp_dir().join("tla_mcp_two_violating_sub_cycles");
+    std::fs::create_dir_all(&dir).unwrap();
+    let spec_path = dir.join("TwoCycle.tla");
+    let cfg_path = dir.join("TwoCycle.cfg");
+    std::fs::write(
+        &spec_path,
+        "---- MODULE TwoCycle ----\n\
+         VARIABLES loc\n\
+         vars == << loc >>\n\
+         Init == loc = \"hub\"\n\
+         EnterA == loc = \"hub\" /\\ loc' = \"a1\"\n\
+         EnterB == loc = \"hub\" /\\ loc' = \"b1\"\n\
+         StepA  == (loc = \"a1\" /\\ loc' = \"a2\") \\/ (loc = \"a2\" /\\ loc' = \"a1\")\n\
+         StepB  == (loc = \"b1\" /\\ loc' = \"b2\") \\/ (loc = \"b2\" /\\ loc' = \"b1\")\n\
+         Escape == (loc = \"b1\" \\/ loc = \"b2\") /\\ loc' = \"hub\"\n\
+         LeaveA == loc = \"a2\" /\\ loc' = \"hub\"\n\
+         Next == EnterA \\/ EnterB \\/ StepA \\/ StepB \\/ Escape \\/ LeaveA\n\
+         Spec == Init /\\ [][Next]_vars /\\ WF_vars(Escape)\n\
+         P == (loc = \"a1\") \\/ (loc = \"b1\")\n\
+         Q == loc = \"hub\"\n\
+         Live == P ~> Q\n\
+         ====\n",
+    )
+    .unwrap();
+    std::fs::write(&cfg_path, "SPECIFICATION Spec\nPROPERTY Live\n").unwrap();
+
+    let input = CheckSpecInput {
+        spec_path: spec_path.to_string_lossy().into_owned(),
+        max_states: 100,
+        max_depth: 50,
+        max_seconds: 30,
+        constants: BTreeMap::new(),
+        symmetry: None,
+        allow_deadlock: None,
+        check_liveness: Some(true),
+        count_satisfying: vec![],
+        continue_on_violation: false,
+        state_constraint: None,
+        config_path: None,
+    };
+    let out = runner::check_spec(&input);
+    let _ = std::fs::remove_file(&spec_path);
+    let _ = std::fs::remove_file(&cfg_path);
+    let _ = std::fs::remove_dir(&dir);
+
+    match out.outcome {
+        CheckOutcome::LivenessViolation { .. } => {}
+        other => panic!(
+            "the a1<->a2 cycle is a fair behavior where P holds but Q is never reached, so Live must be violated even though the unfair b cycle shares the SCC; got {:?}",
+            other
+        ),
+    }
+}
+
+#[test]
 fn validate_spec_surfaces_resolved_constants() {
     let input = ValidateSpecInput {
         spec_path: pass_spec("base_counter"),


### PR DESCRIPTION
## Summary

Fixes three related defects in liveness checking where `WF_vars`/`SF_vars` fairness was effectively not enforced, so `~>` properties that hold under weak fairness were reported as violations. Reported via the MCP `check_spec` tool.

## The bugs

**1. Unfair cycles reported as violations.** A pre-pass returned any SCC where a fair action was continuously enabled but never taken as a `liveness_violation` — before even looking at the property. Fairness *restricts* the behaviors of `Spec`; an unfair cycle is simply not a behavior, so it can never be a counterexample. Removed the pre-pass.

**2. Fairness checked on the wrong SCC.** The property loop filtered fairness on the whole outer SCC, but the actual counterexample is a sub-cycle within it. When held-states and released-states share one SCC (e.g. a seat can be re-held after freeing), an unfair held-only sub-cycle still got reported. Fairness is now checked against the actual violating cycle (sub-SCC).

**3. Quantified fairness and quantified leads-to were unsupported.**
- `\A s \in S : WF_vars(A(s))` leaked `WF_vars` into the initial-state predicate and aborted evaluation. The extractor now captures a temporal quantifier and expands it into per-element constraints using the resolved constants at check time.
- `\A s \in S : P(s) ~> Q(s)` failed with `undefined variable` because `parse_quantifier_body` didn't extend the quantifier across `~>`. Added `LeadsTo` to the quantifier-body parser and expand the property per element.

## Verification

- New regression tests: fairness enforced on an unfair sub-cycle inside a larger SCC; quantified fairness + quantified leads-to (asserts the fair case holds and the unfair case is violated).
- Genuine starvation violations still reported (verified with a reader/writer spec where the writer is only intermittently enabled).
- Full suite (289 tests) passes, 0 clippy warnings.

Version bumped to 0.6.5; CHANGELOG updated.
