### PR TITLE
route cfg temporal PROPERTY to liveness checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - A temporal `PROPERTY` referenced from a cfg file (e.g. `Eventually1 == <>(x = 1)`) is now routed to the liveness checker instead of being evaluated as a state predicate. Previously the cfg loader pushed the raw property body into the liveness property list without unwrapping its temporal operator, so the checker handed a live `<>`/`~>`/`[]<>` node to the evaluator and aborted with "temporal operator `<>` (eventually) reached eval" — making liveness checking unreachable through a cfg `PROPERTY` (and the `check_spec` MCP tool) even with liveness enabled. cfg properties now pass through the same temporal normalization as the `SPECIFICATION` and parser paths, and quantified temporal properties (`\A s \in S : P(s) ~> Q(s)`) alone are enough to trigger the liveness pass.
+- A cfg `PROPERTY` whose definition name ends in `Spec` (e.g. `EventuallySpec == <>(x = 1)`) is no longer extracted into the liveness list twice. The parser already pre-extracts fairness/liveness from any `*Spec`-named definition, and the cfg path now skips re-extraction for those names, matching the `SPECIFICATION` path.
+- An existential temporal property `\E i \in S : <>Q(i)` is now checked instead of being silently dropped. It is normalized to the equivalent `<>(\E i \in S : Q(i))` liveness property. Existential temporal shapes that do not reduce this way (e.g. `\E i \in S : P(i) ~> Q(i)`) now emit a warning rather than vanishing without notice, and cfg-application warnings are surfaced through the loaders (both the CLI/library `prepare_from_path` and the MCP runner) instead of being discarded.
 
 ## [0.6.6] - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.7] - 2026-07-13
+
+### Fixed
+
+- A temporal `PROPERTY` referenced from a cfg file (e.g. `Eventually1 == <>(x = 1)`) is now routed to the liveness checker instead of being evaluated as a state predicate. Previously the cfg loader pushed the raw property body into the liveness property list without unwrapping its temporal operator, so the checker handed a live `<>`/`~>`/`[]<>` node to the evaluator and aborted with "temporal operator `<>` (eventually) reached eval" — making liveness checking unreachable through a cfg `PROPERTY` (and the `check_spec` MCP tool) even with liveness enabled. cfg properties now pass through the same temporal normalization as the `SPECIFICATION` and parser paths, and quantified temporal properties (`\A s \in S : P(s) ~> Q(s)`) alone are enough to trigger the liveness pass.
+
 ## [0.6.6] - 2026-07-06
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"

--- a/SYNTAX_STATUS.md
+++ b/SYNTAX_STATUS.md
@@ -232,6 +232,18 @@ These operators are parsed into the AST but error at evaluation time. They can a
 | `<<A>>_v` | | Diamond action | Parsed, errors if evaluated directly |
 | `\cdot` | | Action composition | Parsed, errors if evaluated directly |
 
