### PR TITLE
extract a real cycle for liveness counterexamples (fixes #64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.10] - 2026-07-14
+
+### Fixed
+
+- Liveness counterexamples now report a real cycle whose steps are actual transitions, instead of the recurrent SCC's state-set rendered in an arbitrary order with fabricated `-->` arrows. The checker extracts an ordered cycle by following genuine edges back to a witnessing state (preferring real progress over the always-present stutter self-loop, and falling back to the minimal single-state cycle when stuttering is the only recurrence). The fairness check still runs over the full recurrent set, so detection is unchanged — only the displayed trace is now faithful. Fixes #64.
+
 ## [0.6.9] - 2026-07-14
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.6.9"
+version = "0.6.10"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1003,9 +1003,10 @@ fn check_liveness_properties(
                     _ => format!("<>{:?}", property),
                 };
                 let cycle_entry = cycle_indices.first().copied().unwrap_or(scc.states[0]);
+                let display_cycle = liveness::extract_display_cycle(&graph, &cycle_indices);
                 let violation = LivenessViolation {
                     prefix: graph.reconstruct_trace(cycle_entry),
-                    cycle: cycle_indices
+                    cycle: display_cycle
                         .iter()
                         .filter_map(|&idx| graph.get_state(idx).cloned())
                         .collect(),

--- a/src/liveness.rs
+++ b/src/liveness.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 
 use crate::ast::{Env, Expr, FairnessConstraint, State, Value};
@@ -199,6 +199,50 @@ fn eval_bool_at(
     }
 }
 
+pub fn extract_display_cycle(graph: &StateGraph, cycle_indices: &[usize]) -> Vec<usize> {
+    let Some(&entry) = cycle_indices.first() else {
+        return Vec::new();
+    };
+    let set: HashSet<usize> = cycle_indices.iter().copied().collect();
+
+    let mut pred: HashMap<usize, usize> = HashMap::new();
+    let mut visited: HashSet<usize> = HashSet::new();
+    let mut queue: VecDeque<usize> = VecDeque::new();
+    visited.insert(entry);
+    queue.push_back(entry);
+
+    let mut closing: Option<usize> = None;
+    'bfs: while let Some(u) = queue.pop_front() {
+        for edge in graph.successors(u) {
+            let v = edge.target;
+            if v == u || !set.contains(&v) {
+                continue;
+            }
+            if v == entry {
+                closing = Some(u);
+                break 'bfs;
+            }
+            if visited.insert(v) {
+                pred.insert(v, u);
+                queue.push_back(v);
+            }
+        }
+    }
+
+    match closing {
+        Some(mut cur) => {
+            let mut path = vec![cur];
+            while cur != entry {
+                cur = pred[&cur];
+                path.push(cur);
+            }
+            path.reverse();
+            path
+        }
+        None => vec![entry],
+    }
+}
+
 pub fn check_eventually(
     graph: &StateGraph,
     scc: &SCC,
@@ -251,10 +295,10 @@ pub fn check_stable_eventually(
         return Ok(Vec::new());
     }
 
-    for &state_idx in &scc.states {
+    for &witness in &scc.states {
         if eval_bool_at(
             graph,
-            state_idx,
+            witness,
             property,
             constants,
             defs,
@@ -262,7 +306,9 @@ pub fn check_stable_eventually(
             "liveness property",
         )? == Some(false)
         {
-            return Ok(vec![scc.states.clone()]);
+            let mut ordered = vec![witness];
+            ordered.extend(scc.states.iter().copied().filter(|&s| s != witness));
+            return Ok(vec![ordered]);
         }
     }
 

--- a/tests/liveness_regressions.rs
+++ b/tests/liveness_regressions.rs
@@ -1,7 +1,15 @@
 use std::path::{Path, PathBuf};
 
+use tla_checker::ast::{State, Value};
 use tla_checker::checker::{CheckResult, check};
 use tla_checker::load::prepare_from_path;
+
+fn x_of(state: &State) -> i64 {
+    match state.values.first() {
+        Some(Value::Int(n)) => *n,
+        other => panic!("expected an Int-valued x, got {other:?}"),
+    }
+}
 
 fn manifest_path(rel: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
@@ -297,5 +305,66 @@ fn vacuous_strong_fairness_on_pure_stutter_action_does_not_rescue_liveness() {
             "<<Stay>>_vars is never enabled (Stay only stutters), so SF_vars(Stay) is vacuous \
              and cannot force Move; <>(x=1) must be violated; got {other:?}"
         ),
+    }
+}
+
+// --- #64: the reported counterexample cycle must be a real cycle whose edges are
+// actual transitions, not the SCC state-set rendered with fabricated arrows. ---
+
+#[test]
+fn violation_cycle_uses_only_real_edges() {
+    let module = "---- MODULE CycleShape ----\n\
+        EXTENDS Naturals\n\
+        VARIABLE x\n\
+        vars == <<x>>\n\
+        Init == x = 0\n\
+        Next == (x = 0 /\\ x' = 1) \\/ (x = 1 /\\ x' = 2) \\/ (x = 2 /\\ x' = 0) \\/ (x = 0 /\\ x' = 0)\n\
+        TypeOK == x \\in 0..2\n\
+        Spec == Init /\\ [][Next]_vars /\\ <>[](x # 0)\n\
+        ====\n";
+    let is_edge = |a: i64, b: i64| matches!((a, b), (0, 1) | (1, 2) | (2, 0) | (0, 0));
+    match run_inline("CycleShape", module) {
+        CheckResult::LivenessViolation(v, _) => {
+            let xs: Vec<i64> = v.cycle.iter().map(x_of).collect();
+            assert!(!xs.is_empty(), "cycle must be non-empty");
+            assert!(
+                xs.contains(&0),
+                "cycle must pass through the not-P witness x=0, got {xs:?}"
+            );
+            for i in 0..xs.len() {
+                let a = xs[i];
+                let b = xs[(i + 1) % xs.len()];
+                assert!(
+                    is_edge(a, b),
+                    "cycle step {a} -> {b} is not a real transition; cycle was {xs:?}"
+                );
+            }
+        }
+        other => panic!("<>[](x # 0) must be violated; got {other:?}"),
+    }
+}
+
+#[test]
+fn stutter_only_recurrence_is_a_single_state_cycle() {
+    let module = "---- MODULE StutterWitness ----\n\
+        EXTENDS Naturals\n\
+        VARIABLE x\n\
+        vars == <<x>>\n\
+        Init == x = 0\n\
+        Rescue == x = 0 /\\ x' = 1\n\
+        Next == Rescue \\/ (x = 1 /\\ UNCHANGED x)\n\
+        TypeOK == x \\in 0..1\n\
+        Spec == Init /\\ [][Next]_vars /\\ <>(x = 1)\n\
+        ====\n";
+    match run_inline("StutterWitness", module) {
+        CheckResult::LivenessViolation(v, _) => {
+            let xs: Vec<i64> = v.cycle.iter().map(x_of).collect();
+            assert_eq!(
+                xs,
+                vec![0],
+                "the only recurrence is stuttering at x=0, so the cycle is that single state; got {xs:?}"
+            );
+        }
+        other => panic!("no fairness forces Rescue, so <>(x=1) must be violated; got {other:?}"),
     }
 }


### PR DESCRIPTION
Fixes #64.

> **Stacked on #65 (fixes #63).** This branch includes #63's fairness fix because the cycle extraction relies on reported violations being genuine. Review/merge #65 first; I'll rebase this onto `main` afterward so it becomes a clean single-commit diff.

Liveness counterexamples reported the entire recurrent SCC as the "cycle", rendered in Tarjan order with `-->` arrows that need not correspond to real transitions (e.g. `<>[](x#0)` over the 3-cycle `{0,1,2}` printed `x=2 -> x=1 -> x=0`, but the spec has no `2->1` or `1->0` edge).

## Fix

`extract_display_cycle` (`src/liveness.rs`) walks real edges from the witnessing entry state back to itself (BFS), returning an ordered cycle whose every step is an actual transition. It prefers a genuine progress cycle over the stutter self-loop that now sits on every state (from the implicit-stuttering work), and falls back to the minimal single-state cycle when stuttering is the only recurrence. `check_stable_eventually` now orders the witnessing `¬P` state first so the extracted cycle passes through it.

The fairness re-check still runs over the **full** recurrent set (`cycle_indices`), so detection is unchanged — only the displayed trace is now faithful.

## Before / after

```
<>[](x # 0)   \* SCC {0,1,2}, x=0 is ¬P
before:  Cycle (3 states):  x=2 -> x=1 -> x=0     (fabricated arrows)
after:   Cycle (3 states):  x=0 -> x=1 -> x=2     (real edges 0->1, 1->2, 2->0)
```

Genuine stutter witness (no fairness forcing progress) now collapses to the minimal cycle:

```
<>(x=1), Rescue unfair
after:   Cycle (1 states):  x=0
```

## Tests

- `violation_cycle_uses_only_real_edges` — asserts every step of the reported cycle (as a ring) is an actual transition; fails against the old fabricated-arrow output.
- `stutter_only_recurrence_is_a_single_state_cycle` — the minimal stutter fallback.
- Full suite green (318 tests), clippy clean under `-D warnings`. The existing `check_spec_leads_to_violation_cycle_contains_state_where_p_holds` still passes.
