### PR TITLE
add --version flag to tla and tla-mcp (fixes #67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.11] - 2026-07-15
+
+### Added
+
+- `tla` and `tla-mcp` now support `--version` (and `-V`), printing the package version and exiting 0. Previously neither binary could report its own version — `tla --version` failed with `unknown option: --version`, so verifying which build was installed (e.g. after a Homebrew upgrade) meant comparing the binary's SHA256 against the release asset. `tla --help` now lists the flag, and `tla-mcp` handles it before starting the stdio server. Fixes #67.
+
 ## [0.6.10] - 2026-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - `tla` and `tla-mcp` now support `--version` (and `-V`), printing the package version and exiting 0. Previously neither binary could report its own version — `tla --version` failed with `unknown option: --version`, so verifying which build was installed (e.g. after a Homebrew upgrade) meant comparing the binary's SHA256 against the release asset. `tla --help` now lists the flag, and `tla-mcp` handles it before starting the stdio server. Fixes #67.
 
+### Changed
+
+- `tla-mcp` now rejects an unrecognized option instead of ignoring it and starting the stdio server. Previously every argument except `--version`/`-V` fell through to the MCP handshake, so a typo like `tla-mcp --verison` produced no output and appeared to hang when run from a terminal (the server was waiting on stdin), while the same typo on `tla` exits 1 with `unknown option`. Both binaries now report an unknown option the same way. The version check is also anchored to the first argument, so a `--version` occurring elsewhere in the command line — including after a `--` separator — no longer suppresses the server. Positional arguments are still ignored.
+- `tla` no longer consumes an option as the value of a preceding value-taking flag. Previously `tla --symmetry --version` silently registered `--version` as a symmetry constant name and then failed with an unrelated `no spec file provided`, never printing the version; `--max-states`, `--max-depth`, `--count-satisfying`, `--config`, and every other flag taking a value accepted the following token just as blindly. A token starting with `-` is now always treated as an option, so the flag reports its own missing value (`--symmetry requires a constant name`) instead. Values that merely contain a leading minus, such as `-c start_val=-5`, are unaffected.
+
 ## [0.6.10] - 2026-07-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"

--- a/MCP.md
+++ b/MCP.md
@@ -57,6 +57,8 @@ cargo install --path . --bin tla-mcp
 }
 ```
 
+To check which build is registered, run `tla-mcp --version` (or `-V`) — it prints the version and exits instead of starting the server. Note this is a different flag from the install script's `--version` above, which pins the release to download.
+
 ## Tools
 
 All tools return a `schema_version: "1"` field — the contract is frozen at version 1 and will be bumped explicitly on breaking changes.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Constants accept integers (`42`), booleans (`TRUE`), strings (`"hello"`), sets (
 | `--explorable` | With `--export-html`: embed the wasm engine for in-browser state exploration |
 | `--json` | JSON output |
 | `-v` | Verbose output (depth breakdowns, etc.) |
+| `--version`, `-V` | Show version information |
 
 ## Documentation
 

--- a/src/bin/tla_mcp.rs
+++ b/src/bin/tla_mcp.rs
@@ -206,9 +206,18 @@ async fn wait_for_shutdown_signal() -> bool {
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    if std::env::args().any(|arg| arg == "--version" || arg == "-V") {
-        println!("tla-mcp {}", env!("CARGO_PKG_VERSION"));
-        return Ok(());
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.first().map(String::as_str) {
+        Some("--version" | "-V") => {
+            println!("tla-mcp {}", env!("CARGO_PKG_VERSION"));
+            return Ok(());
+        }
+        Some(arg) if arg.starts_with('-') => {
+            eprintln!("unknown option: {arg}");
+            eprintln!("Use --version to show version information");
+            std::process::exit(1);
+        }
+        _ => {}
     }
 
     request_parent_death_signal();

--- a/src/bin/tla_mcp.rs
+++ b/src/bin/tla_mcp.rs
@@ -206,6 +206,11 @@ async fn wait_for_shutdown_signal() -> bool {
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if std::env::args().any(|arg| arg == "--version" || arg == "-V") {
+        println!("tla-mcp {}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
     request_parent_death_signal();
 
     tokio::spawn(async {

--- a/src/main.rs
+++ b/src/main.rs
@@ -566,6 +566,10 @@ fn main() -> ExitCode {
                     return ExitCode::FAILURE;
                 }
             }
+            "--version" | "-V" => {
+                println!("tla {}", env!("CARGO_PKG_VERSION"));
+                return ExitCode::SUCCESS;
+            }
             "--help" | "-h" => {
                 println!("tla - TLA+ model checker");
                 println!();
@@ -623,6 +627,7 @@ fn main() -> ExitCode {
                     "  --explorable               With --export-html: embed the wasm engine for ad-hoc state exploration"
                 );
                 println!("  --interactive, -i          Interactive TUI exploration mode");
+                println!("  --version, -V              Show version information");
                 println!("  --help, -h                 Show this help");
                 println!();
                 println!("Scenario format:");

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,6 +282,10 @@ fn run_sweep(
     }
 }
 
+fn missing_value(args: &[String], i: usize) -> bool {
+    args.get(i).is_none_or(|arg| arg.starts_with('-'))
+}
+
 fn main() -> ExitCode {
     #[cfg(feature = "dhat")]
     let _profiler = dhat::Profiler::new_heap();
@@ -325,7 +329,7 @@ fn main() -> ExitCode {
         match args[i].as_str() {
             "--constant" | "-c" => {
                 i += 1;
-                if i >= args.len() {
+                if missing_value(&args, i) {
                     eprintln!("--constant requires NAME=VALUE");
                     return ExitCode::FAILURE;
                 }
@@ -357,7 +361,7 @@ fn main() -> ExitCode {
             }
             "--max-states" => {
                 i += 1;
-                if i >= args.len() {
+                if missing_value(&args, i) {
                     eprintln!("--max-states requires a value");
                     return ExitCode::FAILURE;
                 }
@@ -368,7 +372,7 @@ fn main() -> ExitCode {
             }
             "--max-depth" => {
                 i += 1;
-                if i >= args.len() {
+                if missing_value(&args, i) {
                     eprintln!("--max-depth requires a value");
                     return ExitCode::FAILURE;
                 }
@@ -379,7 +383,7 @@ fn main() -> ExitCode {
             }
             "--symmetry" | "-s" => {
                 i += 1;
-                if i >= args.len() {
+                if missing_value(&args, i) {
                     eprintln!("--symmetry requires a constant name");
                     return ExitCode::FAILURE;
                 }
@@ -389,7 +393,7 @@ fn main() -> ExitCode {
             #[cfg(not(target_arch = "wasm32"))]
             "--export-dot" => {
                 i += 1;
-                if i >= args.len() {
+                if missing_value(&args, i) {
                     eprintln!("--export-dot requires a filename");
                     return ExitCode::FAILURE;
                 }
@@ -397,7 +401,7 @@ fn main() -> ExitCode {
             }
             "--dot-mode" => {
                 i += 1;
-                if i >= args.len() {
+                if missing_value(&args, i) {
                     eprintln!("--dot-mode requires a mode (full, trace, clean, choices)");
                     return ExitCode::FAILURE;
                 }
@@ -434,7 +438,7 @@ fn main() -> ExitCode {
             }
             "--count-satisfying" | "--count" => {
                 i += 1;
-                if i >= args.len() {
+                if missing_value(&args, i) {
                     eprintln!("--count-satisfying requires a definition name");
                     return ExitCode::FAILURE;
                 }
@@ -442,7 +446,7 @@ fn main() -> ExitCode {
             }
             "--config" => {
                 i += 1;
-                if i >= args.len() {
+                if missing_value(&args, i) {
                     eprintln!("--config requires a path");
                     return ExitCode::FAILURE;
                 }
@@ -457,7 +461,7 @@ fn main() -> ExitCode {
             #[cfg(not(target_arch = "wasm32"))]
             "--trace-json" => {
                 i += 1;
-                if i >= args.len() {
+                if missing_value(&args, i) {
                     eprintln!("--trace-json requires a filename");
                     return ExitCode::FAILURE;
                 }
@@ -465,7 +469,7 @@ fn main() -> ExitCode {
             }
             "--scenario" => {
                 i += 1;
-                if i >= args.len() {
+                if missing_value(&args, i) {
                     eprintln!("--scenario requires a scenario string or @filename");
                     return ExitCode::FAILURE;
                 }
@@ -485,7 +489,7 @@ fn main() -> ExitCode {
             #[cfg(not(target_arch = "wasm32"))]
             "--present" => {
                 i += 1;
-                if i >= args.len() {
+                if missing_value(&args, i) {
                     eprintln!("--present requires a manifest file");
                     return ExitCode::FAILURE;
                 }
@@ -494,7 +498,7 @@ fn main() -> ExitCode {
             #[cfg(not(target_arch = "wasm32"))]
             "--export-md" => {
                 i += 1;
-                if i >= args.len() {
+                if missing_value(&args, i) {
                     eprintln!("--export-md requires an output file");
                     return ExitCode::FAILURE;
                 }
@@ -503,7 +507,7 @@ fn main() -> ExitCode {
             #[cfg(not(target_arch = "wasm32"))]
             "--export-html" => {
                 i += 1;
-                if i >= args.len() {
+                if missing_value(&args, i) {
                     eprintln!("--export-html requires an output file");
                     return ExitCode::FAILURE;
                 }
@@ -520,7 +524,7 @@ fn main() -> ExitCode {
             #[cfg(not(target_arch = "wasm32"))]
             "--save-counterexample" => {
                 i += 1;
-                if i >= args.len() {
+                if missing_value(&args, i) {
                     eprintln!("--save-counterexample requires a filename");
                     return ExitCode::FAILURE;
                 }
@@ -529,7 +533,7 @@ fn main() -> ExitCode {
             #[cfg(not(target_arch = "wasm32"))]
             "--replay" => {
                 i += 1;
-                if i >= args.len() {
+                if missing_value(&args, i) {
                     eprintln!("--replay requires a counterexample JSON file");
                     return ExitCode::FAILURE;
                 }
@@ -537,7 +541,7 @@ fn main() -> ExitCode {
             }
             "--sweep" => {
                 i += 1;
-                if i >= args.len() {
+                if missing_value(&args, i) {
                     eprintln!("--sweep requires NAME=VAL1;VAL2;VAL3");
                     return ExitCode::FAILURE;
                 }

--- a/tests/cli_version.rs
+++ b/tests/cli_version.rs
@@ -1,15 +1,19 @@
 use std::process::Command;
 
-fn run(bin: &str, flag: &str) -> (bool, String, String) {
+fn run_args(bin: &str, args: &[&str]) -> (bool, String, String) {
     let output = Command::new(bin)
-        .arg(flag)
+        .args(args)
         .output()
-        .unwrap_or_else(|e| panic!("failed to run {bin} {flag}: {e}"));
+        .unwrap_or_else(|e| panic!("failed to run {bin} {args:?}: {e}"));
     (
         output.status.success(),
         String::from_utf8_lossy(&output.stdout).trim().to_string(),
         String::from_utf8_lossy(&output.stderr).trim().to_string(),
     )
+}
+
+fn run(bin: &str, flag: &str) -> (bool, String, String) {
+    run_args(bin, &[flag])
 }
 
 #[test]
@@ -46,6 +50,30 @@ fn tla_mcp_rejects_an_unknown_option_instead_of_serving() {
         stderr.contains("unknown option: --verison"),
         "tla-mcp must name the rejected option rather than starting the stdio server; stderr:\n{stderr}"
     );
+}
+
+#[test]
+fn tla_does_not_swallow_a_flag_as_a_value_taking_flags_argument() {
+    for flag in [
+        "--symmetry",
+        "--max-states",
+        "--count-satisfying",
+        "--config",
+    ] {
+        let (ok, stdout, stderr) = run_args(env!("CARGO_BIN_EXE_tla"), &[flag, "--version"]);
+        assert!(
+            !ok,
+            "tla {flag} --version must not exit 0; stderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains(&format!("{flag} requires")),
+            "tla {flag} --version must report the missing value for {flag}; stderr:\n{stderr}"
+        );
+        assert!(
+            !stdout.contains(env!("CARGO_PKG_VERSION")),
+            "tla {flag} --version must not consume --version as a value; stdout:\n{stdout}"
+        );
+    }
 }
 
 #[test]

--- a/tests/cli_version.rs
+++ b/tests/cli_version.rs
@@ -1,6 +1,6 @@
 use std::process::Command;
 
-fn run(bin: &str, flag: &str) -> (bool, String) {
+fn run(bin: &str, flag: &str) -> (bool, String, String) {
     let output = Command::new(bin)
         .arg(flag)
         .output()
@@ -8,6 +8,7 @@ fn run(bin: &str, flag: &str) -> (bool, String) {
     (
         output.status.success(),
         String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        String::from_utf8_lossy(&output.stderr).trim().to_string(),
     )
 }
 
@@ -15,11 +16,11 @@ fn run(bin: &str, flag: &str) -> (bool, String) {
 fn tla_version_flags_print_package_version_and_exit_zero() {
     let expected = format!("tla {}", env!("CARGO_PKG_VERSION"));
     for flag in ["--version", "-V"] {
-        let (ok, stdout) = run(env!("CARGO_BIN_EXE_tla"), flag);
-        assert!(ok, "tla {flag} must exit 0");
+        let (ok, stdout, stderr) = run(env!("CARGO_BIN_EXE_tla"), flag);
+        assert!(ok, "tla {flag} must exit 0; stderr:\n{stderr}");
         assert_eq!(
             stdout, expected,
-            "tla {flag} must print the package version"
+            "tla {flag} must print the package version; stderr:\n{stderr}"
         );
     }
 }
@@ -28,19 +29,29 @@ fn tla_version_flags_print_package_version_and_exit_zero() {
 fn tla_mcp_version_flags_print_package_version_and_exit_zero() {
     let expected = format!("tla-mcp {}", env!("CARGO_PKG_VERSION"));
     for flag in ["--version", "-V"] {
-        let (ok, stdout) = run(env!("CARGO_BIN_EXE_tla-mcp"), flag);
-        assert!(ok, "tla-mcp {flag} must exit 0");
+        let (ok, stdout, stderr) = run(env!("CARGO_BIN_EXE_tla-mcp"), flag);
+        assert!(ok, "tla-mcp {flag} must exit 0; stderr:\n{stderr}");
         assert_eq!(
             stdout, expected,
-            "tla-mcp {flag} must print the package version instead of starting the stdio server"
+            "tla-mcp {flag} must print the package version instead of starting the stdio server; stderr:\n{stderr}"
         );
     }
 }
 
 #[test]
+fn tla_mcp_rejects_an_unknown_option_instead_of_serving() {
+    let (ok, _stdout, stderr) = run(env!("CARGO_BIN_EXE_tla-mcp"), "--verison");
+    assert!(!ok, "tla-mcp must reject an unknown option");
+    assert!(
+        stderr.contains("unknown option: --verison"),
+        "tla-mcp must name the rejected option rather than starting the stdio server; stderr:\n{stderr}"
+    );
+}
+
+#[test]
 fn tla_help_lists_the_version_flag() {
-    let (ok, stdout) = run(env!("CARGO_BIN_EXE_tla"), "--help");
-    assert!(ok, "tla --help must exit 0");
+    let (ok, stdout, stderr) = run(env!("CARGO_BIN_EXE_tla"), "--help");
+    assert!(ok, "tla --help must exit 0; stderr:\n{stderr}");
     assert!(
         stdout.contains("--version, -V"),
         "--help must advertise the version flag; got:\n{stdout}"

--- a/tests/cli_version.rs
+++ b/tests/cli_version.rs
@@ -1,0 +1,48 @@
+use std::process::Command;
+
+fn run(bin: &str, flag: &str) -> (bool, String) {
+    let output = Command::new(bin)
+        .arg(flag)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run {bin} {flag}: {e}"));
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).trim().to_string(),
+    )
+}
+
+#[test]
+fn tla_version_flags_print_package_version_and_exit_zero() {
+    let expected = format!("tla {}", env!("CARGO_PKG_VERSION"));
+    for flag in ["--version", "-V"] {
+        let (ok, stdout) = run(env!("CARGO_BIN_EXE_tla"), flag);
+        assert!(ok, "tla {flag} must exit 0");
+        assert_eq!(
+            stdout, expected,
+            "tla {flag} must print the package version"
+        );
+    }
+}
+
+#[test]
+fn tla_mcp_version_flags_print_package_version_and_exit_zero() {
+    let expected = format!("tla-mcp {}", env!("CARGO_PKG_VERSION"));
+    for flag in ["--version", "-V"] {
+        let (ok, stdout) = run(env!("CARGO_BIN_EXE_tla-mcp"), flag);
+        assert!(ok, "tla-mcp {flag} must exit 0");
+        assert_eq!(
+            stdout, expected,
+            "tla-mcp {flag} must print the package version instead of starting the stdio server"
+        );
+    }
+}
+
+#[test]
+fn tla_help_lists_the_version_flag() {
+    let (ok, stdout) = run(env!("CARGO_BIN_EXE_tla"), "--help");
+    assert!(ok, "tla --help must exit 0");
+    assert!(
+        stdout.contains("--version, -V"),
+        "--help must advertise the version flag; got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Fixes #67.

`tla --version` previously failed with `unknown option: --version`, so there was no way for a `tla`/`tla-mcp` binary to report its own version — verifying an installed build (e.g. after a Homebrew upgrade) required comparing the binary's SHA256 against the release asset.

## Change

- `tla` handles `--version` / `-V` before the unknown-option catch-all, printing `tla <version>` and exiting 0. Added to the `--help` listing.
- `tla-mcp` handles `--version` / `-V` at the top of `main`, before starting the stdio server, so it prints and exits instead of blocking on an MCP handshake.
- Both read `env!("CARGO_PKG_VERSION")`, so the reported version tracks `Cargo.toml`.

## Argument-handling fallout

Adding the first-ever flag to `tla-mcp` — and a flag whose whole job is to be typed by hand — surfaced two adjacent gaps. Both are fixed here rather than deferred, since each only became reachable because `--version` now exists:

- **`tla-mcp` rejected nothing.** Every argument except `--version`/`-V` fell through to the MCP handshake, so `tla-mcp --verison` produced no output and appeared to hang (the server was waiting on stdin), while the same typo on `tla` exits 1. Both binaries now report `unknown option: X` and exit 1. The version check is anchored to the first argument, so a `--version` after a `--` separator no longer suppresses the server. Positional arguments are still ignored.
- **`tla` swallowed options as flag values.** `tla --symmetry --version` silently registered `--version` as a symmetry constant name, then failed with an unrelated `no spec file provided`. All 16 value-taking flags shared the same blind `i += 1`; a token starting with `-` is now always treated as an option, so the flag reports its own missing value. Values containing a leading minus, such as `-c start_val=-5`, are unaffected.

## Docs

`--version` added to the README options table. MCP.md gains a line pointing at `tla-mcp --version` and distinguishing it from the install script's unrelated `--version` release-pin flag.

## Tests

`tests/cli_version.rs` drives the real binaries as subprocesses: both flags on both binaries print the expected string and exit 0, `--help` advertises the flag, `tla-mcp` rejects an unknown option, and four value-taking flags refuse to consume a following `--version`. The helper surfaces stderr on failure. Each new test was verified to fail against the unfixed code first. Full suite green (325 tests), fmt + clippy `-D warnings` clean.

Note: `Cargo.toml` documents a past `--release` link failure for `tla-mcp` under `lto = "fat"` with a `cdylib` crate-type; that no longer applies (crate-type is now `["rlib"]`), and the tests pass in both debug and release.

Version bumped 0.6.10 -> 0.6.11 with CHANGELOG entries.
