### PR TITLE
fix liveness soundness: implicit stuttering and <>[]P support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.6.8] - 2026-07-14
+
+### Added
+
+- `<>[]P` (stable-eventually, "eventually always") is now checked instead of being silently dropped. Previously the temporal-property extractor emitted a warning and discarded the inner expression, so a `SPECIFICATION`/cfg `PROPERTY` of the form `<>[]P` made `check_spec` return a vacuous `ok` without checking anything. The property is now dispatched to a dedicated analysis: `<>[]P` is violated exactly when a reachable fair cycle revisits a `¬P` state, and holds when every fair behavior eventually reaches `P` and stays there.
+
+### Fixed
+
+- Liveness checking now models the implicit stuttering that `[][Next]_vars` always permits, matching TLC. Previously the SCC analysis walked only explicit transitions, so a state whose sole successor was an *unfair* action was wrongly treated as forced to take it, and infinite stuttering at a non-deadlock state was never considered a behavior. A liveness property whose satisfaction depends on progress being forced — `<>P` with no fairness, or a consumer that can stall forever while only an unfair action is enabled — could therefore return a false `ok`. The liveness graph now adds an implicit stutter self-loop to every state; the existing weak/strong fairness filtering discharges the spurious cycles (a stutter-only cycle is rejected wherever a fair action is enabled), so only genuinely stuck states survive as violations. Modeling a stalling agent no longer requires an explicit `\/ UNCHANGED vars` disjunct.
+
 ## [0.6.7] - 2026-07-13
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.6.7"
+version = "0.6.8"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"

--- a/SYNTAX_STATUS.md
+++ b/SYNTAX_STATUS.md
@@ -232,6 +232,19 @@ These operators are parsed into the AST but error at evaluation time. They can a
 | `<<A>>_v` | | Diamond action | Parsed, errors if evaluated directly |
 | `\cdot` | | Action composition | Parsed, errors if evaluated directly |
 
+### Liveness Property Forms
+
+With `--check-liveness`, a top-level property (from a cfg `PROPERTY`, a `SPECIFICATION`, or a `*Spec`-named definition) is checked against fair behaviors via SCC analysis. Supported forms and the cycle that witnesses a violation:
+
+| Form | Checked as | Violated by |
+|------|-----------|-------------|
+| `<>P` | Eventually | a reachable fair cycle whose states are all `¬P` |
+| `[]<>P` | Infinitely often | a reachable fair cycle whose states are all `¬P` |
+| `<>[]P` | Stable-eventually | a reachable fair cycle containing any `¬P` state |
+| `P ~> Q` | Leads-to | a reachable fair `¬Q` cycle reachable from a `P ∧ ¬Q` state |
+
+The liveness graph models the implicit stuttering that `[][Next]_vars` always permits — every state gets a stutter self-loop, and weak/strong fairness rules out the cycles it would otherwise create. An agent that may stall forever therefore needs no explicit `\/ UNCHANGED vars` disjunct to be considered.
+
 ### Quantified Temporal Properties
 
 Temporal properties may be quantified over a constant set (requires `--check-liveness`; declared via a cfg `PROPERTY` or the `SPECIFICATION`).

