### PR TITLE
fairness ignores stuttering steps for WF/SF (fixes #63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.9] - 2026-07-14
+
+### Fixed
+
+- Weak/strong fairness (`WF_v(A)` / `SF_v(A)`) now treats fairness as being about `⟨A⟩_v ≡ A ∧ (vars' ≠ vars)` rather than about `A` merely admitting a stuttering step. Previously, when a fair action allowed a stutter (e.g. `A == x' \in {x, x+1}`), the checker counted the `x'=x` self-loop as "A taken" and treated a stutter-forever cycle as fair, reporting a spurious `liveness_violation` for a property that actually holds under weak fairness. Both sides of the fairness check now ignore stuttering steps: an action is "taken" only on a state-changing edge, and "enabled" for fairness only when a state-changing successor satisfies it (so weak fairness on a pure-stutter action is correctly vacuous rather than spuriously forcing progress). Fixes #63.
+
 ## [0.6.8] - 2026-07-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.6.8"
+version = "0.6.9"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/liveness.rs
+++ b/src/liveness.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::ast::{Env, Expr, FairnessConstraint, State, Value};
-use crate::eval::{Definitions, EvalError, eval, is_action_enabled};
+use crate::eval::{Definitions, EvalError, eval};
 use crate::graph::StateGraph;
 use crate::scc::SCC;
 
@@ -56,6 +56,28 @@ pub fn check_fairness_in_scc(
     Ok(true)
 }
 
+fn enables_nonstutter_step(
+    graph: &StateGraph,
+    state_idx: usize,
+    action: &Expr,
+    vars: &[Arc<str>],
+    constants: &Env,
+    defs: &Definitions,
+) -> Result<bool> {
+    let Some(state) = graph.get_state(state_idx) else {
+        return Ok(false);
+    };
+    for edge in graph.successors(state_idx) {
+        if edge.target != state_idx
+            && let Some(next) = graph.get_state(edge.target)
+            && action_matches(action, state, next, vars, constants, defs)?
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 fn scc_all_enabled(
     graph: &StateGraph,
     scc: &SCC,
@@ -65,9 +87,7 @@ fn scc_all_enabled(
     defs: &Definitions,
 ) -> Result<bool> {
     for &state_idx in &scc.states {
-        if let Some(state) = graph.get_state(state_idx)
-            && !is_action_enabled(action, state, vars, constants, defs)?
-        {
+        if !enables_nonstutter_step(graph, state_idx, action, vars, constants, defs)? {
             return Ok(false);
         }
     }
@@ -83,9 +103,7 @@ fn scc_any_enabled(
     defs: &Definitions,
 ) -> Result<bool> {
     for &state_idx in &scc.states {
-        if let Some(state) = graph.get_state(state_idx)
-            && is_action_enabled(action, state, vars, constants, defs)?
-        {
+        if enables_nonstutter_step(graph, state_idx, action, vars, constants, defs)? {
             return Ok(true);
         }
     }
@@ -107,7 +125,8 @@ fn scc_has_action_edge(
             continue;
         };
         for edge in graph.successors(state_idx) {
-            if scc_states.contains(&edge.target)
+            if edge.target != state_idx
+                && scc_states.contains(&edge.target)
                 && let Some(target_state) = graph.get_state(edge.target)
                 && action_matches(action, state, target_state, vars, constants, defs)?
             {

--- a/tests/liveness_regressions.rs
+++ b/tests/liveness_regressions.rs
@@ -256,3 +256,46 @@ fn vacuous_fairness_on_pure_stutter_action_does_not_rescue_liveness() {
         ),
     }
 }
+
+#[test]
+fn strong_fairness_on_stutter_permitting_action_holds() {
+    let module = "---- MODULE StutterStrongFair ----\n\
+        EXTENDS Naturals\n\
+        VARIABLE x\n\
+        vars == <<x>>\n\
+        Init == x = 0\n\
+        Grow == x < 3 /\\ x' \\in {x, x + 1}\n\
+        Next == Grow \\/ (x = 3 /\\ UNCHANGED x)\n\
+        TypeOK == x \\in 0..3\n\
+        Spec == Init /\\ [][Next]_vars /\\ SF_vars(Grow) /\\ <>(x = 3)\n\
+        ====\n";
+    match run_inline("StutterStrongFair", module) {
+        CheckResult::Ok(_) => {}
+        other => panic!(
+            "SF on <<Grow>>_vars (the x+1 step) is enabled infinitely often and forces x -> 3; \
+             the x'=x stutter must not be counted as taking Grow, so <>(x=3) holds; got {other:?}"
+        ),
+    }
+}
+
+#[test]
+fn vacuous_strong_fairness_on_pure_stutter_action_does_not_rescue_liveness() {
+    let module = "---- MODULE PureStutterStrongFair ----\n\
+        EXTENDS Naturals\n\
+        VARIABLE x\n\
+        vars == <<x>>\n\
+        Init == x = 0\n\
+        Stay == x' = x\n\
+        Move == x = 0 /\\ x' = 1\n\
+        Next == Stay \\/ Move\n\
+        TypeOK == x \\in 0..1\n\
+        Spec == Init /\\ [][Next]_vars /\\ SF_vars(Stay) /\\ <>(x = 1)\n\
+        ====\n";
+    match run_inline("PureStutterStrongFair", module) {
+        CheckResult::LivenessViolation(_, _) => {}
+        other => panic!(
+            "<<Stay>>_vars is never enabled (Stay only stutters), so SF_vars(Stay) is vacuous \
+             and cannot force Move; <>(x=1) must be violated; got {other:?}"
+        ),
+    }
+}

--- a/tests/liveness_regressions.rs
+++ b/tests/liveness_regressions.rs
@@ -210,3 +210,49 @@ fn stable_eventually_violated_when_property_flips_forever() {
         ),
     }
 }
+
+// --- #63: weak/strong fairness is defined on <<A>>_v = A /\ vars' # vars, so a
+// stuttering step must never count as taking or enabling a fair action. ---
+
+#[test]
+fn weak_fairness_on_stutter_permitting_action_holds() {
+    let module = "---- MODULE StutterFair ----\n\
+        EXTENDS Naturals\n\
+        VARIABLE x\n\
+        vars == <<x>>\n\
+        Init == x = 0\n\
+        Grow == x < 3 /\\ x' \\in {x, x + 1}\n\
+        Next == Grow \\/ (x = 3 /\\ UNCHANGED x)\n\
+        TypeOK == x \\in 0..3\n\
+        Spec == Init /\\ [][Next]_vars /\\ WF_vars(Grow) /\\ <>(x = 3)\n\
+        ====\n";
+    match run_inline("StutterFair", module) {
+        CheckResult::Ok(_) => {}
+        other => panic!(
+            "WF on <<Grow>>_vars (the x+1 step) forces x -> 3; the x'=x stutter must not be \
+             counted as taking Grow, so <>(x=3) holds; got {other:?}"
+        ),
+    }
+}
+
+#[test]
+fn vacuous_fairness_on_pure_stutter_action_does_not_rescue_liveness() {
+    let module = "---- MODULE PureStutterFair ----\n\
+        EXTENDS Naturals\n\
+        VARIABLE x\n\
+        vars == <<x>>\n\
+        Init == x = 0\n\
+        Stay == x' = x\n\
+        Move == x = 0 /\\ x' = 1\n\
+        Next == Stay \\/ Move\n\
+        TypeOK == x \\in 0..1\n\
+        Spec == Init /\\ [][Next]_vars /\\ WF_vars(Stay) /\\ <>(x = 1)\n\
+        ====\n";
+    match run_inline("PureStutterFair", module) {
+        CheckResult::LivenessViolation(_, _) => {}
+        other => panic!(
+            "<<Stay>>_vars is never enabled (Stay only stutters), so WF_vars(Stay) is vacuous \
+             and cannot force Move; <>(x=1) must be violated; got {other:?}"
+        ),
+    }
+}


### PR DESCRIPTION
Fixes #63.

Weak/strong fairness is defined on `⟨A⟩_v ≡ A ∧ (vars' ≠ vars)`, but the checker treated a stuttering step as taking/enabling a fair action. When a fair action admitted a stutter (`A == x' ∈ {x, x+1}`), the `x'=x` self-loop was counted as "A taken", so a stutter-forever cycle was deemed fair and a spurious `liveness_violation` was reported for a property that actually holds.

## Proof the old behavior was wrong

`F1` and `F2` denote the **same TLA+ formula** (identical `[Next]_x`; `⟨Grow⟩_x == ⟨Inc⟩_x` so `WF_x(Grow) ≡ WF_x(Inc)`), yet pre-fix the checker disagreed — `F1` = violated, `F2` = holds. `F2`'s `holds` is provably correct (WF on the incrementing step forces `x→3`), so `F1`'s `violated` was a bug. Post-fix both hold.

## Fix (`src/liveness.rs`)

Both sides of the fairness check now ignore stuttering steps:
- **taken** (`scc_has_action_edge`): only edges with `target != source` (a real state change) count as taking the action.
- **enabled** (`scc_all_enabled` / `scc_any_enabled` via new `enables_nonstutter_step`): an action is "enabled" for fairness only when a state-changing successor satisfies it — i.e. `ENABLED ⟨A⟩_v`. This keeps weak fairness on a pure-stutter action correctly **vacuous** (rather than filtering out a genuine violation).

## Tests

- `weak_fairness_on_stutter_permitting_action_holds` — the `F1` case now holds.
- `vacuous_fairness_on_pure_stutter_action_does_not_rescue_liveness` — a pure-stutter `WF` is vacuous, so `<>(x=1)` is still correctly **violated** (guards the enabled-side against a false-ok regression).
- Full suite green (316 tests), clippy clean under `-D warnings`. No existing fairness test changed behavior.

Pre-existing bug (present before the implicit-stuttering work in #62); confirmed via a two-binary differential.
