### PR TITLE
add headless playwright test for explorable demo explorer JS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,46 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - run: cargo rustc --lib --release --target wasm32-unknown-unknown --features wasm --crate-type cdylib
+
+  explorer-e2e:
+    name: Explorer E2E (embed-wasm)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build wasm engine
+        run: |
+          cargo rustc --lib --release --target wasm32-unknown-unknown --features wasm --crate-type cdylib
+          WB_VERSION=$(cargo tree --features wasm | grep -oE 'wasm-bindgen v[0-9.]+' | head -1 | sed -E 's/^wasm-bindgen v//')
+          if [ -z "$WB_VERSION" ]; then echo "could not determine resolved wasm-bindgen version"; exit 1; fi
+          cargo install wasm-bindgen-cli --version "$WB_VERSION" --locked
+          wasm-bindgen --target web --out-dir pkg target/wasm32-unknown-unknown/release/tla_checker.wasm
+
+      - name: Build tla with embedded wasm engine
+        run: cargo build --release --bin tla --features embed-wasm
+
+      - name: Export explorable demo fixture
+        run: |
+          mkdir -p tests/explorer/fixtures
+          ./target/release/tla --present test_cases/demo/ExploreDemo.demo.json \
+            --export-html tests/explorer/fixtures/explore.html --explorable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install explorer test deps
+        working-directory: tests/explorer
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        working-directory: tests/explorer
+        run: npx playwright install --with-deps chromium
+
+      - name: Run explorer smoke test
+        working-directory: tests/explorer
+        run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.6] - 2026-07-06
+
+### Added
+
+- Headless browser smoke test for the exported explorable demo's explorer JavaScript. A Playwright test drives the real embedded wasm engine in Chromium and asserts the runtime behavior the Rust render test can only check as string scaffolding: one action row per enabled-action group, a solo action's number-key hotkey firing the transition and advancing the state, `Backspace` stepping back, and a multi-variant group's hotkey expanding its variant sublist. Runs in a new `explorer-e2e` CI job that builds `tla` with the embedded wasm engine, exports a fixture demo, and runs the test against it.
+
 ## [0.6.5] - 2026-07-05
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"

--- a/test_cases/demo/ExploreDemo.demo.json
+++ b/test_cases/demo/ExploreDemo.demo.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "1",
+  "title": "Explorer smoke demo",
+  "variants": {
+    "base": { "spec": "ExploreDemo.tla", "constants": {} }
+  },
+  "beats": [
+    {
+      "title": "Tick then fan out",
+      "variant": "base",
+      "scenario": ["action: Tick", "step: x' = 2"],
+      "note": "a solo Tick then a multi-variant Fan step",
+      "expect": ["final: x = 2", "final: y = 1"]
+    }
+  ]
+}

--- a/test_cases/demo/ExploreDemo.tla
+++ b/test_cases/demo/ExploreDemo.tla
@@ -1,0 +1,12 @@
+---- MODULE ExploreDemo ----
+EXTENDS Integers
+VARIABLES x, y
+
+Init == x = 0 /\ y = 0
+
+Fan == \E d \in {1, 2, 3} : x' = d /\ y' = y
+
+Tick == y' = y + 1 /\ x' = x
+
+Next == Fan \/ Tick
+====

--- a/tests/explorer/.gitignore
+++ b/tests/explorer/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+fixtures/
+test-results/
+playwright-report/

--- a/tests/explorer/README.md
+++ b/tests/explorer/README.md
@@ -1,0 +1,38 @@
+# Explorer end-to-end test
+
+Headless smoke test for the JavaScript that ships inside an exported
+explorable demo (`--present … --export-html … --explorable`). It drives the
+real embedded wasm engine in Chromium and asserts the runtime behavior that
+the Rust render tests can only check as string scaffolding:
+
+- one action row per enabled-action group
+- a solo action's number-key hotkey fires the transition and advances the state
+- `Backspace` steps back to the previous state
+- a multi-variant group's hotkey expands its variant sublist
+
+## Run locally
+
+The test reads a pre-generated fixture from `fixtures/explore.html`, which
+requires a `tla` binary built with the `embed-wasm` feature (so the wasm engine
+is embedded in the HTML):
+
+```bash
+# from the repo root — build the wasm engine into pkg/ then a tla with it embedded
+cargo rustc --lib --release --target wasm32-unknown-unknown --features wasm --crate-type cdylib
+wasm-bindgen --target web --out-dir pkg target/wasm32-unknown-unknown/release/tla_checker.wasm
+cargo build --release --bin tla --features embed-wasm
+
+# export the fixture the test expects
+mkdir -p tests/explorer/fixtures
+./target/release/tla --present test_cases/demo/ExploreDemo.demo.json \
+  --export-html tests/explorer/fixtures/explore.html --explorable
+
+# run the test
+cd tests/explorer
+npm ci
+npx playwright install chromium
+npm test
+```
+
+`fixtures/` and `node_modules/` are gitignored. CI regenerates the fixture on
+every run, so the test always exercises the current template.