--- a/SYNTAX_STATUS.md
+++ b/SYNTAX_STATUS.md
@@ -218,7 +218,7 @@ Stdlib modules (Naturals, Sequences, TLC, etc.) can be used with `LOCAL INSTANCE
 ## Parsed But Not Evaluated ⚠️
 
 ### Temporal Operators
-These operators are parsed into the AST but error at evaluation time. They can appear in skipped definitions (like `Spec`) without causing errors. Fairness operators are handled by the liveness checker (`--check-liveness`).
+These operators are parsed into the AST but error at evaluation time. They can appear in skipped definitions (like `Spec`) without causing errors. Fairness operators are handled by the liveness checker (`--check-liveness`); see **Liveness Property Forms** below for how `<>`, `[]<>`, `<>[]`, and `~>` are checked as top-level properties.
 
 | ASCII | Unicode | Description | Status |
 |-------|---------|-------------|--------|

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -364,9 +364,7 @@ pub fn collect_temporal(
         }
         Expr::Eventually(inner) => {
             if matches!(inner.as_ref(), Expr::Always(_)) {
-                warnings.push(
-                    "temporal pattern <>[]P (stable-eventually) is not supported by the liveness checker — dropping its inner expression".to_string(),
-                );
+                liveness.push(Expr::Eventually(inner.clone()));
             } else {
                 liveness.push((**inner).clone());
             }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -939,6 +939,13 @@ fn check_liveness_properties(
         return Ok(LivenessCheckOutcome::TimeExceeded);
     }
 
+    let stutter_targets: Vec<usize> = (0..graph.state_count())
+        .filter(|&idx| !graph.successors(idx).iter().any(|e| e.target == idx))
+        .collect();
+    for idx in stutter_targets {
+        graph.add_edge(idx, idx, None);
+    }
+
     if !config.quiet {
         eprintln!("  Computing strongly connected components...");
     }
@@ -968,6 +975,12 @@ fn check_liveness_properties(
                 Expr::LeadsTo(p, q) => {
                     liveness::check_leads_to(&graph, scc, p, q, domains, defs, &spec.vars)?
                 }
+                Expr::Eventually(inner) => match inner.as_ref() {
+                    Expr::Always(p) => liveness::check_stable_eventually(
+                        &graph, scc, p, domains, defs, &spec.vars,
+                    )?,
+                    _ => liveness::check_eventually(&graph, scc, inner, domains, defs, &spec.vars)?,
+                },
                 _ => liveness::check_eventually(&graph, scc, property, domains, defs, &spec.vars)?,
             };
 
@@ -983,6 +996,10 @@ fn check_liveness_properties(
 
                 let prop_desc = match property {
                     Expr::LeadsTo(_, _) => format!("{:?}", property),
+                    Expr::Eventually(inner) => match inner.as_ref() {
+                        Expr::Always(p) => format!("<>[]{:?}", p),
+                        _ => format!("<>{:?}", inner),
+                    },
                     _ => format!("<>{:?}", property),
                 };
                 let cycle_entry = cycle_indices.first().copied().unwrap_or(scc.states[0]);

--- a/src/liveness.rs
+++ b/src/liveness.rs
@@ -152,6 +152,34 @@ fn action_matches(
     }
 }
 
+fn eval_bool_at(
+    graph: &StateGraph,
+    state_idx: usize,
+    expr: &Expr,
+    constants: &Env,
+    defs: &Definitions,
+    vars: &[Arc<str>],
+    context: &'static str,
+) -> Result<Option<bool>> {
+    let Some(state) = graph.get_state(state_idx) else {
+        return Ok(None);
+    };
+    let mut env = crate::eval::state_to_env(state, vars);
+    for (k, v) in constants {
+        env.insert(k.clone(), v.clone());
+    }
+    match eval(expr, &mut env, defs) {
+        Ok(Value::Bool(b)) => Ok(Some(b)),
+        Ok(_) => Err(EvalError::TypeMismatch {
+            expected: "Bool",
+            got: Value::Bool(false),
+            context: Some(context),
+            span: None,
+        }),
+        Err(e) => Err(e),
+    }
+}
+
 pub fn check_eventually(
     graph: &StateGraph,
     scc: &SCC,
@@ -166,27 +194,17 @@ pub fn check_eventually(
 
     let mut not_p_states: HashSet<usize> = HashSet::new();
     for &state_idx in &scc.states {
-        let Some(state) = graph.get_state(state_idx) else {
-            continue;
-        };
-        let mut env = crate::eval::state_to_env(state, vars);
-        for (k, v) in constants {
-            env.insert(k.clone(), v.clone());
-        }
-        match eval(property, &mut env, defs) {
-            Ok(Value::Bool(true)) => continue,
-            Ok(Value::Bool(false)) => {
-                not_p_states.insert(state_idx);
-            }
-            Ok(_) => {
-                return Err(EvalError::TypeMismatch {
-                    expected: "Bool",
-                    got: Value::Bool(false),
-                    context: Some("liveness property"),
-                    span: None,
-                });
-            }
-            Err(e) => return Err(e),
+        if eval_bool_at(
+            graph,
+            state_idx,
+            property,
+            constants,
+            defs,
+            vars,
+            "liveness property",
+        )? == Some(false)
+        {
+            not_p_states.insert(state_idx);
         }
     }
 
@@ -215,27 +233,17 @@ pub fn check_stable_eventually(
     }
 
     for &state_idx in &scc.states {
-        let Some(state) = graph.get_state(state_idx) else {
-            continue;
-        };
-        let mut env = crate::eval::state_to_env(state, vars);
-        for (k, v) in constants {
-            env.insert(k.clone(), v.clone());
-        }
-        match eval(property, &mut env, defs) {
-            Ok(Value::Bool(true)) => continue,
-            Ok(Value::Bool(false)) => {
-                return Ok(vec![scc.states.clone()]);
-            }
-            Ok(_) => {
-                return Err(EvalError::TypeMismatch {
-                    expected: "Bool",
-                    got: Value::Bool(false),
-                    context: Some("liveness property"),
-                    span: None,
-                });
-            }
-            Err(e) => return Err(e),
+        if eval_bool_at(
+            graph,
+            state_idx,
+            property,
+            constants,
+            defs,
+            vars,
+            "liveness property",
+        )? == Some(false)
+        {
+            return Ok(vec![scc.states.clone()]);
         }
     }
 
@@ -259,38 +267,29 @@ pub fn check_leads_to(
     let mut not_q_states: HashSet<usize> = HashSet::new();
 
     for &state_idx in &scc.states {
-        let Some(state) = graph.get_state(state_idx) else {
+        let Some(p_holds) = eval_bool_at(
+            graph,
+            state_idx,
+            p,
+            constants,
+            defs,
+            vars,
+            "leads-to antecedent",
+        )?
+        else {
             continue;
         };
-        let mut env = crate::eval::state_to_env(state, vars);
-        for (k, v) in constants {
-            env.insert(k.clone(), v.clone());
-        }
-
-        let p_holds = match eval(p, &mut env, defs) {
-            Ok(Value::Bool(b)) => b,
-            Ok(_) => {
-                return Err(EvalError::TypeMismatch {
-                    expected: "Bool",
-                    got: Value::Bool(false),
-                    context: Some("leads-to antecedent"),
-                    span: None,
-                });
-            }
-            Err(e) => return Err(e),
-        };
-
-        let q_holds = match eval(q, &mut env, defs) {
-            Ok(Value::Bool(b)) => b,
-            Ok(_) => {
-                return Err(EvalError::TypeMismatch {
-                    expected: "Bool",
-                    got: Value::Bool(false),
-                    context: Some("leads-to consequent"),
-                    span: None,
-                });
-            }
-            Err(e) => return Err(e),
+        let Some(q_holds) = eval_bool_at(
+            graph,
+            state_idx,
+            q,
+            constants,
+            defs,
+            vars,
+            "leads-to consequent",
+        )?
+        else {
+            continue;
         };
 
         if !q_holds {

--- a/src/liveness.rs
+++ b/src/liveness.rs
@@ -202,6 +202,46 @@ pub fn check_eventually(
         .collect())
 }
 
+pub fn check_stable_eventually(
+    graph: &StateGraph,
+    scc: &SCC,
+    property: &Expr,
+    constants: &Env,
+    defs: &Definitions,
+    vars: &[Arc<str>],
+) -> Result<Vec<Vec<usize>>> {
+    if scc.is_trivial {
+        return Ok(Vec::new());
+    }
+
+    for &state_idx in &scc.states {
+        let Some(state) = graph.get_state(state_idx) else {
+            continue;
+        };
+        let mut env = crate::eval::state_to_env(state, vars);
+        for (k, v) in constants {
+            env.insert(k.clone(), v.clone());
+        }
+        match eval(property, &mut env, defs) {
+            Ok(Value::Bool(true)) => continue,
+            Ok(Value::Bool(false)) => {
+                return Ok(vec![scc.states.clone()]);
+            }
+            Ok(_) => {
+                return Err(EvalError::TypeMismatch {
+                    expected: "Bool",
+                    got: Value::Bool(false),
+                    context: Some("liveness property"),
+                    span: None,
+                });
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(Vec::new())
+}
+
 pub fn check_leads_to(
     graph: &StateGraph,
     scc: &SCC,
@@ -332,6 +372,60 @@ mod tests {
         State {
             values: vec![Value::Int(n)],
         }
+    }
+
+    fn eq_x(n: i64) -> Expr {
+        Expr::Eq(
+            Box::new(Expr::Var(Arc::from("x"))),
+            Box::new(Expr::Lit(Value::Int(n))),
+        )
+    }
+
+    #[test]
+    fn stable_eventually_flags_cycle_touching_not_p() {
+        let mut graph = StateGraph::new();
+        graph.add_state(state_with_x(0), None);
+        graph.add_state(state_with_x(1), Some(0));
+        graph.add_edge(0, 1, Some("Toggle".into()));
+        graph.add_edge(1, 0, Some("Toggle".into()));
+
+        let sccs = compute_sccs(&graph);
+        let scc = &sccs[0];
+        assert!(!scc.is_trivial);
+
+        let vars = vec![Arc::from("x")];
+        let constants = Env::new();
+        let defs = Definitions::new();
+
+        let cycles =
+            check_stable_eventually(&graph, scc, &eq_x(1), &constants, &defs, &vars).unwrap();
+        assert_eq!(
+            cycles.len(),
+            1,
+            "the cycle revisits x=0 (not-P) forever, so <>[](x=1) is violated"
+        );
+    }
+
+    #[test]
+    fn stable_eventually_ok_when_all_states_satisfy_p() {
+        let mut graph = StateGraph::new();
+        graph.add_state(state_with_x(1), None);
+        graph.add_edge(0, 0, Some("Stay".into()));
+
+        let sccs = compute_sccs(&graph);
+        let scc = &sccs[0];
+        assert!(!scc.is_trivial);
+
+        let vars = vec![Arc::from("x")];
+        let constants = Env::new();
+        let defs = Definitions::new();
+
+        let cycles =
+            check_stable_eventually(&graph, scc, &eq_x(1), &constants, &defs, &vars).unwrap();
+        assert!(
+            cycles.is_empty(),
+            "every state in the cycle satisfies x=1, so <>[](x=1) holds"
+        );
     }
 
     #[test]

--- a/test_cases/should_pass/eventually_test.tla
+++ b/test_cases/should_pass/eventually_test.tla
@@ -11,6 +11,6 @@ Next == Inc \/ (x = 5 /\ UNCHANGED x)
 
 TypeOK == x \in 0..5
 
-Spec == Init /\ [][Next]_x /\ <>(x = 5)
+Spec == Init /\ [][Next]_x /\ WF_x(Inc) /\ <>(x = 5)
 
 ====

--- a/test_cases/should_pass/infinitely_often.tla
+++ b/test_cases/should_pass/infinitely_often.tla
@@ -11,6 +11,6 @@ Next == Toggle
 
 TypeOK == x \in 0..1
 
-Spec == Init /\ [][Next]_x /\ []<>(x = 0)
+Spec == Init /\ [][Next]_x /\ WF_x(Toggle) /\ []<>(x = 0)
 
 ====

--- a/test_cases/should_pass/leads_to_test.tla
+++ b/test_cases/should_pass/leads_to_test.tla
@@ -11,6 +11,6 @@ Next == Inc \/ (x = 5 /\ UNCHANGED x)
 
 TypeOK == x \in 0..5
 
-Spec == Init /\ [][Next]_x /\ ((x = 0) ~> (x = 5))
+Spec == Init /\ [][Next]_x /\ WF_x(Inc) /\ ((x = 0) ~> (x = 5))
 
 ====

--- a/tests/cfg_temporal_property_dispatch.rs
+++ b/tests/cfg_temporal_property_dispatch.rs
@@ -94,6 +94,35 @@ fn cfg_unsupported_existential_temporal_warns_instead_of_silently_dropping() {
 }
 
 #[test]
+fn cfg_stable_eventually_property_is_captured_not_dropped() {
+    let spec_src = "---- MODULE M ----\n\
+        EXTENDS Naturals\n\
+        VARIABLE x\n\
+        Init == x = 0\n\
+        Next == x' = x\n\
+        StableEventually == <>[](x = 1)\n\
+        ====\n";
+    let cfg_src = "INIT Init\nNEXT Next\nPROPERTY StableEventually\n";
+    let (spec, warnings) = apply(spec_src, cfg_src);
+    assert_eq!(
+        spec.liveness_properties.len(),
+        1,
+        "<>[]P must be captured for checking, not silently dropped"
+    );
+    assert!(
+        matches!(
+            &spec.liveness_properties[0],
+            Expr::Eventually(inner) if matches!(inner.as_ref(), Expr::Always(_))
+        ),
+        "<>[]P must retain its Eventually(Always(..)) shape so the checker dispatches stable-eventually"
+    );
+    assert!(
+        !warnings.iter().any(|w| w.contains("dropping")),
+        "<>[]P must no longer warn about dropping its inner expression, got {warnings:?}"
+    );
+}
+
+#[test]
 fn cfg_universal_temporal_property_is_captured() {
     let spec_src = "---- MODULE M ----\n\
         EXTENDS Naturals\n\

--- a/tests/liveness_regressions.rs
+++ b/tests/liveness_regressions.rs
@@ -1,0 +1,212 @@
+use std::path::{Path, PathBuf};
+
+use tla_checker::checker::{CheckResult, check};
+use tla_checker::load::prepare_from_path;
+
+fn manifest_path(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn check_liveness_at(path: &Path) -> CheckResult {
+    let prepared = prepare_from_path(path, None, &[]).expect("spec prepares");
+    let mut cc = prepared.checker_config;
+    cc.check_liveness = true;
+    check(&prepared.spec, &prepared.domains, &cc)
+}
+
+fn run_inline(name: &str, module: &str) -> CheckResult {
+    let dir = std::env::temp_dir().join("tla_liveness_regressions");
+    std::fs::create_dir_all(&dir).unwrap();
+    let spec_path = dir.join(format!("{name}.tla"));
+    std::fs::write(&spec_path, module).unwrap();
+    let prepared = prepare_from_path(&spec_path, None, &[]).expect("spec prepares");
+    let mut cc = prepared.checker_config;
+    cc.check_liveness = true;
+    let result = check(&prepared.spec, &prepared.domains, &cc);
+    let _ = std::fs::remove_file(&spec_path);
+    result
+}
+
+// --- Standalone fixture wiring: these test_cases/ liveness specs were never
+// exercised by cargo test, so a semantic regression in them went uncaught. ---
+
+#[test]
+fn fixture_eventually_holds_under_weak_fairness() {
+    match check_liveness_at(&manifest_path("test_cases/should_pass/eventually_test.tla")) {
+        CheckResult::Ok(_) => {}
+        other => panic!("WF_x(Inc) must drive x to 5 so <>(x=5) holds; got {other:?}"),
+    }
+}
+
+#[test]
+fn fixture_infinitely_often_holds_under_weak_fairness() {
+    match check_liveness_at(&manifest_path(
+        "test_cases/should_pass/infinitely_often.tla",
+    )) {
+        CheckResult::Ok(_) => {}
+        other => panic!("WF_x(Toggle) forces toggling forever so []<>(x=0) holds; got {other:?}"),
+    }
+}
+
+#[test]
+fn fixture_leads_to_holds_under_weak_fairness() {
+    match check_liveness_at(&manifest_path("test_cases/should_pass/leads_to_test.tla")) {
+        CheckResult::Ok(_) => {}
+        other => panic!("WF_x(Inc) must drive x to 5 so (x=0)~>(x=5) holds; got {other:?}"),
+    }
+}
+
+#[test]
+fn fixture_eventually_violation_is_reported() {
+    match check_liveness_at(&manifest_path(
+        "test_cases/should_violate/liveness_violation.tla",
+    )) {
+        CheckResult::LivenessViolation(_, _) => {}
+        other => panic!("x only reaches 0/1, so <>(x=5) must be violated; got {other:?}"),
+    }
+}
+
+#[test]
+fn fixture_infinitely_often_violation_is_reported() {
+    match check_liveness_at(&manifest_path(
+        "test_cases/should_violate/infinitely_often_violation.tla",
+    )) {
+        CheckResult::LivenessViolation(_, _) => {}
+        other => panic!("x stutters at 3 forever, so []<>(x=0) must be violated; got {other:?}"),
+    }
+}
+
+#[test]
+fn fixture_leads_to_violation_is_reported() {
+    match check_liveness_at(&manifest_path(
+        "test_cases/should_violate/leads_to_violation.tla",
+    )) {
+        CheckResult::LivenessViolation(_, _) => {}
+        other => panic!("x never reaches 5, so (x=0)~>(x=5) must be violated; got {other:?}"),
+    }
+}
+
+// --- Fix B: implicit stuttering. A machine with no explicit `\/ UNCHANGED` at
+// the non-goal state can still stutter there forever under [][Next]_vars.
+// Without fairness that stutter violates <>P; weak fairness rules it out. ---
+
+const STUTTER_MODULE: &str = "---- MODULE ImplicitStutter ----\n\
+    EXTENDS Naturals\n\
+    VARIABLE x\n\
+    vars == <<x>>\n\
+    Init == x = 0\n\
+    Step == x = 0 /\\ x' = 1\n\
+    Next == Step \\/ (x = 1 /\\ UNCHANGED x)\n\
+    TypeOK == x \\in 0..1\n\
+    SPEC_LINE\n\
+    ====\n";
+
+#[test]
+fn implicit_stutter_without_fairness_violates_eventually() {
+    let module =
+        STUTTER_MODULE.replace("SPEC_LINE", "Spec == Init /\\ [][Next]_vars /\\ <>(x = 1)");
+    match run_inline("ImplicitStutter", &module) {
+        CheckResult::LivenessViolation(_, _) => {}
+        other => panic!(
+            "x=0 has no explicit self-loop but [][Next]_vars still permits stuttering there \
+             forever, so without fairness <>(x=1) must be violated; got {other:?}"
+        ),
+    }
+}
+
+#[test]
+fn implicit_stutter_with_weak_fairness_holds() {
+    let module = STUTTER_MODULE.replace(
+        "SPEC_LINE",
+        "Spec == Init /\\ [][Next]_vars /\\ WF_vars(Step) /\\ <>(x = 1)",
+    );
+    match run_inline("ImplicitStutterFair", &module) {
+        CheckResult::Ok(_) => {}
+        other => panic!("WF_vars(Step) forbids stuttering at x=0, so <>(x=1) holds; got {other:?}"),
+    }
+}
+
+// The stalled-consumer lesson: at the stuck state the only enabled transition is
+// an UNFAIR action. The checker must not treat that action as forced.
+
+const UNFAIR_ONLY_MODULE: &str = "---- MODULE UnfairOnly ----\n\
+    EXTENDS Naturals\n\
+    VARIABLE x\n\
+    vars == <<x>>\n\
+    Init == x = 0\n\
+    Rescue == x = 0 /\\ x' = 1\n\
+    Next == Rescue \\/ (x = 1 /\\ UNCHANGED x)\n\
+    TypeOK == x \\in 0..1\n\
+    SPEC_LINE\n\
+    ====\n";
+
+#[test]
+fn unfair_only_exit_does_not_rescue_liveness() {
+    let module =
+        UNFAIR_ONLY_MODULE.replace("SPEC_LINE", "Spec == Init /\\ [][Next]_vars /\\ <>(x = 1)");
+    match run_inline("UnfairOnly", &module) {
+        CheckResult::LivenessViolation(_, _) => {}
+        other => panic!(
+            "the only exit from x=0 is the unfair Rescue action, so the checker must not \
+             assume it is taken; <>(x=1) must be violated; got {other:?}"
+        ),
+    }
+}
+
+#[test]
+fn fair_exit_rescues_liveness() {
+    let module = UNFAIR_ONLY_MODULE.replace(
+        "SPEC_LINE",
+        "Spec == Init /\\ [][Next]_vars /\\ WF_vars(Rescue) /\\ <>(x = 1)",
+    );
+    match run_inline("FairExit", &module) {
+        CheckResult::Ok(_) => {}
+        other => panic!("WF_vars(Rescue) forces the exit, so <>(x=1) holds; got {other:?}"),
+    }
+}
+
+// --- Fix A: <>[]P (stable-eventually) is checked, not silently dropped. ---
+
+#[test]
+fn stable_eventually_holds_when_property_stabilizes() {
+    let module = "---- MODULE StableHolds ----\n\
+        EXTENDS Naturals\n\
+        VARIABLE x\n\
+        vars == <<x>>\n\
+        Init == x = 0\n\
+        Step == x = 0 /\\ x' = 1\n\
+        Next == Step \\/ (x = 1 /\\ UNCHANGED x)\n\
+        TypeOK == x \\in 0..1\n\
+        Spec == Init /\\ [][Next]_vars /\\ WF_vars(Step) /\\ <>[](x = 1)\n\
+        ====\n";
+    match run_inline("StableHolds", module) {
+        CheckResult::Ok(_) => {}
+        other => panic!("x reaches 1 and stays, so <>[](x=1) holds; got {other:?}"),
+    }
+}
+
+#[test]
+fn stable_eventually_violated_when_property_flips_forever() {
+    let module = "---- MODULE StableFlips ----\n\
+        EXTENDS Naturals\n\
+        VARIABLE x\n\
+        vars == <<x>>\n\
+        Init == x = 0\n\
+        Toggle == x' = 1 - x\n\
+        Next == Toggle\n\
+        TypeOK == x \\in 0..1\n\
+        Spec == Init /\\ [][Next]_vars /\\ WF_vars(Toggle) /\\ <>[](x = 1)\n\
+        ====\n";
+    match run_inline("StableFlips", module) {
+        CheckResult::LivenessViolation(violation, _) => {
+            assert!(
+                violation.property.starts_with("<>[]"),
+                "the reported property must be the stable-eventually form, got {}",
+                violation.property
+            );
+        }
+        other => panic!(
+            "x toggles forever so x=1 never stabilizes; <>[](x=1) must be violated; got {other:?}"
+        ),
+    }
+}


### PR DESCRIPTION
Fixes two liveness-checker soundness bugs, each of which could return a false `ok`, plus adds support for `<>[]P`.

## Defects

**`<>[]P` silently dropped.** The temporal-property extractor emitted a warning and discarded the inner expression, so a `SPECIFICATION`/cfg `PROPERTY` of the form `<>[]P` made `check_spec` return a vacuous `ok` without checking anything.

**Implicit stuttering ignored in liveness.** `[][Next]_vars` always permits a stuttering step, but the SCC analysis walked only explicit transitions. A state whose sole successor was an *unfair* action was wrongly treated as forced to take it, and infinite stuttering at a non-deadlock state was never considered a behavior. So a property whose satisfaction depends on progress being forced (e.g. `<>P` with no fairness, or a consumer that can stall forever while only an unfair action is enabled) could return a false `ok`. Minimal witness: fairness-free `Spec == Init /\ [][Next]_vars` with `Step: x=0 -> x'=1` and `<>(x=1)` — TLC reports a violation; the old checker returned `ok`.