+### Quantified Temporal Properties
+
+Temporal properties may be quantified over a constant set (requires `--check-liveness`; declared via a cfg `PROPERTY` or the `SPECIFICATION`).
+
+| Form | Handling |
+|------|----------|
+| `\A x \in S : <>P(x)` / `\A x \in S : P(x) ~> Q(x)` | Expanded to one liveness property per element of `S`; all must hold. |
+| `\E x \in S : <>Q(x)` | Normalized to `<>(\E x \in S : Q(x))` and checked as a single liveness property. |
+| `\E x \in S : P(x) ~> Q(x)` (existential, non-`<>` body) | Not supported — emits a warning and is dropped. |
+
+`S` must evaluate to a constant set. A property whose definition name ends in `Spec` is extracted by the parser, so it is not re-extracted when also named in a cfg `PROPERTY`.
+
 ---
 
 ## Not Implemented ✗

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -391,6 +391,16 @@ pub fn collect_temporal(
         Expr::Forall(var, domain, body) if expr_contains_temporal(body) => {
             quantified.push((var.clone(), (**domain).clone(), (**body).clone()));
         }
+        Expr::Exists(var, domain, body) if expr_contains_temporal(body) => {
+            match body.as_ref() {
+                Expr::Eventually(inner) if !matches!(inner.as_ref(), Expr::Always(_)) => {
+                    liveness.push(Expr::Exists(var.clone(), domain.clone(), inner.clone()));
+                }
+                _ => warnings.push(
+                    "existential temporal property \\E x \\in S : P is only supported when P is <>Q — dropping".to_string(),
+                ),
+            }
+        }
         Expr::DiamondAction(_, _) => {
             warnings.push(
                 "temporal operator <<A>>_v (diamond action) is not currently extracted into fairness or liveness — dropping".to_string(),

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -445,7 +445,9 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
     let mut queue: VecDeque<(usize, usize)> = VecDeque::new();
 
     let needs_liveness_check = config.check_liveness
-        && (!spec.fairness.is_empty() || !spec.liveness_properties.is_empty());
+        && (!spec.fairness.is_empty()
+            || !spec.liveness_properties.is_empty()
+            || !spec.quantified_temporal.is_empty());
 
     #[cfg(not(target_arch = "wasm32"))]
     let collect_edges =

--- a/src/config.rs
+++ b/src/config.rs
@@ -684,7 +684,12 @@ pub fn apply_config(
         for prop_name in &cfg.properties {
             match spec.definitions.get(prop_name.as_ref()) {
                 Some((params, expr)) if params.is_empty() => {
-                    spec.liveness_properties.push(expr.clone());
+                    let expr = expr.clone();
+                    if crate::ast::expr_contains_temporal(&expr) {
+                        warnings.extend(spec.extract_fairness_and_liveness(&expr));
+                    } else {
+                        spec.liveness_properties.push(expr);
+                    }
                 }
                 Some(_) => {
                     return Err(format!(
@@ -1223,6 +1228,106 @@ mod tests {
         .unwrap();
 
         assert_eq!(checker_config.symmetric_constants, vec![Arc::from("RM")]);
+    }
+
+    #[test]
+    fn apply_config_temporal_property_unwrapped_into_liveness() {
+        let mut spec = Spec {
+            vars: vec![Arc::from("x")],
+            init: None,
+            next: None,
+            invariants: vec![],
+            invariant_names: vec![],
+            definitions: std::collections::BTreeMap::new(),
+            instances: vec![],
+            extends: vec![],
+            fairness: vec![],
+            assumes: vec![],
+            liveness_properties: vec![],
+            quantified_temporal: vec![],
+            constants: vec![],
+        };
+
+        let inner = Expr::Eq(
+            Box::new(Expr::Var(Arc::from("x"))),
+            Box::new(Expr::Lit(Value::Int(1))),
+        );
+        spec.definitions.insert(
+            Arc::from("Eventually1"),
+            (vec![], Expr::Eventually(Box::new(inner.clone()))),
+        );
+
+        let cfg = parse_cfg("PROPERTY Eventually1").unwrap();
+        let mut domains = Env::new();
+        let mut checker_config = CheckerConfig::default();
+
+        apply_config(
+            &cfg,
+            &mut spec,
+            &mut domains,
+            &mut checker_config,
+            &[],
+            &[],
+            false,
+        )
+        .unwrap();
+
+        assert!(checker_config.check_liveness);
+        assert_eq!(spec.liveness_properties.len(), 1);
+        assert_eq!(
+            format!("{:?}", spec.liveness_properties[0]),
+            format!("{inner:?}")
+        );
+    }
+
+    #[test]
+    fn apply_config_leads_to_property_preserved() {
+        let mut spec = Spec {
+            vars: vec![Arc::from("x")],
+            init: None,
+            next: None,
+            invariants: vec![],
+            invariant_names: vec![],
+            definitions: std::collections::BTreeMap::new(),
+            instances: vec![],
+            extends: vec![],
+            fairness: vec![],
+            assumes: vec![],
+            liveness_properties: vec![],
+            quantified_temporal: vec![],
+            constants: vec![],
+        };
+
+        let p = Box::new(Expr::Eq(
+            Box::new(Expr::Var(Arc::from("x"))),
+            Box::new(Expr::Lit(Value::Int(0))),
+        ));
+        let q = Box::new(Expr::Eq(
+            Box::new(Expr::Var(Arc::from("x"))),
+            Box::new(Expr::Lit(Value::Int(1))),
+        ));
+        spec.definitions.insert(
+            Arc::from("Leads"),
+            (vec![], Expr::LeadsTo(p.clone(), q.clone())),
+        );
+
+        let cfg = parse_cfg("PROPERTY Leads").unwrap();
+        let mut domains = Env::new();
+        let mut checker_config = CheckerConfig::default();
+
+        apply_config(
+            &cfg,
+            &mut spec,
+            &mut domains,
+            &mut checker_config,
+            &[],
+            &[],
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(spec.liveness_properties.len(), 1);
+        assert!(matches!(spec.liveness_properties[0], Expr::LeadsTo(_, _)));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -686,7 +686,9 @@ pub fn apply_config(
                 Some((params, expr)) if params.is_empty() => {
                     let expr = expr.clone();
                     if crate::ast::expr_contains_temporal(&expr) {
-                        warnings.extend(spec.extract_fairness_and_liveness(&expr));
+                        if !parser_pre_extracts_temporal(prop_name) {
+                            warnings.extend(spec.extract_fairness_and_liveness(&expr));
+                        }
                     } else {
                         spec.liveness_properties.push(expr);
                     }
@@ -791,6 +793,10 @@ fn collect_init(expr: &Expr) -> Option<Expr> {
     }
 }
 
+fn parser_pre_extracts_temporal(name: &str) -> bool {
+    name == "Spec" || name.ends_with("Spec")
+}
+
 fn resolve_specification(spec_name: &Arc<str>, spec: &mut Spec) -> Result<Vec<String>, String> {
     let expr_clone = match spec.definitions.get(spec_name.as_ref()) {
         Some((params, expr)) if params.is_empty() => expr.clone(),
@@ -810,7 +816,7 @@ fn resolve_specification(spec_name: &Arc<str>, spec: &mut Spec) -> Result<Vec<St
     if let Some(next_expr) = find_box_action(&expr_clone) {
         spec.init = Some(collect_init(&expr_clone).unwrap_or(Expr::Lit(Value::Bool(true))));
         spec.next = Some(next_expr);
-        let parser_already_extracted = spec_name.as_ref() == "Spec" || spec_name.ends_with("Spec");
+        let parser_already_extracted = parser_pre_extracts_temporal(spec_name);
         let warnings = if parser_already_extracted {
             Vec::new()
         } else {

--- a/src/eval/helpers.rs
+++ b/src/eval/helpers.rs
@@ -201,10 +201,8 @@ pub(crate) fn fn_as_tuple(f: &BTreeMap<Value, Value>) -> Option<Vec<Value>> {
     let n = f.len();
     let mut result = Vec::with_capacity(n);
     for i in 1..=n {
-        match f.get(&Value::Int(i as i64)) {
-            Some(v) => result.push(v.clone()),
-            None => return None,
-        }
+        let v = f.get(&Value::Int(i as i64))?;
+        result.push(v.clone());
     }
     Some(result)
 }

--- a/src/load.rs
+++ b/src/load.rs
@@ -45,7 +45,7 @@ pub fn prepare_from_path(
         .map_err(|e| PrepareError::Io(format!("failed to read {}: {}", spec_path.display(), e)))?;
     let source = Source::new(spec_path.display().to_string(), contents.clone());
 
-    let (mut spec, warnings) =
+    let (mut spec, mut warnings) =
         parse_with_warnings(&contents).map_err(|err| PrepareError::Parse {
             message: err.message.clone(),
             span: err.span,
@@ -71,7 +71,7 @@ pub fn prepare_from_path(
         })?;
         let cfg_parsed = parse_cfg(&cfg_contents)
             .map_err(|e| PrepareError::Config(format!("cfg parse error: {}", e)))?;
-        apply_config(
+        let cfg_warnings = apply_config(
             &cfg_parsed,
             &mut spec,
             &mut domains,
@@ -81,6 +81,11 @@ pub fn prepare_from_path(
             false,
         )
         .map_err(|e| PrepareError::Config(format!("cfg apply error: {}", e)))?;
+        warnings.extend(
+            cfg_warnings
+                .into_iter()
+                .map(|w| Spanned::new(w, Span::default())),
+        );
     }
 
     for (name, value) in constants {

--- a/src/mcp/runner.rs
+++ b/src/mcp/runner.rs
@@ -52,7 +52,7 @@ pub fn prepare(
             .and_then(|s| (!s.is_empty()).then(|| SourceSpan::from_span(s, &source)));
         StructuredError::parse(err.message.clone(), span)
     })?;
-    let warnings: Vec<ParseWarning> = parser_warnings
+    let mut warnings: Vec<ParseWarning> = parser_warnings
         .iter()
         .map(|w| ParseWarning::from_spanned(w, &source))
         .collect();
@@ -90,7 +90,7 @@ pub fn prepare(
         })?;
         let cfg_parsed = parse_cfg(&cfg_contents)
             .map_err(|e| StructuredError::config(format!("cfg parse error: {}", e)))?;
-        apply_config(
+        let cfg_warnings = apply_config(
             &cfg_parsed,
             &mut spec,
             &mut domains,
@@ -100,6 +100,10 @@ pub fn prepare(
             false,
         )
         .map_err(|e| StructuredError::config(format!("cfg apply error: {}", e)))?;
+        warnings.extend(cfg_warnings.into_iter().map(|message| ParseWarning {
+            message,
+            span: None,
+        }));
     }
 
     for (name, value) in cli_constants {

--- a/tests/cfg_temporal_property_dispatch.rs
+++ b/tests/cfg_temporal_property_dispatch.rs
@@ -1,0 +1,163 @@
+use tla_checker::ast::{Env, Expr};
+use tla_checker::checker::{CheckResult, CheckerConfig};
+use tla_checker::config::{apply_config, parse_cfg};
+use tla_checker::parser::parse;
+
+fn apply(spec_src: &str, cfg_src: &str) -> (tla_checker::ast::Spec, Vec<String>) {
+    let mut spec = parse(spec_src).expect("spec parses");
+    let cfg = parse_cfg(cfg_src).expect("cfg parses");
+    let mut domains = Env::new();
+    let mut checker_config = CheckerConfig::default();
+    let warnings = apply_config(
+        &cfg,
+        &mut spec,
+        &mut domains,
+        &mut checker_config,
+        &[],
+        &[],
+        false,
+    )
+    .expect("apply_config ok");
+    (spec, warnings)
+}
+
+#[test]
+fn cfg_property_named_ending_in_spec_is_not_double_extracted() {
+    let spec_src = "---- MODULE M ----\n\
+        EXTENDS Naturals\n\
+        VARIABLE x\n\
+        Init == x = 0\n\
+        Next == x' = x\n\
+        EventuallySpec == <>(x = 1)\n\
+        ====\n";
+    let cfg_src = "INIT Init\nNEXT Next\nPROPERTY EventuallySpec\n";
+    let (spec, _) = apply(spec_src, cfg_src);
+    assert_eq!(
+        spec.liveness_properties.len(),
+        1,
+        "a *Spec-named property is pre-extracted by the parser; the cfg path must not extract it again"
+    );
+}
+
+#[test]
+fn cfg_property_with_normal_name_is_extracted_once() {
+    let spec_src = "---- MODULE M ----\n\
+        EXTENDS Naturals\n\
+        VARIABLE x\n\
+        Init == x = 0\n\
+        Next == x' = x\n\
+        Eventually1 == <>(x = 1)\n\
+        ====\n";
+    let cfg_src = "INIT Init\nNEXT Next\nPROPERTY Eventually1\n";
+    let (spec, _) = apply(spec_src, cfg_src);
+    assert_eq!(spec.liveness_properties.len(), 1);
+}
+
+#[test]
+fn cfg_existential_eventually_property_is_captured() {
+    let spec_src = "---- MODULE M ----\n\
+        EXTENDS Naturals\n\
+        VARIABLE x\n\
+        Init == x = 0\n\
+        Next == x' = x\n\
+        S == 0..2\n\
+        ExistsEventually == \\E i \\in S : <>(x = i)\n\
+        ====\n";
+    let cfg_src = "INIT Init\nNEXT Next\nPROPERTY ExistsEventually\n";
+    let (spec, _) = apply(spec_src, cfg_src);
+    assert_eq!(spec.liveness_properties.len(), 1);
+    assert!(
+        matches!(spec.liveness_properties[0], Expr::Exists(_, _, _)),
+        "\\E i : <>Q(i) reduces to <>(\\E i : Q(i)); a \\E state predicate must land in liveness"
+    );
+}
+
+#[test]
+fn cfg_unsupported_existential_temporal_warns_instead_of_silently_dropping() {
+    let spec_src = "---- MODULE M ----\n\
+        EXTENDS Naturals\n\
+        VARIABLE x\n\
+        Init == x = 0\n\
+        Next == x' = x\n\
+        S == 0..2\n\
+        ExistsLeads == \\E i \\in S : (x = 0) ~> (x = i)\n\
+        ====\n";
+    let cfg_src = "INIT Init\nNEXT Next\nPROPERTY ExistsLeads\n";
+    let (spec, warnings) = apply(spec_src, cfg_src);
+    let captured =
+        spec.liveness_properties.len() + spec.quantified_temporal.len() + spec.fairness.len();
+    assert_eq!(captured, 0);
+    assert!(
+        warnings.iter().any(|w| w.contains("existential temporal")),
+        "unsupported existential temporal must warn, got {warnings:?}"
+    );
+}
+
+#[test]
+fn cfg_universal_temporal_property_is_captured() {
+    let spec_src = "---- MODULE M ----\n\
+        EXTENDS Naturals\n\
+        VARIABLE x\n\
+        Init == x = 0\n\
+        Next == x' = x\n\
+        S == 0..2\n\
+        ForallEventually == \\A i \\in S : <>(x = i)\n\
+        ====\n";
+    let cfg_src = "INIT Init\nNEXT Next\nPROPERTY ForallEventually\n";
+    let (spec, _) = apply(spec_src, cfg_src);
+    assert!(!spec.quantified_temporal.is_empty());
+}
+
+fn run_existential_e2e(fair: bool) -> CheckResult {
+    let dir = std::env::temp_dir().join("tla_cfg_exists_e2e");
+    std::fs::create_dir_all(&dir).unwrap();
+    let spec_path = dir.join("ExistsE2E.tla");
+    let cfg_path = dir.join("ExistsE2E.cfg");
+    let spec_line = if fair {
+        "Spec == Init /\\ [][Next]_vars /\\ WF_vars(Step)"
+    } else {
+        "Spec == Init /\\ [][Next]_vars"
+    };
+    let module = format!(
+        "---- MODULE ExistsE2E ----\n\
+         EXTENDS Naturals\n\
+         VARIABLE x\n\
+         vars == <<x>>\n\
+         Init == x = 0\n\
+         Step == x = 0 /\\ x' = 1\n\
+         Next == Step \\/ UNCHANGED x\n\
+         {spec_line}\n\
+         TypeOK == x \\in 0..2\n\
+         ExistsEventually == \\E i \\in {{1, 2}} : <>(x = i)\n\
+         ====\n"
+    );
+    std::fs::write(&spec_path, module).unwrap();
+    std::fs::write(
+        &cfg_path,
+        "SPECIFICATION Spec\nINVARIANT TypeOK\nPROPERTY ExistsEventually\n",
+    )
+    .unwrap();
+
+    let prepared = tla_checker::load::prepare_from_path(&spec_path, None, &[]).unwrap();
+    let mut cc = prepared.checker_config;
+    cc.check_liveness = true;
+    let result = tla_checker::checker::check(&prepared.spec, &prepared.domains, &cc);
+    let _ = std::fs::remove_file(&spec_path);
+    let _ = std::fs::remove_file(&cfg_path);
+    let _ = std::fs::remove_dir(&dir);
+    result
+}
+
+#[test]
+fn cfg_existential_eventually_is_checked_end_to_end() {
+    match run_existential_e2e(true) {
+        CheckResult::Ok(_) => {}
+        other => panic!("WF forces x->1 so \\E i in {{1,2}} : <>(x=i) holds; got {other:?}"),
+    }
+    match run_existential_e2e(false) {
+        CheckResult::LivenessViolation(_, _) => {}
+        other => panic!(
+            "without fairness x stalls at 0 so \\E i in {{1,2}} : <>(x=i) is violated; got {other:?}"
+        ),
+    }
+}

--- a/tests/mcp_integration.rs
+++ b/tests/mcp_integration.rs
@@ -872,6 +872,82 @@ fn check_spec_expands_quantified_fairness_and_leads_to_property() {
 }
 
 #[test]
+fn check_spec_routes_cfg_temporal_property_to_liveness_checker() {
+    let dir = std::env::temp_dir().join("tla_mcp_cfg_temporal_property");
+    std::fs::create_dir_all(&dir).unwrap();
+    let spec_path = dir.join("LivenessRepro.tla");
+    let cfg_path = dir.join("LivenessRepro.cfg");
+
+    let module = "---- MODULE LivenessRepro ----\n\
+         EXTENDS Naturals\n\
+         VARIABLE x\n\
+         vars == <<x>>\n\
+         Init == x = 0\n\
+         Step == x = 0 /\\ x' = 1\n\
+         Next == Step \\/ UNCHANGED x\n\
+         FAIR_SPEC\n\
+         TypeOK == x \\in 0..1\n\
+         Eventually1 == <>(x = 1)\n\
+         ====\n";
+
+    let run = |fair: bool| {
+        let spec_line = if fair {
+            "Spec == Init /\\ [][Next]_vars /\\ WF_vars(Step)"
+        } else {
+            "Spec == Init /\\ [][Next]_vars"
+        };
+        std::fs::write(&spec_path, module.replace("FAIR_SPEC", spec_line)).unwrap();
+        std::fs::write(
+            &cfg_path,
+            "SPECIFICATION Spec\nINVARIANTS\n    TypeOK\nPROPERTY\n    Eventually1\n",
+        )
+        .unwrap();
+        let input = CheckSpecInput {
+            spec_path: spec_path.to_string_lossy().into_owned(),
+            max_states: 100,
+            max_depth: 20,
+            max_seconds: 15,
+            constants: BTreeMap::new(),
+            symmetry: None,
+            allow_deadlock: None,
+            check_liveness: Some(true),
+            count_satisfying: vec![],
+            continue_on_violation: false,
+            state_constraint: None,
+            config_path: None,
+        };
+        runner::check_spec(&input).outcome
+    };
+
+    let with_fairness = run(true);
+    let without_fairness = run(false);
+    let _ = std::fs::remove_file(&spec_path);
+    let _ = std::fs::remove_file(&cfg_path);
+    let _ = std::fs::remove_dir(&dir);
+
+    match with_fairness {
+        CheckOutcome::Ok { .. } => {}
+        other => panic!(
+            "WF_vars(Step) forces x to reach 1, so <>(x=1) must hold; got {:?}",
+            other
+        ),
+    }
+    match without_fairness {
+        CheckOutcome::LivenessViolation { property, .. } => {
+            assert!(
+                property.contains("Eq"),
+                "expected the eventually property expanded to a state predicate, got {}",
+                property
+            );
+        }
+        other => panic!(
+            "without fairness x can stall at 0 forever, so <>(x=1) must be violated; got {:?}",
+            other
+        ),
+    }
+}
+
+#[test]
 fn check_spec_reports_fair_sub_cycle_when_an_unfair_sub_cycle_shares_the_scc() {
     let dir = std::env::temp_dir().join("tla_mcp_two_violating_sub_cycles");
     std::fs::create_dir_all(&dir).unwrap();


### PR DESCRIPTION
## Problem

A temporal `PROPERTY` referenced from a cfg file could not be checked. The cfg loader pushed the raw property body into the liveness property list without unwrapping its temporal operator, so the checker handed a live `<>`/`~>`/`[]<>` node to the state-predicate evaluator and aborted with:

```
temporal operator <> (eventually) reached eval — wrap it in a definition and
reference it via cfg PROPERTY (with --check-liveness), don't use it as a state predicate.
```

This made liveness checking unreachable through a cfg `PROPERTY` — including the `check_spec` MCP tool — even with liveness enabled. The error was self-contradictory: it prescribed exactly the configuration that triggered it.

### Minimal reproduction

`LivenessRepro.tla`:
```tla
---- MODULE LivenessRepro ----
EXTENDS Naturals
VARIABLE x
vars == <<x>>
Init == x = 0
Step == x = 0 /\ x' = 1
Next == Step \/ UNCHANGED x
Spec == Init /\ [][Next]_vars /\ WF_vars(Step)
TypeOK == x \in 0..1
Eventually1 == <>(x = 1)
====
```
`LivenessRepro.cfg`:
```
SPECIFICATION Spec
INVARIANTS TypeOK
PROPERTY Eventually1
```

## Root cause

Every other path (parser, `SPECIFICATION`) normalizes properties through `collect_temporal`, which unwraps `<>P → P`, `[]<>P → P`, keeps `~>`, and routes quantified `\A i: <>...` into `quantified_temporal`. The cfg-`PROPERTY` path in `apply_config` skipped that normalization.

## Fix

- `src/config.rs`: cfg `PROPERTY` bodies now pass through `extract_fairness_and_liveness` (`collect_temporal`) when temporal, matching the other paths. Non-temporal properties keep the raw push.
- `src/checker.rs`: `needs_liveness_check` now also considers `spec.quantified_temporal`, so a quantified temporal property alone triggers the liveness pass (otherwise it was silently skipped).

## Verification

- The reporter's repro returns `ok` (WF forces `x→1`); dropping the fairness yields a `liveness_violation`.
- `~>`, `[]<>`, and quantified `\A s: P(s) ~> Q(s)` forms all check correctly.
- Added 2 config unit tests + 1 MCP integration test replicating the report scenario.
- Full suite green: 190 lib + 42 mcp_integration + 65 oracle tests; `cargo fmt` and `cargo clippy` clean (also resolved a pre-existing `question_mark` clippy lint in `fn_as_tuple`).