--- a/tests/explorer/explorer.spec.ts
+++ b/tests/explorer/explorer.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect, Page } from "@playwright/test";
+
+async function openExplorer(page: Page) {
+  await page.goto("/explore.html");
+  await page.locator("#tab-explore").click();
+  await expect(page.locator("#explore-view")).not.toHaveClass(/hidden/);
+  await expect(page.locator('[id^="arow-"]').first()).toBeVisible();
+}
+
+const crumbs = (page: Page) => page.locator("#explore-view .crumbs");
+const yValue = (page: Page) =>
+  page
+    .locator("#explore-view table.state tr", {
+      has: page.locator("td.vn", { hasText: /^y$/ }),
+    })
+    .locator("td.vv");
+const fanVariants = (page: Page) =>
+  page.locator("#explore-view .agroup", { has: page.locator("#arow-0") }).locator(".avariants");
+
+test.describe("exported explorable demo explorer", () => {
+  test.beforeEach(async ({ page }) => {
+    await openExplorer(page);
+  });
+
+  test("renders one action row per enabled-action group", async ({ page }) => {
+    await expect(page.locator('[id^="arow-"]')).toHaveCount(2);
+    await expect(page.locator('#arow-0[data-group="Fan"]')).toBeVisible();
+    await expect(page.locator("#arow-1[data-i]")).toBeVisible();
+  });
+
+  test("solo hotkey fires the transition and advances the state", async ({ page }) => {
+    await expect(crumbs(page)).toHaveText("Init");
+    await expect(yValue(page)).toHaveText("0");
+
+    await page.keyboard.press("2");
+
+    await expect(crumbs(page)).toContainText("Tick");
+    await expect(yValue(page)).toHaveText("1");
+  });
+
+  test("Backspace steps back to the previous state", async ({ page }) => {
+    await page.keyboard.press("2");
+    await expect(crumbs(page)).toContainText("Tick");
+
+    await page.keyboard.press("Backspace");
+
+    await expect(crumbs(page)).toHaveText("Init");
+    await expect(yValue(page)).toHaveText("0");
+  });
+
+  test("group hotkey expands the variant sublist", async ({ page }) => {
+    await expect(fanVariants(page)).toHaveClass(/hidden/);
+
+    await page.keyboard.press("1");
+
+    await expect(fanVariants(page)).not.toHaveClass(/hidden/);
+  });
+});

--- a/tests/explorer/package-lock.json
+++ b/tests/explorer/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "tla-explorer-e2e",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tla-explorer-e2e",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/explorer/package.json
+++ b/tests/explorer/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "tla-explorer-e2e",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Headless smoke test for the exported explorable demo explorer JS",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0"
+  }
+}

--- a/tests/explorer/playwright.config.ts
+++ b/tests/explorer/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = Number(process.env.EXPLORER_PORT ?? 8791);
+const FIXTURES = process.env.EXPLORER_FIXTURES_DIR ?? "fixtures";
+
+export default defineConfig({
+  testDir: ".",
+  timeout: 30_000,
+  forbidOnly: !!process.env.CI,
+  reporter: process.env.CI ? "list" : "line",
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    ...devices["Desktop Chrome"],
+  },
+  webServer: {
+    command: `python3 -m http.server ${PORT} --directory ${FIXTURES} --bind 127.0.0.1`,
+    port: PORT,
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
Closes #55.

## Summary

Adds a headless browser smoke test for the JavaScript that ships inside an exported explorable demo (`--present … --export-html … --explorable`). Until now the explorer's runtime behavior — action grouping, number-key hotkey dispatch, the multi-variant expand toggle, `Backspace` back — was only guarded by a Rust render test that checks `include_str!` string substitution, never the runtime. A regression in that JS would ship silently (the gap #55 describes).

A Playwright test drives the **real embedded wasm engine** in Chromium against a freshly-exported demo and asserts:

- one action row per enabled-action group
- a solo action's number-key hotkey fires the transition and advances the state
- `Backspace` steps back to the previous state
- a multi-variant group's hotkey expands its variant sublist

## Changes

- `test_cases/demo/ExploreDemo.tla` + `ExploreDemo.demo.json` — a minimal demo with both a multi-variant action group (`Fan == \E d \in {1,2,3}: x'=d`) and a state-changing solo action (`Tick`), so one page exercises all four behaviors.
- `tests/explorer/` — `@playwright/test` suite: `playwright.config.ts` (serves `fixtures/` via `python3 -m http.server`), `explorer.spec.ts`, `package.json`/`package-lock.json`, `.gitignore`, `README.md`. `fixtures/` and `node_modules/` are gitignored.
- `.github/workflows/ci.yml` — new `explorer-e2e` job: builds the wasm engine into `pkg/`, builds `tla` with `--features embed-wasm`, exports the fixture, then `npm ci` + `npx playwright install --with-deps chromium` + `npm test`.
- Version bumped to 0.6.6; CHANGELOG updated.

## Verification

- Locally (`npx playwright test` and `CI=1 npm ci && npx playwright test`): 4/4 pass against a freshly-generated embed-wasm fixture.
- `cargo test demo` passes with the new fixtures; `ci.yml` validated as well-formed YAML.

Note: the `explorer-e2e` job compiles `wasm-bindgen-cli` and installs Chromium, so it is heavier than the other CI jobs (a few minutes before the rust-cache warms).