## Fixes

- `src/ast.rs` — keep `<>[]P` as `Eventually(Always(P))` instead of dropping it.
- `src/liveness.rs` — new `check_stable_eventually`: `<>[]P` is violated iff a reachable fair cycle contains a `¬P` state.
- `src/checker.rs` — add an implicit stutter self-loop to every liveness-graph state before SCC computation, and dispatch `<>[]P`. Existing weak/strong fairness filtering discharges the spurious cycles (a stutter-only cycle is rejected wherever a fair action is enabled), so only genuinely stuck states survive as violations. This matches TLC; modeling a stalling agent no longer needs an explicit `\/ UNCHANGED vars` disjunct.

## Tests

- New `tests/liveness_regressions.rs`: wires the six previously-unexercised `test_cases/` liveness fixtures into the suite, plus focused guards for both bugs (implicit-stutter violation vs. WF-holds with no explicit `\/ UNCHANGED`; unfair-only-exit does not rescue liveness; `<>[]P` holds vs. violates).
- Extraction guard in `tests/cfg_temporal_property_dispatch.rs` proving `<>[]P` is captured, not dropped.
- `check_stable_eventually` unit tests in `src/liveness.rs`.
- Three `should_pass` fixtures were only passing because of the stuttering bug (their properties are unsatisfiable without fairness); each now declares the `WF` it actually requires.

All 314 tests pass; clippy clean under `-D warnings`.

Docs: `CHANGELOG.md` `[0.6.8]`, `Cargo.toml` bump to 0.6.8, and a "Liveness Property Forms" table in `SYNTAX_STATUS.md`.
