### PR TITLE
continuation-passing walker as the default state-generation engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.8.0] - 2026-08-13
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- A variable that an action leaves unassigned is now a reported error naming the variable and the action, matching TLC ("The variable x was not assigned a value"). Previously such a successor was silently dropped: `Next == (x' = 1 - x) \/ UNCHANGED <<x, y>>` where the first disjunct forgets `y'` explored only the stutters of the second disjunct and reported a clean run, hiding that the intended action is malformed — a false pass. Pass `--allow-unassigned-stutter` to recover the old lenient behaviour, which treats an unassigned variable as an implicit `UNCHANGED` of that variable.
+
+### Added
+
+- `--allow-unassigned-stutter` treats a variable an action leaves unassigned as `UNCHANGED` instead of raising an error.
+
 ## [0.7.0] - 2026-08-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@
 
 - Conjuncts of an `Init` or next-state predicate are now evaluated in order, so a guard that reads a variable before the conjunct that assigns it is an error, matching TLC ("the identifier x is undefined"). `Init == x > 0 /\ x \in 1..3` must be written `x \in 1..3 /\ x > 0`. The previous candidate-inference engine was order-insensitive and accepted the guard-first form; specs that relied on that now report the undefined variable instead. Writing the assignment (`x = e` / `x \in S`, or a primed assignment in `Next`) before any guard that reads the variable works unchanged.
 
+- Operator definition bodies are shared via `Arc`, so resolving a parameterized `LET` or an instance operator no longer deep-clones the whole definition map per call — an ~18-42x speedup on specs with a large definition set and many such calls per state.
+
+### Fixed
+
+- A `LET`-local definition now shadows a same-named top-level operator, as TLA+ lexical scoping requires. `LET G(n) == 0 IN G(x)` with a top-level `G(n) == 1000` previously used the top-level `1000` on both engines — the parser inlined operator applications from the top-level definitions without tracking `LET` scope, a silent wrong result (spurious violation or false pass). The zero-argument form (`LET c == 0` over a top-level `c`) was affected too.
+
+- A parameterized `LET` operator (`LET F(x) == body IN ... F(...)`) now resolves. The parser encoded it as a marker that no evaluator consumed, so both engines errored with an undefined variable. It resolves in invariants and guards on both engines; the walker additionally enumerates it in a next-state assignment (`x' = F(x)`), which the inference engine cannot.
+
+- Substitution is capture-avoiding. Substituting an argument whose name collides with a bound variable inside the target (`Op(c)` where the body binds `c`, as in `{c \in S : c # author}`) no longer captures it into `c # c`. This affected operator inlining in the walker and `WITH` substitutions in module instantiation; a bound variable is now alpha-renamed when a replacement would capture it.
+
+- An equality between two primed variables assigns whichever side is unbound. `x' = 1 /\ x' = y'` binds `y' := 1` and reaches the successor instead of evaluating the still-unbound `y'` as a constraint and aborting.
+
+- An indexed next-state constraint whose index is outside the value's domain — `f' = g /\ f'[k] = v` with `k` not in `DOMAIN g` — is reported as an out-of-domain access, not silently pruned as an unsatisfiable constraint.
+
 ### Added
 
 - `--allow-unassigned-stutter` treats a variable an action leaves unassigned as `UNCHANGED` instead of raising an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Changed
 
+- State generation now uses a continuation-passing walker over the next-state relation, replacing the candidate-inference engine. The old engine inferred a set of candidate values per primed variable and filtered their cross product, which can only ever *reject* a successor — so any shortfall in the inference produced too few successors and a silent false pass. Concretely, the walker reaches successors the old engine dropped: a primed variable whose value depends on another primed variable (`a' \in S /\ b' = a' + 10`), on an operator argument, or on an `IF`/`CASE`; initial states reached only through `\E`/`IF`/`LET`; and it attributes every transition to the action that produced it, including actions quantified as `\E rm \in RM : A(rm) \/ B(rm)` (the old engine could reach these states but is needed for fairness/liveness to know which action fired). On the corpus the walker also runs faster (TwoPhase 5RM ~0.35s vs ~0.54s). Pass `TLA_ENGINE=inference` to select the previous engine for one release; it will be removed after that.
+
 - A variable that an action leaves unassigned is now a reported error naming the variable and the action, matching TLC ("The variable x was not assigned a value"). Previously such a successor was silently dropped: `Next == (x' = 1 - x) \/ UNCHANGED <<x, y>>` where the first disjunct forgets `y'` explored only the stutters of the second disjunct and reported a clean run, hiding that the intended action is malformed — a false pass. Pass `--allow-unassigned-stutter` to recover the old lenient behaviour, which treats an unassigned variable as an implicit `UNCHANGED` of that variable.
 
 ### Added
 
 - `--allow-unassigned-stutter` treats a variable an action leaves unassigned as `UNCHANGED` instead of raising an error.
+
+- `TLA_ENGINE=inference` selects the previous candidate-inference engine for one release.
 
 ## [0.7.0] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - A variable that an action leaves unassigned is now a reported error naming the variable and the action, matching TLC ("The variable x was not assigned a value"). Previously such a successor was silently dropped: `Next == (x' = 1 - x) \/ UNCHANGED <<x, y>>` where the first disjunct forgets `y'` explored only the stutters of the second disjunct and reported a clean run, hiding that the intended action is malformed — a false pass. Pass `--allow-unassigned-stutter` to recover the old lenient behaviour, which treats an unassigned variable as an implicit `UNCHANGED` of that variable.
 
+- Conjuncts of an `Init` or next-state predicate are now evaluated in order, so a guard that reads a variable before the conjunct that assigns it is an error, matching TLC ("the identifier x is undefined"). `Init == x > 0 /\ x \in 1..3` must be written `x \in 1..3 /\ x > 0`. The previous candidate-inference engine was order-insensitive and accepted the guard-first form; specs that relied on that now report the undefined variable instead. Writing the assignment (`x = e` / `x \in S`, or a primed assignment in `Next`) before any guard that reads the variable works unchanged.
+
 ### Added
 
 - `--allow-unassigned-stutter` treats a variable an action leaves unassigned as `UNCHANGED` instead of raising an error.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -361,11 +361,13 @@ pub struct Transition {
     pub action: Option<Arc<str>>,
 }
 
+pub type DefinitionMap = BTreeMap<Arc<str>, (Vec<Arc<str>>, Arc<Expr>)>;
+
 pub struct Spec {
     pub vars: Vec<Arc<str>>,
     pub constants: Vec<Arc<str>>,
     pub extends: Vec<Arc<str>>,
-    pub definitions: BTreeMap<Arc<str>, (Vec<Arc<str>>, Expr)>,
+    pub definitions: DefinitionMap,
     pub assumes: Vec<Expr>,
     pub instances: Vec<InstanceDecl>,
     pub init: Option<Expr>,

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -49,6 +49,7 @@ pub struct CheckerConfig {
     pub trace_json_path: Option<PathBuf>,
     pub state_constraints: Vec<Expr>,
     pub allow_unassigned_stutter: bool,
+    pub use_inference_engine: bool,
 }
 
 impl Default for CheckerConfig {
@@ -75,6 +76,7 @@ impl Default for CheckerConfig {
             trace_json_path: None,
             state_constraints: Vec::new(),
             allow_unassigned_stutter: false,
+            use_inference_engine: false,
         }
     }
 }
@@ -339,6 +341,7 @@ pub fn prepare_spec(
 }
 
 pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult {
+    crate::eval::set_use_inference_engine(config.use_inference_engine);
     crate::eval::set_allow_unassigned_stutter(config.allow_unassigned_stutter);
     #[cfg(not(target_arch = "wasm32"))]
     let prep = prepare_spec(spec, domains, config.spec_path.as_ref(), config.quiet);

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -499,7 +499,7 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
         .count_properties
         .iter()
         .filter_map(|name| match defs.get(name) {
-            Some((params, expr)) if params.is_empty() => Some((name.clone(), expr.clone())),
+            Some((params, expr)) if params.is_empty() => Some((name.clone(), (**expr).clone())),
             Some(_) => {
                 if !config.quiet {
                     eprintln!("  Warning: '{}' has parameters, skipping", name);
@@ -2014,7 +2014,7 @@ mod tests {
             extends: vec![],
             definitions: BTreeMap::from([(
                 Arc::from("Action"),
-                (vec![], eq(prime_expr("x"), var_expr("x"))),
+                (vec![], Arc::new(eq(prime_expr("x"), var_expr("x")))),
             )]),
             assumes: vec![],
             instances: vec![],
@@ -2054,10 +2054,10 @@ mod tests {
                 Arc::from("Action"),
                 (
                     vec![],
-                    and(
+                    Arc::new(and(
                         eq(var_expr("x"), lit_int(0)),
                         eq(prime_expr("x"), lit_int(1)),
-                    ),
+                    )),
                 ),
             )]),
             assumes: vec![],

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -48,6 +48,7 @@ pub struct CheckerConfig {
     #[cfg(not(target_arch = "wasm32"))]
     pub trace_json_path: Option<PathBuf>,
     pub state_constraints: Vec<Expr>,
+    pub allow_unassigned_stutter: bool,
 }
 
 impl Default for CheckerConfig {
@@ -73,6 +74,7 @@ impl Default for CheckerConfig {
             #[cfg(not(target_arch = "wasm32"))]
             trace_json_path: None,
             state_constraints: Vec::new(),
+            allow_unassigned_stutter: false,
         }
     }
 }
@@ -337,6 +339,7 @@ pub fn prepare_spec(
 }
 
 pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult {
+    crate::eval::set_allow_unassigned_stutter(config.allow_unassigned_stutter);
     #[cfg(not(target_arch = "wasm32"))]
     let prep = prepare_spec(spec, domains, config.spec_path.as_ref(), config.quiet);
     #[cfg(target_arch = "wasm32")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -265,11 +265,7 @@ fn collect_model_values(val: &Value, out: &mut Vec<Arc<str>>) {
     }
 }
 
-pub fn bind_model_value_names(
-    domains: &mut Env,
-    spec: &Spec,
-    defs: &BTreeMap<Arc<str>, (Vec<Arc<str>>, Expr)>,
-) {
+pub fn bind_model_value_names(domains: &mut Env, spec: &Spec, defs: &crate::ast::DefinitionMap) {
     let mut names = Vec::new();
     for (_, val) in domains.iter() {
         collect_model_values(val, &mut names);
@@ -653,7 +649,7 @@ pub fn apply_config(
     if let Some(ref init_name) = cfg.init {
         match spec.definitions.get(init_name.as_ref()) {
             Some((params, expr)) if params.is_empty() => {
-                spec.init = Some(expr.clone());
+                spec.init = Some((**expr).clone());
             }
             Some(_) => {
                 return Err(format!(
@@ -670,7 +666,7 @@ pub fn apply_config(
     if let Some(ref next_name) = cfg.next {
         match spec.definitions.get(next_name.as_ref()) {
             Some((params, expr)) if params.is_empty() => {
-                spec.next = Some(expr.clone());
+                spec.next = Some((**expr).clone());
             }
             Some(_) => {
                 return Err(format!(
@@ -695,7 +691,7 @@ pub fn apply_config(
         for inv_name in &cfg.invariants {
             match spec.definitions.get(inv_name.as_ref()) {
                 Some((params, expr)) if params.is_empty() => {
-                    new_invariants.push(expr.clone());
+                    new_invariants.push((**expr).clone());
                     new_names.push(Some(inv_name.clone()));
                 }
                 Some(_) => {
@@ -720,7 +716,7 @@ pub fn apply_config(
         for prop_name in &cfg.properties {
             match spec.definitions.get(prop_name.as_ref()) {
                 Some((params, expr)) if params.is_empty() => {
-                    let expr = expr.clone();
+                    let expr = (**expr).clone();
                     if crate::ast::expr_contains_temporal(&expr) {
                         if !parser_pre_extracts_temporal(prop_name) {
                             warnings.extend(spec.extract_fairness_and_liveness(&expr));
@@ -750,15 +746,15 @@ pub fn apply_config(
         && cli_symmetry.is_empty()
     {
         if let Some((_params, expr)) = spec.definitions.get(sym_name.as_ref()) {
-            if let Expr::FnCall(const_name, _) = expr {
+            if let Expr::FnCall(const_name, _) = expr.as_ref() {
                 checker_config.symmetric_constants.push(const_name.clone());
-            } else if let Expr::Permutations(inner) = expr {
+            } else if let Expr::Permutations(inner) = expr.as_ref() {
                 if let Expr::Var(const_name) = inner.as_ref() {
                     checker_config.symmetric_constants.push(const_name.clone());
                 } else {
                     checker_config.symmetric_constants.push(sym_name.clone());
                 }
-            } else if let Expr::Var(const_name) = expr {
+            } else if let Expr::Var(const_name) = expr.as_ref() {
                 checker_config.symmetric_constants.push(const_name.clone());
             } else {
                 checker_config.symmetric_constants.push(sym_name.clone());
@@ -777,7 +773,7 @@ pub fn apply_config(
     for c in &cfg.constraints {
         match spec.definitions.get(c.as_ref()) {
             Some((params, expr)) if params.is_empty() => {
-                checker_config.state_constraints.push(expr.clone());
+                checker_config.state_constraints.push((**expr).clone());
             }
             Some(_) => {
                 return Err(format!(
@@ -1250,7 +1246,7 @@ mod tests {
             Arc::from("Perms"),
             (
                 vec![],
-                Expr::Permutations(Box::new(Expr::Var(Arc::from("RM")))),
+                Expr::Permutations(Box::new(Expr::Var(Arc::from("RM")))).into(),
             ),
         );
 
@@ -1296,7 +1292,7 @@ mod tests {
         );
         spec.definitions.insert(
             Arc::from("Eventually1"),
-            (vec![], Expr::Eventually(Box::new(inner.clone()))),
+            (vec![], Expr::Eventually(Box::new(inner.clone())).into()),
         );
 
         let cfg = parse_cfg("PROPERTY Eventually1").unwrap();
@@ -1350,7 +1346,7 @@ mod tests {
         ));
         spec.definitions.insert(
             Arc::from("Leads"),
-            (vec![], Expr::LeadsTo(p.clone(), q.clone())),
+            (vec![], Expr::LeadsTo(p.clone(), q.clone()).into()),
         );
 
         let cfg = parse_cfg("PROPERTY Leads").unwrap();
@@ -1397,7 +1393,7 @@ mod tests {
             Box::new(Expr::BoxAction(Box::new(next_expr.clone()), Arc::from("x"))),
         );
         spec.definitions
-            .insert(Arc::from("Spec"), (vec![], spec_body));
+            .insert(Arc::from("Spec"), (vec![], spec_body.into()));
 
         let cfg = parse_cfg("SPECIFICATION Spec").unwrap();
         let mut domains = Env::new();
@@ -1462,7 +1458,7 @@ mod tests {
             )),
         );
         spec.definitions
-            .insert(Arc::from("Spec"), (vec![], spec_body));
+            .insert(Arc::from("Spec"), (vec![], spec_body.into()));
 
         let cfg = parse_cfg("SPECIFICATION Spec").unwrap();
         let mut domains = Env::new();
@@ -1502,8 +1498,10 @@ mod tests {
             constants: vec![],
         };
 
-        spec.definitions
-            .insert(Arc::from("Spec"), (vec![], Expr::Var(Arc::from("Init"))));
+        spec.definitions.insert(
+            Arc::from("Spec"),
+            (vec![], Expr::Var(Arc::from("Init")).into()),
+        );
 
         let cfg = parse_cfg("SPECIFICATION Spec").unwrap();
         let mut domains = Env::new();

--- a/src/eval/ast_utils.rs
+++ b/src/eval/ast_utils.rs
@@ -292,7 +292,13 @@ fn contains_prime_ref_impl(
                         if let Some(instance_defs) = instances.get(instance_name)
                             && let Some((_, body)) = instance_defs.get(op)
                         {
-                            return contains_prime_ref_impl(body, defs, visited);
+                            let marker: Arc<str> = Arc::from(format!("{instance_name}!{op}"));
+                            if !visited.insert(marker.clone()) {
+                                return true;
+                            }
+                            let result = contains_prime_ref_impl(body, defs, visited);
+                            visited.remove(&marker);
+                            return result;
                         }
                         true
                     })

--- a/src/eval/ast_utils.rs
+++ b/src/eval/ast_utils.rs
@@ -72,7 +72,7 @@ pub(crate) fn parameterized_let_op(binding: &Expr) -> Option<(Vec<Arc<str>>, &Ex
 
 fn match_def_body(expr: &Expr, defs: &Definitions) -> Option<Arc<str>> {
     for (name, (params, body)) in defs {
-        if params.is_empty() && body == expr {
+        if params.is_empty() && body.as_ref() == expr {
             return Some(name.clone());
         }
     }
@@ -100,7 +100,7 @@ pub(crate) fn infer_name_from_let_chain(expr: &Expr, defs: &Definitions) -> Opti
         depth += 1;
     }
     for (name, (params, body)) in defs {
-        if params.len() == depth && body == inner {
+        if params.len() == depth && body.as_ref() == inner {
             return Some(name.clone());
         }
     }
@@ -496,7 +496,7 @@ mod prime_ref_tests {
             .map(|(n, ps, body)| {
                 (
                     Arc::from(n),
-                    (ps.into_iter().map(Arc::from).collect(), body),
+                    (ps.into_iter().map(Arc::from).collect(), Arc::new(body)),
                 )
             })
             .collect()

--- a/src/eval/ast_utils.rs
+++ b/src/eval/ast_utils.rs
@@ -147,7 +147,7 @@ fn contains_prime_ref_impl(
         Expr::Var(name) => match defs.get(name) {
             Some((params, body)) if params.is_empty() => {
                 if !visited.insert(name.clone()) {
-                    return true;
+                    return false;
                 }
                 let result = contains_prime_ref_impl(body, defs, visited);
                 visited.remove(name);
@@ -278,7 +278,7 @@ fn contains_prime_ref_impl(
             match defs.get(name) {
                 Some((_, body)) => {
                     if !visited.insert(name.clone()) {
-                        return true;
+                        return false;
                     }
                     let result = contains_prime_ref_impl(body, defs, visited);
                     visited.remove(name);
@@ -304,7 +304,7 @@ fn contains_prime_ref_impl(
                         {
                             let marker: Arc<str> = Arc::from(format!("{instance_name}!{op}"));
                             if !visited.insert(marker.clone()) {
-                                return true;
+                                return false;
                             }
                             let result = contains_prime_ref_impl(body, defs, visited);
                             visited.remove(&marker);

--- a/src/eval/ast_utils.rs
+++ b/src/eval/ast_utils.rs
@@ -50,6 +50,26 @@ pub(crate) fn format_expr_brief(expr: &Expr) -> String {
     }
 }
 
+/// A parameterized `LET F(p1, ..) == body` operator, which the parser encodes as
+/// `Let("_params", TupleLit([p1, ..]), body)`. Returns its parameter names and
+/// body so a caller can register it as a definition; `None` for a plain LET value.
+pub(crate) fn parameterized_let_op(binding: &Expr) -> Option<(Vec<Arc<str>>, &Expr)> {
+    if let Expr::Let(marker, params_tuple, body) = binding
+        && marker.as_ref() == "_params"
+        && let Expr::TupleLit(param_exprs) = params_tuple.as_ref()
+    {
+        let params: Option<Vec<Arc<str>>> = param_exprs
+            .iter()
+            .map(|e| match e {
+                Expr::Var(n) => Some(n.clone()),
+                _ => None,
+            })
+            .collect();
+        return params.map(|p| (p, body.as_ref()));
+    }
+    None
+}
+
 fn match_def_body(expr: &Expr, defs: &Definitions) -> Option<Arc<str>> {
     for (name, (params, body)) in defs {
         if params.is_empty() && body == expr {

--- a/src/eval/ast_utils.rs
+++ b/src/eval/ast_utils.rs
@@ -239,32 +239,55 @@ fn contains_prime_ref_impl(
                 })
         }
         Expr::FnCall(name, args) => {
-            if let Some((_, body)) = defs.get(name) {
-                if visited.contains(name) {
-                    return false;
+            // Arguments are evaluated in the caller's scope, so a prime in an
+            // argument is a real reference regardless of the operator body.
+            if args
+                .iter()
+                .any(|a| contains_prime_ref_impl(a, defs, visited))
+            {
+                return true;
+            }
+            match defs.get(name) {
+                Some((_, body)) => {
+                    if !visited.insert(name.clone()) {
+                        // Already on the current resolution path: a recursive
+                        // definition we cannot fully inspect here. Over-approximate.
+                        return true;
+                    }
+                    let result = contains_prime_ref_impl(body, defs, visited);
+                    visited.remove(name);
+                    result
                 }
-                visited.insert(name.clone());
-                contains_prime_ref_impl(body, defs, visited)
-            } else {
-                args.iter()
-                    .any(|a| contains_prime_ref_impl(a, defs, visited))
+                // Unresolved operator: its body cannot be inspected, so assume
+                // it may reference a prime. Over-approximation is the only safe
+                // direction — every caller uses this to decide whether to do
+                // MORE work (collect candidates, refine), never less.
+                None => true,
             }
         }
-        Expr::QualifiedCall(instance_expr, op, _) => match instance_expr.as_ref() {
-            Expr::Var(instance_name) => {
-                use super::global_state::RESOLVED_INSTANCES;
-                RESOLVED_INSTANCES.with(|inst_ref| {
-                    let instances = inst_ref.borrow();
-                    if let Some(instance_defs) = instances.get(instance_name)
-                        && let Some((_, body)) = instance_defs.get(op)
-                    {
-                        return contains_prime_ref_impl(body, defs, visited);
-                    }
-                    true
-                })
+        Expr::QualifiedCall(instance_expr, op, args) => {
+            if args
+                .iter()
+                .any(|a| contains_prime_ref_impl(a, defs, visited))
+            {
+                return true;
             }
-            _ => true,
-        },
+            match instance_expr.as_ref() {
+                Expr::Var(instance_name) => {
+                    use super::global_state::RESOLVED_INSTANCES;
+                    RESOLVED_INSTANCES.with(|inst_ref| {
+                        let instances = inst_ref.borrow();
+                        if let Some(instance_defs) = instances.get(instance_name)
+                            && let Some((_, body)) = instance_defs.get(op)
+                        {
+                            return contains_prime_ref_impl(body, defs, visited);
+                        }
+                        true
+                    })
+                }
+                _ => true,
+            }
+        }
         Expr::Lambda(_, body) => contains_prime_ref_impl(body, defs, visited),
         Expr::Let(_, binding, body) => {
             contains_prime_ref_impl(binding, defs, visited)
@@ -420,5 +443,94 @@ pub(crate) fn expr_references(expr: &Expr, name: &Arc<str>) -> bool {
         | Expr::StrongFairness(_, e)
         | Expr::BoxAction(e, _)
         | Expr::DiamondAction(e, _) => expr_references(e, name),
+    }
+}
+
+#[cfg(test)]
+mod prime_ref_tests {
+    use super::contains_prime_ref;
+    use crate::ast::{Expr, Value};
+    use crate::eval::Definitions;
+    use std::sync::Arc;
+
+    fn v(name: &str) -> Expr {
+        Expr::Var(Arc::from(name))
+    }
+    fn prime(name: &str) -> Expr {
+        Expr::Prime(Arc::from(name))
+    }
+    fn call(name: &str, args: Vec<Expr>) -> Expr {
+        Expr::FnCall(Arc::from(name), args)
+    }
+    fn defs(entries: Vec<(&str, Vec<&str>, Expr)>) -> Definitions {
+        entries
+            .into_iter()
+            .map(|(n, ps, body)| {
+                (
+                    Arc::from(n),
+                    (ps.into_iter().map(Arc::from).collect(), body),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn operator_applied_to_a_prime_argument_has_a_prime() {
+        // IsTwice(a) == a = 0  — a prime-free body, but the argument is primed.
+        // The prime is at the call site, so the reference is real.
+        let d = defs(vec![(
+            "IsTwice",
+            vec!["a"],
+            Expr::Eq(Box::new(v("a")), Box::new(Expr::Lit(Value::Int(0)))),
+        )]);
+        assert!(contains_prime_ref(&call("IsTwice", vec![prime("y")]), &d));
+    }
+
+    #[test]
+    fn operator_applied_to_nonprime_arguments_is_prime_free() {
+        let d = defs(vec![(
+            "IsTwice",
+            vec!["a"],
+            Expr::Eq(Box::new(v("a")), Box::new(Expr::Lit(Value::Int(0)))),
+        )]);
+        assert!(!contains_prime_ref(
+            &call("IsTwice", vec![Expr::Lit(Value::Int(1))]),
+            &d
+        ));
+    }
+
+    #[test]
+    fn operator_with_a_primed_body_has_a_prime() {
+        let d = defs(vec![("UsesPrime", vec![], prime("x"))]);
+        assert!(contains_prime_ref(&call("UsesPrime", vec![]), &d));
+    }
+
+    #[test]
+    fn a_recursive_operator_applied_to_a_prime_has_a_prime() {
+        // Sum(n) == IF n = 0 THEN 0 ELSE Sum(n)  — self-referential; the cycle
+        // must not swallow the primed argument.
+        let d = defs(vec![(
+            "Sum",
+            vec!["n"],
+            Expr::If(
+                Box::new(Expr::Eq(
+                    Box::new(v("n")),
+                    Box::new(Expr::Lit(Value::Int(0))),
+                )),
+                Box::new(Expr::Lit(Value::Int(0))),
+                Box::new(call("Sum", vec![v("n")])),
+            ),
+        )]);
+        assert!(contains_prime_ref(&call("Sum", vec![prime("x")]), &d));
+    }
+
+    #[test]
+    fn an_unresolved_operator_is_over_approximated() {
+        // No definition for `Mystery`; its body cannot be inspected, so it must
+        // be assumed to reference a prime.
+        assert!(contains_prime_ref(
+            &call("Mystery", vec![Expr::Lit(Value::Int(1))]),
+            &Definitions::new()
+        ));
     }
 }

--- a/src/eval/ast_utils.rs
+++ b/src/eval/ast_utils.rs
@@ -124,8 +124,6 @@ fn contains_prime_ref_impl(
 ) -> bool {
     match expr {
         Expr::Prime(_) | Expr::Unchanged(_) => true,
-        // A bare name may be a zero-argument operator whose body references a
-        // prime (e.g. `Act == x' = 1`). Resolve it; over-approximate on a cycle.
         Expr::Var(name) => match defs.get(name) {
             Some((params, body)) if params.is_empty() => {
                 if !visited.insert(name.clone()) {
@@ -251,8 +249,6 @@ fn contains_prime_ref_impl(
                 })
         }
         Expr::FnCall(name, args) => {
-            // Arguments are evaluated in the caller's scope, so a prime in an
-            // argument is a real reference regardless of the operator body.
             if args
                 .iter()
                 .any(|a| contains_prime_ref_impl(a, defs, visited))
@@ -262,18 +258,12 @@ fn contains_prime_ref_impl(
             match defs.get(name) {
                 Some((_, body)) => {
                     if !visited.insert(name.clone()) {
-                        // Already on the current resolution path: a recursive
-                        // definition we cannot fully inspect here. Over-approximate.
                         return true;
                     }
                     let result = contains_prime_ref_impl(body, defs, visited);
                     visited.remove(name);
                     result
                 }
-                // Unresolved operator: its body cannot be inspected, so assume
-                // it may reference a prime. Over-approximation is the only safe
-                // direction — every caller uses this to decide whether to do
-                // MORE work (collect candidates, refine), never less.
                 None => true,
             }
         }
@@ -494,8 +484,6 @@ mod prime_ref_tests {
 
     #[test]
     fn operator_applied_to_a_prime_argument_has_a_prime() {
-        // IsTwice(a) == a = 0  — a prime-free body, but the argument is primed.
-        // The prime is at the call site, so the reference is real.
         let d = defs(vec![(
             "IsTwice",
             vec!["a"],
@@ -525,8 +513,6 @@ mod prime_ref_tests {
 
     #[test]
     fn a_recursive_operator_applied_to_a_prime_has_a_prime() {
-        // Sum(n) == IF n = 0 THEN 0 ELSE Sum(n)  — self-referential; the cycle
-        // must not swallow the primed argument.
         let d = defs(vec![(
             "Sum",
             vec!["n"],
@@ -544,8 +530,6 @@ mod prime_ref_tests {
 
     #[test]
     fn an_unresolved_operator_is_over_approximated() {
-        // No definition for `Mystery`; its body cannot be inspected, so it must
-        // be assumed to reference a prime.
         assert!(contains_prime_ref(
             &call("Mystery", vec![Expr::Lit(Value::Int(1))]),
             &Definitions::new()

--- a/src/eval/ast_utils.rs
+++ b/src/eval/ast_utils.rs
@@ -124,8 +124,20 @@ fn contains_prime_ref_impl(
 ) -> bool {
     match expr {
         Expr::Prime(_) | Expr::Unchanged(_) => true,
-        Expr::Var(_)
-        | Expr::Lit(_)
+        // A bare name may be a zero-argument operator whose body references a
+        // prime (e.g. `Act == x' = 1`). Resolve it; over-approximate on a cycle.
+        Expr::Var(name) => match defs.get(name) {
+            Some((params, body)) if params.is_empty() => {
+                if !visited.insert(name.clone()) {
+                    return true;
+                }
+                let result = contains_prime_ref_impl(body, defs, visited);
+                visited.remove(name);
+                result
+            }
+            _ => false,
+        },
+        Expr::Lit(_)
         | Expr::OldValue
         | Expr::Any
         | Expr::EmptyBag

--- a/src/eval/core.rs
+++ b/src/eval/core.rs
@@ -1342,6 +1342,11 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
         }
 
         Expr::Let(var, binding, body) => {
+            if let Some((params, op_body)) = super::ast_utils::parameterized_let_op(binding) {
+                let mut local_defs = defs.clone();
+                local_defs.insert(var.clone(), (params, op_body.clone()));
+                return eval(body, env, &local_defs);
+            }
             if let Expr::FnDef(param, domain_expr, fn_body) = binding.as_ref() {
                 let mut local_defs = defs.clone();
                 local_defs.insert(var.clone(), (vec![], (**binding).clone()));

--- a/src/eval/core.rs
+++ b/src/eval/core.rs
@@ -29,7 +29,7 @@ pub(crate) fn expand_unchanged_vars(vars: &[Arc<str>], defs: &Definitions) -> Ve
     for var in vars {
         if let Some((params, body)) = defs.get(var)
             && params.is_empty()
-            && let Expr::TupleLit(elems) = body
+            && let Expr::TupleLit(elems) = body.as_ref()
             && elems.iter().all(|e| matches!(e, Expr::Var(_)))
         {
             for elem in elems {
@@ -1344,12 +1344,12 @@ fn eval_inner(expr: &Expr, env: &mut Env, defs: &Definitions) -> Result<Value> {
         Expr::Let(var, binding, body) => {
             if let Some((params, op_body)) = super::ast_utils::parameterized_let_op(binding) {
                 let mut local_defs = defs.clone();
-                local_defs.insert(var.clone(), (params, op_body.clone()));
+                local_defs.insert(var.clone(), (params, Arc::new(op_body.clone())));
                 return eval(body, env, &local_defs);
             }
             if let Expr::FnDef(param, domain_expr, fn_body) = binding.as_ref() {
                 let mut local_defs = defs.clone();
-                local_defs.insert(var.clone(), (vec![], (**binding).clone()));
+                local_defs.insert(var.clone(), (vec![], Arc::new((**binding).clone())));
                 let dom = eval_set(domain_expr, env, &local_defs)?;
                 let dom_vec: Vec<_> = dom.into_iter().collect();
                 let fn_result =

--- a/src/eval/enumerate.rs
+++ b/src/eval/enumerate.rs
@@ -116,7 +116,7 @@ pub(crate) fn next_states_impl(
     Ok(results)
 }
 
-/// Walker engine (TLA_WALK): split the relation into labelled top-level
+/// Walker engine: split the relation into labelled top-level
 /// disjuncts for action attribution, then walk each one. The walker handles all
 /// nested structure (`\E`, `\/`, `\in`, IF/CASE, dependent assignments) itself.
 fn walk_next_states(effective: &Expr, env: &mut Env, ctx: &EnumCtx<'_>) -> Result<Vec<Transition>> {

--- a/src/eval/enumerate.rs
+++ b/src/eval/enumerate.rs
@@ -68,6 +68,50 @@ pub(crate) fn next_states_impl(
     primed_vars: &[Arc<str>],
     defs: &Definitions,
 ) -> Result<Vec<Transition>> {
+    let results = next_states_dispatch(next, base_env, vars, primed_vars, defs)?;
+    #[cfg(debug_assertions)]
+    debug_assert_successors_satisfy_next(next, base_env, primed_vars, defs, &results);
+    Ok(results)
+}
+
+/// In debug builds, every emitted successor must actually satisfy the next-state
+/// relation: binding its primed values into the current state and evaluating
+/// `Next` must yield `true`. This catches an engine fabricating a successor the
+/// relation forbids — the failure mode that turns a real violation into a false
+/// pass or a bogus counterexample. Compiled out of release builds.
+#[cfg(debug_assertions)]
+fn debug_assert_successors_satisfy_next(
+    next: &Expr,
+    base_env: &mut Env,
+    primed_vars: &[Arc<str>],
+    defs: &Definitions,
+    results: &[Transition],
+) {
+    for transition in results {
+        for (i, primed) in primed_vars.iter().enumerate() {
+            if let Some(val) = transition.state.values.get(i) {
+                base_env.insert(primed.clone(), val.clone());
+            }
+        }
+        let holds = eval_bool(next, base_env, defs);
+        for primed in primed_vars {
+            base_env.remove(primed);
+        }
+        debug_assert!(
+            matches!(holds, Ok(true)),
+            "engine emitted a successor that does not satisfy Next: {:?} (eval = {holds:?})",
+            transition.state.values
+        );
+    }
+}
+
+fn next_states_dispatch(
+    next: &Expr,
+    base_env: &mut Env,
+    vars: &[Arc<str>],
+    primed_vars: &[Arc<str>],
+    defs: &Definitions,
+) -> Result<Vec<Transition>> {
     let ctx = EnumCtx {
         vars,
         primed_vars,

--- a/src/eval/enumerate.rs
+++ b/src/eval/enumerate.rs
@@ -74,6 +74,11 @@ pub(crate) fn next_states_impl(
         defs,
     };
     let effective = resolve_next(next, defs);
+
+    if super::walk::walk_enabled() {
+        return walk_next_states(effective, base_env, &ctx);
+    }
+
     if let Expr::Exists(_, _, _) = effective {
         let action = infer_action_name(effective, defs);
         let mut all_results = indexmap::IndexSet::new();
@@ -109,6 +114,27 @@ pub(crate) fn next_states_impl(
     let mut results = Vec::new();
     enumerate_next(effective, base_env, &ctx, action, &mut results)?;
     Ok(results)
+}
+
+/// Walker engine (TLA_WALK): split the relation into labelled top-level
+/// disjuncts for action attribution, then walk each one. The walker handles all
+/// nested structure (`\E`, `\/`, `\in`, IF/CASE, dependent assignments) itself.
+fn walk_next_states(effective: &Expr, env: &mut Env, ctx: &EnumCtx<'_>) -> Result<Vec<Transition>> {
+    use super::walk::{WalkCtx, walk_next};
+    let wctx = WalkCtx {
+        vars: ctx.vars,
+        primed_vars: ctx.primed_vars,
+        defs: ctx.defs,
+    };
+    let mut all = indexmap::IndexSet::new();
+    for (disjunct, action) in collect_disjuncts_with_labels(effective, ctx.defs) {
+        let mut results = Vec::new();
+        walk_next(disjunct, env, &wctx, action, &mut results)?;
+        for transition in results {
+            all.insert(transition);
+        }
+    }
+    Ok(all.into_iter().collect())
 }
 
 fn resolve_next<'a>(expr: &'a Expr, defs: &'a Definitions) -> &'a Expr {

--- a/src/eval/enumerate.rs
+++ b/src/eval/enumerate.rs
@@ -126,6 +126,7 @@ fn walk_next_states(effective: &Expr, env: &mut Env, ctx: &EnumCtx<'_>) -> Resul
         state_keys: ctx.primed_vars,
         defs: ctx.defs,
         phase: Phase::Next,
+        require_total: true,
     };
     let mut all = indexmap::IndexSet::new();
     for (disjunct, action) in collect_disjuncts_with_labels(effective, ctx.defs) {

--- a/src/eval/enumerate.rs
+++ b/src/eval/enumerate.rs
@@ -120,11 +120,12 @@ pub(crate) fn next_states_impl(
 /// disjuncts for action attribution, then walk each one. The walker handles all
 /// nested structure (`\E`, `\/`, `\in`, IF/CASE, dependent assignments) itself.
 fn walk_next_states(effective: &Expr, env: &mut Env, ctx: &EnumCtx<'_>) -> Result<Vec<Transition>> {
-    use super::walk::{WalkCtx, walk_next};
+    use super::walk::{Phase, WalkCtx, walk_next};
     let wctx = WalkCtx {
         vars: ctx.vars,
-        primed_vars: ctx.primed_vars,
+        state_keys: ctx.primed_vars,
         defs: ctx.defs,
+        phase: Phase::Next,
     };
     let mut all = indexmap::IndexSet::new();
     for (disjunct, action) in collect_disjuncts_with_labels(effective, ctx.defs) {

--- a/src/eval/init.rs
+++ b/src/eval/init.rs
@@ -23,8 +23,11 @@ pub fn init_states(
     #[cfg(feature = "profiling")]
     let _start = Instant::now();
 
-    let mut results = Vec::new();
     let mut initial_env = domains.clone();
+    if super::walk::walk_enabled() {
+        return super::walk::walk_init(init, &mut initial_env, vars, defs);
+    }
+    let mut results = Vec::new();
     enumerate_init(init, &mut initial_env, vars, 0, domains, defs, &mut results)?;
 
     #[cfg(feature = "profiling")]

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -48,7 +48,7 @@ pub use self::state::{
 };
 
 pub(crate) use self::ast_utils::contains_prime_ref;
-pub use self::walk::set_allow_unassigned_stutter;
+pub use self::walk::{set_allow_unassigned_stutter, set_use_inference_engine};
 
 pub(crate) fn resolve_parameterized_defs(
     param_inst: &ParameterizedInstance,

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -47,7 +47,7 @@ pub use self::state::{
     is_action_enabled, make_primed_names, next_states, next_states_with_guards, state_to_env,
 };
 
-pub(crate) use self::ast_utils::contains_prime_ref;
+pub(crate) use self::ast_utils::{contains_prime_ref, expr_references};
 pub use self::walk::{set_allow_unassigned_stutter, set_use_inference_engine};
 
 pub(crate) fn resolve_parameterized_defs(

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use crate::ast::Expr;
 
-pub type Definitions = BTreeMap<Arc<str>, (Vec<Arc<str>>, Expr)>;
+pub type Definitions = crate::ast::DefinitionMap;
 pub type ResolvedInstances = BTreeMap<Arc<str>, Definitions>;
 
 #[derive(Debug, Clone)]
@@ -489,7 +489,7 @@ mod tests {
         let mut d = defs();
         d.insert(
             var("Double"),
-            (vec![var("n")], add(var_expr("n"), var_expr("n"))),
+            (vec![var("n")], add(var_expr("n"), var_expr("n")).into()),
         );
         let mut env = Env::new();
         let expr = Expr::FnCall(var("Double"), vec![lit_int(5)]);

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -11,6 +11,7 @@ mod helpers;
 mod init;
 mod recursive;
 mod state;
+mod walk;
 
 use std::collections::BTreeMap;
 use std::sync::Arc;

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -48,6 +48,7 @@ pub use self::state::{
 };
 
 pub(crate) use self::ast_utils::contains_prime_ref;
+pub use self::walk::set_allow_unassigned_stutter;
 
 pub(crate) fn resolve_parameterized_defs(
     param_inst: &ParameterizedInstance,

--- a/src/eval/recursive.rs
+++ b/src/eval/recursive.rs
@@ -61,7 +61,7 @@ pub(crate) fn eval_with_memo(
                 }
                 if let Some((params, fn_body)) = defs.get(name)
                     && params.is_empty()
-                    && let Expr::FnDef(p, _, body) = fn_body
+                    && let Expr::FnDef(p, _, body) = fn_body.as_ref()
                 {
                     let prev_p = env.insert(p.clone(), av.clone());
                     let result =
@@ -85,7 +85,7 @@ pub(crate) fn eval_with_memo(
 
         Expr::Let(var, binding, body) => {
             let mut local_defs = defs.clone();
-            local_defs.insert(var.clone(), (vec![], (**binding).clone()));
+            local_defs.insert(var.clone(), (vec![], Arc::new((**binding).clone())));
             eval_with_memo(body, env, &local_defs, fn_name, fn_param, fn_domain, memo)
         }
 

--- a/src/eval/state.rs
+++ b/src/eval/state.rs
@@ -115,6 +115,9 @@ pub fn is_action_enabled(
         base_env.insert(k.clone(), v.clone());
     }
     let primed_vars = make_primed_names(vars);
+    if super::walk::walk_enabled() {
+        return super::walk::walk_action_enabled(action, &mut base_env, vars, &primed_vars, defs);
+    }
     check_enabled(action, &mut base_env, vars, &primed_vars, 0, defs)
 }
 

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -712,19 +712,37 @@ fn walk_qualified_call(
             let (params, body) = instance_defs.get(op)?;
             Some((instance_defs.clone(), params.clone(), body.clone()))
         }),
-        Expr::FnCall(instance_name, instance_args) => PARAMETERIZED_INSTANCES.with(|r| {
-            let instances = r.borrow();
-            let param_inst = instances.get(instance_name)?;
-            if instance_args.len() != param_inst.params.len() {
-                return None;
-            }
-            let instance_defs =
-                super::resolve_parameterized_defs_symbolic(param_inst, instance_args.to_vec());
-            let (params, body) = instance_defs.get(op)?;
-            let params = params.clone();
-            let body = body.clone();
-            Some((instance_defs, params, body))
-        }),
+        Expr::FnCall(instance_name, instance_args) => {
+            // Resolve with the arguments' concrete values, not their expressions.
+            // A `WITH p <- f[arg]` substitution puts `arg` under a prime, and
+            // `prime_expr` primes every variable it contains, so a symbolic
+            // `Var` argument becomes an undefined `arg'`; a `Lit` value is rigid
+            // under priming. The inference engine resolves with values for the
+            // same reason. Arguments in action position are always bound here; if
+            // one is not evaluable, fall back to the symbolic resolution.
+            let concrete: Option<Vec<Value>> = instance_args
+                .iter()
+                .map(|a| eval(a, env, ctx.defs).ok())
+                .collect();
+            PARAMETERIZED_INSTANCES.with(|r| {
+                let instances = r.borrow();
+                let param_inst = instances.get(instance_name)?;
+                if instance_args.len() != param_inst.params.len() {
+                    return None;
+                }
+                let instance_defs = match &concrete {
+                    Some(vals) => super::resolve_parameterized_defs(param_inst, vals.clone()),
+                    None => super::resolve_parameterized_defs_symbolic(
+                        param_inst,
+                        instance_args.to_vec(),
+                    ),
+                };
+                let (params, body) = instance_defs.get(op)?;
+                let params = params.clone();
+                let body = body.clone();
+                Some((instance_defs, params, body))
+            })
+        }
         _ => None,
     };
 

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -1,0 +1,412 @@
+//! Continuation-passing next-state generation, a port of TLC's `getNextStates`.
+//!
+//! Instead of inferring a candidate set per primed variable and filtering the
+//! cross product (which can only ever *reject*, so any inference shortfall is a
+//! silent false pass), this walks the next-state relation over a single partial
+//! successor state. A primed variable is *bound* at the conjunct that assigns
+//! it; `\/`, `\E`, `\in`, `IF`/`CASE` branch the recursion; a successor is
+//! emitted only when the whole relation has been discharged with every variable
+//! assigned. Dependencies like `b' = a' + 10` need no analysis: `a'` is already
+//! bound when `b'`'s conjunct is reached.
+//!
+//! Gated behind `TLA_WALK` while both engines coexist (design commits 3–10).
+
+use std::sync::Arc;
+
+use super::Definitions;
+use super::core::{eval, expand_unchanged_vars};
+use super::error::{EvalError, Result};
+use super::helpers::{eval_bool, eval_set, update_nested_value};
+use super::state::env_to_next_state;
+use crate::ast::{Env, Expr, Transition, Value};
+use crate::intern::primed_name;
+use crate::substitution::substitute_expr;
+
+/// Whether the walker engine is selected.
+pub(crate) fn walk_enabled() -> bool {
+    std::env::var_os("TLA_WALK").is_some()
+}
+
+pub(crate) struct WalkCtx<'a> {
+    pub vars: &'a [Arc<str>],
+    pub primed_vars: &'a [Arc<str>],
+    pub defs: &'a Definitions,
+}
+
+/// The conjuncts still to be discharged, newest first — TLC's `ActionItemList`.
+/// `Slice` carries a block of owned conjuncts (from `\A` expansion or `UNCHANGED`
+/// desugaring) without allocating a node per item.
+enum Cont<'a> {
+    Nil,
+    Cons(&'a Expr, &'a Cont<'a>),
+    Slice(&'a [Expr], &'a Cont<'a>),
+}
+
+/// The output side of a walk: the label to attribute to each successor (constant
+/// for one action) and the sink they are collected into.
+struct Emit<'r> {
+    action: Option<Arc<str>>,
+    results: &'r mut Vec<Transition>,
+}
+
+/// Walk one action (a top-level disjunct, already labelled by the caller) and
+/// append every successor it produces.
+pub(crate) fn walk_next(
+    action_expr: &Expr,
+    env: &mut Env,
+    ctx: &WalkCtx<'_>,
+    action: Option<Arc<str>>,
+    results: &mut Vec<Transition>,
+) -> Result<()> {
+    let mut emit = Emit { action, results };
+    walk(action_expr, &Cont::Nil, env, ctx, &mut emit)
+}
+
+fn walk(
+    node: &Expr,
+    cont: &Cont<'_>,
+    env: &mut Env,
+    ctx: &WalkCtx<'_>,
+    emit: &mut Emit<'_>,
+) -> Result<()> {
+    match node {
+        // Conjunction: discharge left-to-right. Push the rest onto the
+        // continuation and recurse into the head, so every later conjunct sees
+        // the primes the earlier ones bound.
+        Expr::And(l, r) => walk(l, &Cont::Cons(r, cont), env, ctx, emit),
+
+        // Disjunction: each branch explored with the same continuation and the
+        // same partial successor.
+        Expr::Or(l, r) => {
+            walk(l, cont, env, ctx, emit)?;
+            walk(r, cont, env, ctx, emit)
+        }
+
+        // A named-but-unparameterised action reference, or an action operator:
+        // substitute the arguments into the body and walk it.
+        Expr::Var(name) => match ctx.defs.get(name) {
+            Some((params, body)) if params.is_empty() => walk(&body.clone(), cont, env, ctx, emit),
+            _ => walk_bool(node, cont, env, ctx, emit),
+        },
+        Expr::FnCall(name, args) => match ctx.defs.get(name) {
+            Some((params, body)) if params.len() == args.len() => {
+                let subs: Vec<(Arc<str>, Expr)> =
+                    params.iter().cloned().zip(args.iter().cloned()).collect();
+                walk(&substitute_expr(body, &subs), cont, env, ctx, emit)
+            }
+            _ => walk_bool(node, cont, env, ctx, emit),
+        },
+        Expr::LabeledAction(_, inner) => walk(inner, cont, env, ctx, emit),
+
+        // Instance operator in action position: resolve the operator body (with
+        // WITH-substitutions and, for parameterized instances, the instance
+        // arguments applied), substitute the call arguments, and walk it.
+        Expr::QualifiedCall(instance_expr, op, args) => {
+            walk_qualified_call(instance_expr, op, args, cont, env, ctx, emit)
+        }
+
+        // Existential in action position: one branch per witness.
+        Expr::Exists(var, domain, body) => {
+            let dom = eval_set(domain, env, ctx.defs)?;
+            let prev = env.get(var).cloned();
+            for val in dom {
+                env.insert(var.clone(), val);
+                walk(body, cont, env, ctx, emit)?;
+            }
+            restore(env, var, prev);
+            Ok(())
+        }
+
+        // Universal in action position: the body must hold for every element,
+        // so expand to a conjunction over the (concrete) domain.
+        Expr::Forall(var, domain, body) => {
+            let dom = eval_set(domain, env, ctx.defs)?;
+            let items: Vec<Expr> = dom
+                .into_iter()
+                .map(|val| substitute_expr(body, &[(var.clone(), Expr::Lit(val))]))
+                .collect();
+            advance(&Cont::Slice(&items, cont), env, ctx, emit)
+        }
+
+        // UNCHANGED assigns each variable its pre-state value (the evaluator's
+        // own arm is a *constraint*, which needs the primes already bound).
+        Expr::Unchanged(vars) => {
+            let items: Vec<Expr> = expand_unchanged_vars(vars, ctx.defs)
+                .into_iter()
+                .map(|v| Expr::Eq(Box::new(Expr::Prime(v.clone())), Box::new(Expr::Var(v))))
+                .collect();
+            advance(&Cont::Slice(&items, cont), env, ctx, emit)
+        }
+
+        // IF: guard is a boolean read in the current partial state; recurse into
+        // exactly one branch.
+        Expr::If(c, t, e) => {
+            if eval_bool(c, env, ctx.defs)? {
+                walk(t, cont, env, ctx, emit)
+            } else {
+                walk(e, cont, env, ctx, emit)
+            }
+        }
+
+        // CASE: first branch whose guard holds; a non-exhaustive CASE is a hard
+        // error (as in the evaluator).
+        Expr::Case(branches) => {
+            for (guard, body) in branches {
+                if eval_bool(guard, env, ctx.defs)? {
+                    return walk(body, cont, env, ctx, emit);
+                }
+            }
+            Err(EvalError::domain_error("CASE: no matching branch"))
+        }
+
+        // LET: bind the definition into the body and walk it.
+        Expr::Let(name, binding, body) => {
+            let bound = substitute_expr(body, &[(name.clone(), (**binding).clone())]);
+            walk(&bound, cont, env, ctx, emit)
+        }
+
+        // Equality: an assignment when one side is an (indexed) unbound prime,
+        // a constraint otherwise.
+        Expr::Eq(l, r) => walk_eq(node, l, r, cont, env, ctx, emit),
+
+        // Membership: a binding construct that enumerates the set when the
+        // element is an unbound prime, a constraint otherwise.
+        Expr::In(elem, set) => walk_in(node, elem, set, cont, env, ctx, emit),
+
+        // Everything else is a boolean predicate: evaluate, prune on false.
+        _ => walk_bool(node, cont, env, ctx, emit),
+    }
+}
+
+/// Discharge the continuation: pop the next pending conjunct, or emit a
+/// successor if none remain.
+fn advance(cont: &Cont<'_>, env: &mut Env, ctx: &WalkCtx<'_>, emit: &mut Emit<'_>) -> Result<()> {
+    match cont {
+        Cont::Cons(head, tail) => walk(head, tail, env, ctx, emit),
+        Cont::Slice(items, tail) => match items.split_first() {
+            None => advance(tail, env, ctx, emit),
+            Some((head, rest)) => walk(head, &Cont::Slice(rest, tail), env, ctx, emit),
+        },
+        Cont::Nil => {
+            // A successor exists only if every variable was assigned. The walker
+            // never invents a stutter for an unassigned variable; a loud
+            // diagnostic for that case lands in a later commit.
+            if ctx.primed_vars.iter().all(|p| env.get(p).is_some()) {
+                emit.results.push(Transition {
+                    state: env_to_next_state(env, ctx.vars, ctx.primed_vars),
+                    action: emit.action.clone(),
+                });
+            }
+            Ok(())
+        }
+    }
+}
+
+fn walk_bool(
+    node: &Expr,
+    cont: &Cont<'_>,
+    env: &mut Env,
+    ctx: &WalkCtx<'_>,
+    emit: &mut Emit<'_>,
+) -> Result<()> {
+    if eval_bool(node, env, ctx.defs)? {
+        advance(cont, env, ctx, emit)
+    } else {
+        Ok(())
+    }
+}
+
+fn walk_eq(
+    node: &Expr,
+    l: &Expr,
+    r: &Expr,
+    cont: &Cont<'_>,
+    env: &mut Env,
+    ctx: &WalkCtx<'_>,
+    emit: &mut Emit<'_>,
+) -> Result<()> {
+    if let Some((name, keys)) = prime_target(l) {
+        return assign_or_constrain(&name, &keys, r, cont, env, ctx, emit);
+    }
+    if let Some((name, keys)) = prime_target(r) {
+        return assign_or_constrain(&name, &keys, l, cont, env, ctx, emit);
+    }
+    walk_bool(node, cont, env, ctx, emit)
+}
+
+fn walk_in(
+    node: &Expr,
+    elem: &Expr,
+    set: &Expr,
+    cont: &Cont<'_>,
+    env: &mut Env,
+    ctx: &WalkCtx<'_>,
+    emit: &mut Emit<'_>,
+) -> Result<()> {
+    if let Some((name, keys)) = prime_target(elem)
+        && keys.is_empty()
+    {
+        let primed = primed_name(&name);
+        if env.get(&primed).is_none() {
+            let dom = eval_set(set, env, ctx.defs)?;
+            for val in dom {
+                env.insert(primed.clone(), val);
+                advance(cont, env, ctx, emit)?;
+            }
+            env.remove(&primed);
+            return Ok(());
+        }
+    }
+    walk_bool(node, cont, env, ctx, emit)
+}
+
+/// Bind `name'` (possibly at a nested key path) to the value of `rhs`, or, if it
+/// is already bound, treat the equality as a constraint.
+fn assign_or_constrain(
+    name: &Arc<str>,
+    keys: &[Expr],
+    rhs: &Expr,
+    cont: &Cont<'_>,
+    env: &mut Env,
+    ctx: &WalkCtx<'_>,
+    emit: &mut Emit<'_>,
+) -> Result<()> {
+    let primed = primed_name(name);
+    let rhs_val = eval(rhs, env, ctx.defs)?;
+
+    if keys.is_empty() {
+        match env.get(&primed).cloned() {
+            None => {
+                env.insert(primed.clone(), rhs_val);
+                advance(cont, env, ctx, emit)?;
+                env.remove(&primed);
+                Ok(())
+            }
+            Some(existing) => {
+                if existing == rhs_val {
+                    advance(cont, env, ctx, emit)
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    } else {
+        // Indexed assignment `name'[k..] = rhs`. Base is the current binding of
+        // `name'` if any, otherwise the pre-state value of `name`. Overwrite
+        // semantics; repeated-key constraint handling lands in a later commit.
+        let key_vals: Vec<Value> = keys
+            .iter()
+            .map(|k| eval(k, env, ctx.defs))
+            .collect::<Result<_>>()?;
+        let base = match env.get(&primed).cloned().or_else(|| env.get(name).cloned()) {
+            Some(v) => v,
+            None => return Ok(()),
+        };
+        let updated = update_nested_value(&base, &key_vals, rhs_val)?;
+        let prev = env.get(&primed).cloned();
+        env.insert(primed.clone(), updated);
+        advance(cont, env, ctx, emit)?;
+        restore(env, &primed, prev);
+        Ok(())
+    }
+}
+
+/// Resolve an instance operator to `(merged defs, params, body)`, then
+/// substitute the call arguments and walk the body as an action.
+fn walk_qualified_call(
+    instance_expr: &Expr,
+    op: &Arc<str>,
+    args: &[Expr],
+    cont: &Cont<'_>,
+    env: &mut Env,
+    ctx: &WalkCtx<'_>,
+    emit: &mut Emit<'_>,
+) -> Result<()> {
+    use super::global_state::{PARAMETERIZED_INSTANCES, RESOLVED_INSTANCES};
+
+    let resolved: Option<(Definitions, Vec<Arc<str>>, Expr)> = match instance_expr {
+        Expr::Var(instance_name) => RESOLVED_INSTANCES.with(|r| {
+            let instances = r.borrow();
+            let instance_defs = instances.get(instance_name)?;
+            let (params, body) = instance_defs.get(op)?;
+            Some((instance_defs.clone(), params.clone(), body.clone()))
+        }),
+        Expr::FnCall(instance_name, instance_args) => PARAMETERIZED_INSTANCES.with(|r| {
+            let instances = r.borrow();
+            let param_inst = instances.get(instance_name)?;
+            if instance_args.len() != param_inst.params.len() {
+                return None;
+            }
+            let instance_defs =
+                super::resolve_parameterized_defs_symbolic(param_inst, instance_args.to_vec());
+            let (params, body) = instance_defs.get(op)?;
+            let params = params.clone();
+            let body = body.clone();
+            Some((instance_defs, params, body))
+        }),
+        _ => None,
+    };
+
+    let Some((instance_defs, params, body)) = resolved else {
+        // Not resolvable as an action call; fall back to boolean evaluation,
+        // which produces the evaluator's own diagnostic.
+        let fallback =
+            Expr::QualifiedCall(Box::new(instance_expr.clone()), op.clone(), args.to_vec());
+        return walk_bool(&fallback, cont, env, ctx, emit);
+    };
+
+    if params.len() != args.len() {
+        let fallback =
+            Expr::QualifiedCall(Box::new(instance_expr.clone()), op.clone(), args.to_vec());
+        return walk_bool(&fallback, cont, env, ctx, emit);
+    }
+
+    let subs: Vec<(Arc<str>, Expr)> = params.into_iter().zip(args.iter().cloned()).collect();
+    let bound_body = substitute_expr(&body, &subs);
+
+    let mut merged = ctx.defs.clone();
+    for (name, def) in instance_defs {
+        merged.insert(name, def);
+    }
+    let sub_ctx = WalkCtx {
+        vars: ctx.vars,
+        primed_vars: ctx.primed_vars,
+        defs: &merged,
+    };
+    walk(&bound_body, cont, env, &sub_ctx, emit)
+}
+
+/// If `expr` is a prime, or an indexed access rooted at a prime, return the base
+/// variable name and the key path (outermost first).
+fn prime_target(expr: &Expr) -> Option<(Arc<str>, Vec<Expr>)> {
+    match expr {
+        Expr::Prime(name) => Some((name.clone(), Vec::new())),
+        Expr::FnApp(f, key) => {
+            let (name, mut keys) = prime_target(f)?;
+            keys.push((**key).clone());
+            Some((name, keys))
+        }
+        Expr::RecordAccess(r, field) => {
+            let (name, mut keys) = prime_target(r)?;
+            keys.push(Expr::Lit(Value::Str(field.clone())));
+            Some((name, keys))
+        }
+        Expr::TupleAccess(t, idx) => {
+            let (name, mut keys) = prime_target(t)?;
+            keys.push(Expr::Lit(Value::Int(*idx as i64 + 1)));
+            Some((name, keys))
+        }
+        _ => None,
+    }
+}
+
+fn restore(env: &mut Env, key: &Arc<str>, prev: Option<Value>) {
+    match prev {
+        Some(v) => {
+            env.insert(key.clone(), v);
+        }
+        None => {
+            env.remove(key);
+        }
+    }
+}

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -6,8 +6,10 @@
 //! successor state. A primed variable is *bound* at the conjunct that assigns
 //! it; `\/`, `\E`, `\in`, `IF`/`CASE` branch the recursion; a successor is
 //! emitted only when the whole relation has been discharged with every variable
-//! assigned. Dependencies like `b' = a' + 10` need no analysis: `a'` is already
-//! bound when `b'`'s conjunct is reached.
+//! assigned. Dependencies like `b' = a' + 10` need no analysis when the assigning
+//! conjunct precedes the dependent one: `a'` is already bound when `b'`'s conjunct
+//! is reached. Conjuncts are evaluated in source order, as in TLC, so a read of a
+//! variable before the conjunct that assigns it is an error, not a reordering.
 //!
 //! The default engine; the legacy candidate-inference engine remains available
 //! for one release as an escape hatch (`TLA_ENGINE=inference`).
@@ -611,11 +613,30 @@ fn assign_or_constrain(
                 r
             }
             Some(existing) => {
-                if existing == rhs_val {
-                    advance(cont, env, ctx, run)
-                } else {
-                    Ok(())
+                let indexed: Vec<Vec<Value>> = run
+                    .assigned_paths
+                    .iter()
+                    .filter(|(k, _)| *k == key)
+                    .map(|(_, p)| p.clone())
+                    .collect();
+                if run.fully_assigned.contains(&key) || indexed.is_empty() {
+                    return if existing == rhs_val {
+                        advance(cont, env, ctx, run)
+                    } else {
+                        Ok(())
+                    };
                 }
+                for path in &indexed {
+                    if get_nested(&existing, path)? != get_nested(&rhs_val, path)? {
+                        return Ok(());
+                    }
+                }
+                let prev = env.insert(key.clone(), rhs_val);
+                run.fully_assigned.push(key.clone());
+                let r = advance(cont, env, ctx, run);
+                run.fully_assigned.pop();
+                restore(env, &key, prev);
+                r
             }
         }
     } else {

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -621,7 +621,12 @@ fn assign_or_constrain(
 
         let base = match env.get(&key).cloned().or_else(|| env.get(name).cloned()) {
             Some(v) => v,
-            None => return Ok(()),
+            None => {
+                return Err(EvalError::domain_error(format!(
+                    "cannot assign an element of `{name}` before `{name}` has a value; \
+                     assign the whole variable first"
+                )));
+            }
         };
         let updated = update_nested_value(&base, &key_vals, rhs_val)?;
         let prev = env.get(&key).cloned();

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -27,10 +27,41 @@ pub(crate) fn walk_enabled() -> bool {
     std::env::var_os("TLA_WALK").is_some()
 }
 
+/// Whether the walker is generating successors (`x' = e` binds `x'`) or initial
+/// states (`x = e` binds `x`). The machine is otherwise identical, as in TLC.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Phase {
+    Next,
+    Init,
+}
+
 pub(crate) struct WalkCtx<'a> {
     pub vars: &'a [Arc<str>],
-    pub primed_vars: &'a [Arc<str>],
+    /// The env keys the emitted state is read from — the primed names for
+    /// `Next`, the bare variable names for `Init`.
+    pub state_keys: &'a [Arc<str>],
     pub defs: &'a Definitions,
+    pub phase: Phase,
+}
+
+impl WalkCtx<'_> {
+    /// The env key an assignment to state variable `name` binds.
+    fn key_for(&self, name: &Arc<str>) -> Arc<str> {
+        match self.phase {
+            Phase::Next => primed_name(name),
+            Phase::Init => name.clone(),
+        }
+    }
+
+    /// If `expr` is an assignment target for this phase — a prime (`Next`) or a
+    /// bare state variable (`Init`), possibly indexed — return its base name and
+    /// key path.
+    fn assign_target(&self, expr: &Expr) -> Option<(Arc<str>, Vec<Expr>)> {
+        match self.phase {
+            Phase::Next => prime_target(expr),
+            Phase::Init => init_target(expr, self.vars),
+        }
+    }
 }
 
 /// The conjuncts still to be discharged, newest first — TLC's `ActionItemList`.
@@ -60,6 +91,36 @@ pub(crate) fn walk_next(
 ) -> Result<()> {
     let mut emit = Emit { action, results };
     walk(action_expr, &Cont::Nil, env, ctx, &mut emit)
+}
+
+/// Walk the Init predicate over one partial state, binding unprimed variables,
+/// and return the distinct initial states. The same machine as `walk_next`, so
+/// `\E`/`IF`/`LET`/operator calls in Init branch exactly as they do in Next.
+pub(crate) fn walk_init(
+    init: &Expr,
+    env: &mut Env,
+    vars: &[Arc<str>],
+    defs: &Definitions,
+) -> Result<Vec<crate::ast::State>> {
+    let ctx = WalkCtx {
+        vars,
+        state_keys: vars,
+        defs,
+        phase: Phase::Init,
+    };
+    let mut results = Vec::new();
+    {
+        let mut emit = Emit {
+            action: None,
+            results: &mut results,
+        };
+        walk(init, &Cont::Nil, env, &ctx, &mut emit)?;
+    }
+    let mut seen = indexmap::IndexSet::new();
+    for t in results {
+        seen.insert(t.state);
+    }
+    Ok(seen.into_iter().collect())
 }
 
 fn walk(
@@ -191,9 +252,9 @@ fn advance(cont: &Cont<'_>, env: &mut Env, ctx: &WalkCtx<'_>, emit: &mut Emit<'_
             // A successor exists only if every variable was assigned. The walker
             // never invents a stutter for an unassigned variable; a loud
             // diagnostic for that case lands in a later commit.
-            if ctx.primed_vars.iter().all(|p| env.get(p).is_some()) {
+            if ctx.state_keys.iter().all(|k| env.get(k).is_some()) {
                 emit.results.push(Transition {
-                    state: env_to_next_state(env, ctx.vars, ctx.primed_vars),
+                    state: env_to_next_state(env, ctx.vars, ctx.state_keys),
                     action: emit.action.clone(),
                 });
             }
@@ -225,10 +286,10 @@ fn walk_eq(
     ctx: &WalkCtx<'_>,
     emit: &mut Emit<'_>,
 ) -> Result<()> {
-    if let Some((name, keys)) = prime_target(l) {
+    if let Some((name, keys)) = ctx.assign_target(l) {
         return assign_or_constrain(&name, &keys, r, cont, env, ctx, emit);
     }
-    if let Some((name, keys)) = prime_target(r) {
+    if let Some((name, keys)) = ctx.assign_target(r) {
         return assign_or_constrain(&name, &keys, l, cont, env, ctx, emit);
     }
     walk_bool(node, cont, env, ctx, emit)
@@ -243,17 +304,17 @@ fn walk_in(
     ctx: &WalkCtx<'_>,
     emit: &mut Emit<'_>,
 ) -> Result<()> {
-    if let Some((name, keys)) = prime_target(elem)
+    if let Some((name, keys)) = ctx.assign_target(elem)
         && keys.is_empty()
     {
-        let primed = primed_name(&name);
-        if env.get(&primed).is_none() {
+        let key = ctx.key_for(&name);
+        if env.get(&key).is_none() {
             let dom = eval_set(set, env, ctx.defs)?;
             for val in dom {
-                env.insert(primed.clone(), val);
+                env.insert(key.clone(), val);
                 advance(cont, env, ctx, emit)?;
             }
-            env.remove(&primed);
+            env.remove(&key);
             return Ok(());
         }
     }
@@ -271,15 +332,15 @@ fn assign_or_constrain(
     ctx: &WalkCtx<'_>,
     emit: &mut Emit<'_>,
 ) -> Result<()> {
-    let primed = primed_name(name);
+    let key = ctx.key_for(name);
     let rhs_val = eval(rhs, env, ctx.defs)?;
 
     if keys.is_empty() {
-        match env.get(&primed).cloned() {
+        match env.get(&key).cloned() {
             None => {
-                env.insert(primed.clone(), rhs_val);
+                env.insert(key.clone(), rhs_val);
                 advance(cont, env, ctx, emit)?;
-                env.remove(&primed);
+                env.remove(&key);
                 Ok(())
             }
             Some(existing) => {
@@ -298,15 +359,15 @@ fn assign_or_constrain(
             .iter()
             .map(|k| eval(k, env, ctx.defs))
             .collect::<Result<_>>()?;
-        let base = match env.get(&primed).cloned().or_else(|| env.get(name).cloned()) {
+        let base = match env.get(&key).cloned().or_else(|| env.get(name).cloned()) {
             Some(v) => v,
             None => return Ok(()),
         };
         let updated = update_nested_value(&base, &key_vals, rhs_val)?;
-        let prev = env.get(&primed).cloned();
-        env.insert(primed.clone(), updated);
+        let prev = env.get(&key).cloned();
+        env.insert(key.clone(), updated);
         advance(cont, env, ctx, emit)?;
-        restore(env, &primed, prev);
+        restore(env, &key, prev);
         Ok(())
     }
 }
@@ -370,10 +431,35 @@ fn walk_qualified_call(
     }
     let sub_ctx = WalkCtx {
         vars: ctx.vars,
-        primed_vars: ctx.primed_vars,
+        state_keys: ctx.state_keys,
         defs: &merged,
+        phase: ctx.phase,
     };
     walk(&bound_body, cont, env, &sub_ctx, emit)
+}
+
+/// If `expr` is a bare state variable, or an indexed access rooted at one,
+/// return its base name and key path — the `Init`-phase assignment target.
+fn init_target(expr: &Expr, vars: &[Arc<str>]) -> Option<(Arc<str>, Vec<Expr>)> {
+    match expr {
+        Expr::Var(name) if vars.contains(name) => Some((name.clone(), Vec::new())),
+        Expr::FnApp(f, key) => {
+            let (name, mut keys) = init_target(f, vars)?;
+            keys.push((**key).clone());
+            Some((name, keys))
+        }
+        Expr::RecordAccess(r, field) => {
+            let (name, mut keys) = init_target(r, vars)?;
+            keys.push(Expr::Lit(Value::Str(field.clone())));
+            Some((name, keys))
+        }
+        Expr::TupleAccess(t, idx) => {
+            let (name, mut keys) = init_target(t, vars)?;
+            keys.push(Expr::Lit(Value::Int(*idx as i64 + 1)));
+            Some((name, keys))
+        }
+        _ => None,
+    }
 }
 
 /// If `expr` is a prime, or an indexed access rooted at a prime, return the base

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -14,6 +14,7 @@
 use std::sync::Arc;
 
 use super::Definitions;
+use super::ast_utils::contains_prime_ref;
 use super::core::{eval, expand_unchanged_vars};
 use super::error::{EvalError, Result};
 use super::helpers::{eval_bool, eval_set, get_nested, update_nested_value};
@@ -196,6 +197,24 @@ fn walk(
 ) -> Result<()> {
     if ctx.satisfied(run) {
         return Ok(());
+    }
+    // Hoist prime-free conjuncts: a node that assigns nothing is a guard, so
+    // evaluate it in place instead of branching structurally. Without this a
+    // prime-free `\A i \in 1..n : (P \/ Q)` walked as an action discharges the
+    // whole continuation once per disjunct — O(2^n). If evaluating it errors,
+    // fall through to the structural walk (which produces the real diagnostic
+    // and preserves conjunct order). Only in `Next`, where "assigns nothing"
+    // is exactly "contains no prime".
+    if ctx.phase == Phase::Next
+        && !matches!(node, Expr::And(_, _))
+        && !contains_prime_ref(node, ctx.defs)
+        && let Ok(b) = eval_bool(node, env, ctx.defs)
+    {
+        return if b {
+            advance(cont, env, ctx, run)
+        } else {
+            Ok(())
+        };
     }
     match node {
         // Conjunction: discharge left-to-right. Push the rest onto the

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use super::Definitions;
 use super::core::{eval, expand_unchanged_vars};
 use super::error::{EvalError, Result};
-use super::helpers::{eval_bool, eval_set, update_nested_value};
+use super::helpers::{eval_bool, eval_set, get_nested, update_nested_value};
 use super::state::env_to_next_state;
 use crate::ast::{Env, Expr, Transition, Value};
 use crate::intern::primed_name;
@@ -101,6 +101,11 @@ struct Run<'r> {
     action: Option<Arc<str>>,
     results: &'r mut Vec<Transition>,
     journal: Vec<(Arc<str>, Option<Value>)>,
+    /// The `(state key, key path)` pairs already assigned on the current branch.
+    /// A second assignment to the same path is a *constraint* (compare), not an
+    /// overwrite — `f'[1] = 5 /\ f'[1] = 6` is unsatisfiable, and a `\A` that
+    /// sets every index must not be silently overwritten by a later `f'[i] = e`.
+    assigned_paths: Vec<(Arc<str>, Vec<Value>)>,
 }
 
 /// Walk one action (a top-level disjunct, already labelled by the caller) and
@@ -116,6 +121,7 @@ pub(crate) fn walk_next(
         action,
         results,
         journal: Vec::new(),
+        assigned_paths: Vec::new(),
     };
     walk(action_expr, &Cont::Nil, env, ctx, &mut run)
 }
@@ -142,6 +148,7 @@ pub(crate) fn walk_init(
             action: None,
             results: &mut results,
             journal: Vec::new(),
+            assigned_paths: Vec::new(),
         };
         walk(init, &Cont::Nil, env, &ctx, &mut run)?;
     }
@@ -174,6 +181,7 @@ pub(crate) fn walk_action_enabled(
         action: None,
         results: &mut results,
         journal: Vec::new(),
+        assigned_paths: Vec::new(),
     };
     walk(action, &Cont::Nil, env, &ctx, &mut run)?;
     Ok(!results.is_empty())
@@ -467,13 +475,33 @@ fn assign_or_constrain(
             }
         }
     } else {
-        // Indexed assignment `name'[k..] = rhs`. Base is the current binding of
-        // `name'` if any, otherwise the pre-state value of `name`. Overwrite
-        // semantics; repeated-key constraint handling lands in a later commit.
+        // Indexed assignment `name'[k..] = rhs`.
         let key_vals: Vec<Value> = keys
             .iter()
             .map(|k| eval(k, env, ctx.defs))
             .collect::<Result<_>>()?;
+
+        // If this exact path was already assigned on this branch, the equality is
+        // a *constraint*: the value already there must match, or the branch has no
+        // successor. (`f'[1] = 5 /\ f'[1] = 6` is unsatisfiable.)
+        let already_assigned = run
+            .assigned_paths
+            .iter()
+            .any(|(k, p)| *k == key && *p == key_vals);
+        if already_assigned {
+            let matches = env
+                .get(&key)
+                .and_then(|v| get_nested(v, &key_vals).ok())
+                .is_some_and(|existing| existing == rhs_val);
+            return if matches {
+                advance(cont, env, ctx, run)
+            } else {
+                Ok(())
+            };
+        }
+
+        // A fresh path: extend the partial function. Base is the current binding
+        // of `name'` if any, otherwise the pre-state value of `name`.
         let base = match env.get(&key).cloned().or_else(|| env.get(name).cloned()) {
             Some(v) => v,
             None => return Ok(()),
@@ -481,9 +509,11 @@ fn assign_or_constrain(
         let updated = update_nested_value(&base, &key_vals, rhs_val)?;
         let prev = env.get(&key).cloned();
         env.insert(key.clone(), updated);
-        advance(cont, env, ctx, run)?;
+        run.assigned_paths.push((key.clone(), key_vals));
+        let r = advance(cont, env, ctx, run);
+        run.assigned_paths.pop();
         restore(env, &key, prev);
-        Ok(())
+        r
     }
 }
 

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -730,49 +730,46 @@ fn walk_qualified_call(
 /// If `expr` is a bare state variable, or an indexed access rooted at one,
 /// return its base name and key path — the `Init`-phase assignment target.
 fn init_target(expr: &Expr, vars: &[Arc<str>]) -> Option<(Arc<str>, Vec<Expr>)> {
-    match expr {
-        Expr::Var(name) if vars.contains(name) => Some((name.clone(), Vec::new())),
-        Expr::FnApp(f, key) => {
-            let (name, mut keys) = init_target(f, vars)?;
-            keys.push((**key).clone());
-            Some((name, keys))
-        }
-        Expr::RecordAccess(r, field) => {
-            let (name, mut keys) = init_target(r, vars)?;
-            keys.push(Expr::Lit(Value::Str(field.clone())));
-            Some((name, keys))
-        }
-        Expr::TupleAccess(t, idx) => {
-            let (name, mut keys) = init_target(t, vars)?;
-            keys.push(Expr::Lit(Value::Int(*idx as i64 + 1)));
-            Some((name, keys))
-        }
+    key_path_target(expr, &|e| match e {
+        Expr::Var(name) if vars.contains(name) => Some(name.clone()),
         _ => None,
-    }
+    })
 }
 
 /// If `expr` is a prime, or an indexed access rooted at a prime, return the base
 /// variable name and the key path (outermost first).
-fn prime_target(expr: &Expr) -> Option<(Arc<str>, Vec<Expr>)> {
+/// Unwind an (indexed) assignment target — `base`, `base[k]`, `base.f`,
+/// `base[i]` — into its root name and key path. `base_name` recognises the root
+/// for the phase (a prime for `Next`, a bare state variable for `Init`).
+fn key_path_target(
+    expr: &Expr,
+    base_name: &impl Fn(&Expr) -> Option<Arc<str>>,
+) -> Option<(Arc<str>, Vec<Expr>)> {
     match expr {
-        Expr::Prime(name) => Some((name.clone(), Vec::new())),
         Expr::FnApp(f, key) => {
-            let (name, mut keys) = prime_target(f)?;
+            let (name, mut keys) = key_path_target(f, base_name)?;
             keys.push((**key).clone());
             Some((name, keys))
         }
         Expr::RecordAccess(r, field) => {
-            let (name, mut keys) = prime_target(r)?;
+            let (name, mut keys) = key_path_target(r, base_name)?;
             keys.push(Expr::Lit(Value::Str(field.clone())));
             Some((name, keys))
         }
         Expr::TupleAccess(t, idx) => {
-            let (name, mut keys) = prime_target(t)?;
+            let (name, mut keys) = key_path_target(t, base_name)?;
             keys.push(Expr::Lit(Value::Int(*idx as i64 + 1)));
             Some((name, keys))
         }
-        _ => None,
+        other => base_name(other).map(|name| (name, Vec::new())),
     }
+}
+
+fn prime_target(expr: &Expr) -> Option<(Arc<str>, Vec<Expr>)> {
+    key_path_target(expr, &|e| match e {
+        Expr::Prime(name) => Some(name.clone()),
+        _ => None,
+    })
 }
 
 fn restore(env: &mut Env, key: &Arc<str>, prev: Option<Value>) {

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -53,8 +53,8 @@ pub(crate) struct WalkCtx<'a> {
 impl WalkCtx<'_> {
     /// True once a witness has been found and no further search is needed
     /// (the `ENABLED` case).
-    fn satisfied(&self, emit: &Emit<'_>) -> bool {
-        !self.require_total && !emit.results.is_empty()
+    fn satisfied(&self, run: &Run<'_>) -> bool {
+        !self.require_total && !run.results.is_empty()
     }
 }
 
@@ -80,18 +80,27 @@ impl WalkCtx<'_> {
 
 /// The conjuncts still to be discharged, newest first — TLC's `ActionItemList`.
 /// `Slice` carries a block of owned conjuncts (from `\A` expansion or `UNCHANGED`
-/// desugaring) without allocating a node per item.
+/// desugaring) without allocating a node per item. The `usize` is the scope
+/// mark: the shadow-journal length when the item was pushed, so it can be
+/// discharged in the scope it was written in (see `discharge`).
 enum Cont<'a> {
     Nil,
-    Cons(&'a Expr, &'a Cont<'a>),
-    Slice(&'a [Expr], &'a Cont<'a>),
+    Cons(&'a Expr, usize, &'a Cont<'a>),
+    Slice(&'a [Expr], usize, &'a Cont<'a>),
 }
 
-/// The output side of a walk: the label to attribute to each successor (constant
-/// for one action) and the sink they are collected into.
-struct Emit<'r> {
+/// The mutable state of one walk: the label to attribute to each successor, the
+/// sink they are collected into, and the shadow journal.
+///
+/// The journal records every quantifier binding that *overwrites* an existing
+/// name (`(name, value it shadowed)`). A continuation item pushed at scope mark
+/// `m` must be evaluated with the bindings that were live at `m`, not whatever
+/// an intervening quantifier rebound — TLC gives every continuation node its own
+/// context; the journal reconstructs that with one flat env. See `discharge`.
+struct Run<'r> {
     action: Option<Arc<str>>,
     results: &'r mut Vec<Transition>,
+    journal: Vec<(Arc<str>, Option<Value>)>,
 }
 
 /// Walk one action (a top-level disjunct, already labelled by the caller) and
@@ -103,8 +112,12 @@ pub(crate) fn walk_next(
     action: Option<Arc<str>>,
     results: &mut Vec<Transition>,
 ) -> Result<()> {
-    let mut emit = Emit { action, results };
-    walk(action_expr, &Cont::Nil, env, ctx, &mut emit)
+    let mut run = Run {
+        action,
+        results,
+        journal: Vec::new(),
+    };
+    walk(action_expr, &Cont::Nil, env, ctx, &mut run)
 }
 
 /// Walk the Init predicate over one partial state, binding unprimed variables,
@@ -125,11 +138,12 @@ pub(crate) fn walk_init(
     };
     let mut results = Vec::new();
     {
-        let mut emit = Emit {
+        let mut run = Run {
             action: None,
             results: &mut results,
+            journal: Vec::new(),
         };
-        walk(init, &Cont::Nil, env, &ctx, &mut emit)?;
+        walk(init, &Cont::Nil, env, &ctx, &mut run)?;
     }
     let mut seen = indexmap::IndexSet::new();
     for t in results {
@@ -156,11 +170,12 @@ pub(crate) fn walk_action_enabled(
         require_total: false,
     };
     let mut results = Vec::new();
-    let mut emit = Emit {
+    let mut run = Run {
         action: None,
         results: &mut results,
+        journal: Vec::new(),
     };
-    walk(action, &Cont::Nil, env, &ctx, &mut emit)?;
+    walk(action, &Cont::Nil, env, &ctx, &mut run)?;
     Ok(!results.is_empty())
 }
 
@@ -169,59 +184,66 @@ fn walk(
     cont: &Cont<'_>,
     env: &mut Env,
     ctx: &WalkCtx<'_>,
-    emit: &mut Emit<'_>,
+    run: &mut Run<'_>,
 ) -> Result<()> {
-    if ctx.satisfied(emit) {
+    if ctx.satisfied(run) {
         return Ok(());
     }
     match node {
         // Conjunction: discharge left-to-right. Push the rest onto the
         // continuation and recurse into the head, so every later conjunct sees
         // the primes the earlier ones bound.
-        Expr::And(l, r) => walk(l, &Cont::Cons(r, cont), env, ctx, emit),
+        Expr::And(l, r) => {
+            let mark = run.journal.len();
+            walk(l, &Cont::Cons(r, mark, cont), env, ctx, run)
+        }
 
         // Disjunction: each branch explored with the same continuation and the
         // same partial successor.
         Expr::Or(l, r) => {
-            walk(l, cont, env, ctx, emit)?;
-            walk(r, cont, env, ctx, emit)
+            walk(l, cont, env, ctx, run)?;
+            walk(r, cont, env, ctx, run)
         }
 
         // A named-but-unparameterised action reference, or an action operator:
         // substitute the arguments into the body and walk it.
         Expr::Var(name) => match ctx.defs.get(name) {
-            Some((params, body)) if params.is_empty() => walk(&body.clone(), cont, env, ctx, emit),
-            _ => walk_bool(node, cont, env, ctx, emit),
+            Some((params, body)) if params.is_empty() => walk(&body.clone(), cont, env, ctx, run),
+            _ => walk_bool(node, cont, env, ctx, run),
         },
         Expr::FnCall(name, args) => match ctx.defs.get(name) {
             Some((params, body)) if params.len() == args.len() => {
                 let subs: Vec<(Arc<str>, Expr)> =
                     params.iter().cloned().zip(args.iter().cloned()).collect();
-                walk(&substitute_expr(body, &subs), cont, env, ctx, emit)
+                walk(&substitute_expr(body, &subs), cont, env, ctx, run)
             }
-            _ => walk_bool(node, cont, env, ctx, emit),
+            _ => walk_bool(node, cont, env, ctx, run),
         },
-        Expr::LabeledAction(_, inner) => walk(inner, cont, env, ctx, emit),
+        Expr::LabeledAction(_, inner) => walk(inner, cont, env, ctx, run),
 
         // Instance operator in action position: resolve the operator body (with
         // WITH-substitutions and, for parameterized instances, the instance
         // arguments applied), substitute the call arguments, and walk it.
         Expr::QualifiedCall(instance_expr, op, args) => {
-            walk_qualified_call(instance_expr, op, args, cont, env, ctx, emit)
+            walk_qualified_call(instance_expr, op, args, cont, env, ctx, run)
         }
 
-        // Existential in action position: one branch per witness.
+        // Existential in action position: one branch per witness. The binding
+        // is journalled so a continuation item pushed in an enclosing scope that
+        // is discharged inside this `\E` still sees its own binding, not ours.
         Expr::Exists(var, domain, body) => {
             let dom = eval_set(domain, env, ctx.defs)?;
-            let prev = env.get(var).cloned();
             for val in dom {
-                if ctx.satisfied(emit) {
+                if ctx.satisfied(run) {
                     break;
                 }
-                env.insert(var.clone(), val);
-                walk(body, cont, env, ctx, emit)?;
+                let shadowed = env.insert(var.clone(), val);
+                run.journal.push((var.clone(), shadowed));
+                let r = walk(body, cont, env, ctx, run);
+                let (name, prev) = run.journal.pop().expect("journal balanced");
+                restore(env, &name, prev);
+                r?;
             }
-            restore(env, var, prev);
             Ok(())
         }
 
@@ -233,7 +255,8 @@ fn walk(
                 .into_iter()
                 .map(|val| substitute_expr(body, &[(var.clone(), Expr::Lit(val))]))
                 .collect();
-            advance(&Cont::Slice(&items, cont), env, ctx, emit)
+            let mark = run.journal.len();
+            advance(&Cont::Slice(&items, mark, cont), env, ctx, run)
         }
 
         // UNCHANGED assigns each variable its pre-state value (the evaluator's
@@ -243,16 +266,17 @@ fn walk(
                 .into_iter()
                 .map(|v| Expr::Eq(Box::new(Expr::Prime(v.clone())), Box::new(Expr::Var(v))))
                 .collect();
-            advance(&Cont::Slice(&items, cont), env, ctx, emit)
+            let mark = run.journal.len();
+            advance(&Cont::Slice(&items, mark, cont), env, ctx, run)
         }
 
         // IF: guard is a boolean read in the current partial state; recurse into
         // exactly one branch.
         Expr::If(c, t, e) => {
             if eval_bool(c, env, ctx.defs)? {
-                walk(t, cont, env, ctx, emit)
+                walk(t, cont, env, ctx, run)
             } else {
-                walk(e, cont, env, ctx, emit)
+                walk(e, cont, env, ctx, run)
             }
         }
 
@@ -261,7 +285,7 @@ fn walk(
         Expr::Case(branches) => {
             for (guard, body) in branches {
                 if eval_bool(guard, env, ctx.defs)? {
-                    return walk(body, cont, env, ctx, emit);
+                    return walk(body, cont, env, ctx, run);
                 }
             }
             Err(EvalError::domain_error("CASE: no matching branch"))
@@ -270,30 +294,32 @@ fn walk(
         // LET: bind the definition into the body and walk it.
         Expr::Let(name, binding, body) => {
             let bound = substitute_expr(body, &[(name.clone(), (**binding).clone())]);
-            walk(&bound, cont, env, ctx, emit)
+            walk(&bound, cont, env, ctx, run)
         }
 
         // Equality: an assignment when one side is an (indexed) unbound prime,
         // a constraint otherwise.
-        Expr::Eq(l, r) => walk_eq(node, l, r, cont, env, ctx, emit),
+        Expr::Eq(l, r) => walk_eq(node, l, r, cont, env, ctx, run),
 
         // Membership: a binding construct that enumerates the set when the
         // element is an unbound prime, a constraint otherwise.
-        Expr::In(elem, set) => walk_in(node, elem, set, cont, env, ctx, emit),
+        Expr::In(elem, set) => walk_in(node, elem, set, cont, env, ctx, run),
 
         // Everything else is a boolean predicate: evaluate, prune on false.
-        _ => walk_bool(node, cont, env, ctx, emit),
+        _ => walk_bool(node, cont, env, ctx, run),
     }
 }
 
-/// Discharge the continuation: pop the next pending conjunct, or emit a
+/// Discharge the continuation: pop the next pending conjunct, or run a
 /// successor if none remain.
-fn advance(cont: &Cont<'_>, env: &mut Env, ctx: &WalkCtx<'_>, emit: &mut Emit<'_>) -> Result<()> {
+fn advance(cont: &Cont<'_>, env: &mut Env, ctx: &WalkCtx<'_>, run: &mut Run<'_>) -> Result<()> {
     match cont {
-        Cont::Cons(head, tail) => walk(head, tail, env, ctx, emit),
-        Cont::Slice(items, tail) => match items.split_first() {
-            None => advance(tail, env, ctx, emit),
-            Some((head, rest)) => walk(head, &Cont::Slice(rest, tail), env, ctx, emit),
+        Cont::Cons(head, mark, tail) => discharge(head, tail, *mark, env, ctx, run),
+        Cont::Slice(items, mark, tail) => match items.split_first() {
+            None => advance(tail, env, ctx, run),
+            Some((head, rest)) => {
+                discharge(head, &Cont::Slice(rest, *mark, tail), *mark, env, ctx, run)
+            }
         },
         Cont::Nil => {
             // Generating a state requires every variable assigned — the walker
@@ -301,9 +327,9 @@ fn advance(cont: &Cont<'_>, env: &mut Env, ctx: &WalkCtx<'_>, emit: &mut Emit<'_
             // diagnostic for that lands in a later commit). `ENABLED`
             // (require_total = false) accepts a partial assignment as a witness.
             if !ctx.require_total || ctx.state_keys.iter().all(|k| env.get(k).is_some()) {
-                emit.results.push(Transition {
+                run.results.push(Transition {
                     state: env_to_next_state(env, ctx.vars, ctx.state_keys),
-                    action: emit.action.clone(),
+                    action: run.action.clone(),
                 });
             }
             Ok(())
@@ -311,15 +337,53 @@ fn advance(cont: &Cont<'_>, env: &mut Env, ctx: &WalkCtx<'_>, emit: &mut Emit<'_
     }
 }
 
+/// Discharge a continuation item that was pushed at scope `mark`. The journal
+/// may have grown since — quantifiers entered between the push and now — so
+/// unwind those shadowing bindings to reconstruct the scope the item was written
+/// in, walk it, then redo them so the enclosing scopes see their own bindings
+/// again (sibling disjuncts and the quantifier loops depend on it).
+fn discharge(
+    head: &Expr,
+    tail: &Cont<'_>,
+    mark: usize,
+    env: &mut Env,
+    ctx: &WalkCtx<'_>,
+    run: &mut Run<'_>,
+) -> Result<()> {
+    // Fast path: nothing was shadowed since the item was pushed.
+    if run.journal.len() == mark {
+        return walk(head, tail, env, ctx, run);
+    }
+
+    // Unwind to `mark`, remembering both the shadowed value (to redo the
+    // journal) and the shadowing value currently in env (to redo env).
+    let mut undone: Vec<(Arc<str>, Option<Value>, Option<Value>)> = Vec::new();
+    while run.journal.len() > mark {
+        let (name, shadowed) = run.journal.pop().expect("journal longer than mark");
+        let shadowing = env.get(&name).cloned();
+        restore(env, &name, shadowed.clone());
+        undone.push((name, shadowed, shadowing));
+    }
+
+    let r = walk(head, tail, env, ctx, run);
+
+    // Redo, bottom-of-the-unwound-suffix first, restoring env and journal exactly.
+    for (name, shadowed, shadowing) in undone.into_iter().rev() {
+        restore(env, &name, shadowing);
+        run.journal.push((name, shadowed));
+    }
+    r
+}
+
 fn walk_bool(
     node: &Expr,
     cont: &Cont<'_>,
     env: &mut Env,
     ctx: &WalkCtx<'_>,
-    emit: &mut Emit<'_>,
+    run: &mut Run<'_>,
 ) -> Result<()> {
     if eval_bool(node, env, ctx.defs)? {
-        advance(cont, env, ctx, emit)
+        advance(cont, env, ctx, run)
     } else {
         Ok(())
     }
@@ -332,15 +396,15 @@ fn walk_eq(
     cont: &Cont<'_>,
     env: &mut Env,
     ctx: &WalkCtx<'_>,
-    emit: &mut Emit<'_>,
+    run: &mut Run<'_>,
 ) -> Result<()> {
     if let Some((name, keys)) = ctx.assign_target(l) {
-        return assign_or_constrain(&name, &keys, r, cont, env, ctx, emit);
+        return assign_or_constrain(&name, &keys, r, cont, env, ctx, run);
     }
     if let Some((name, keys)) = ctx.assign_target(r) {
-        return assign_or_constrain(&name, &keys, l, cont, env, ctx, emit);
+        return assign_or_constrain(&name, &keys, l, cont, env, ctx, run);
     }
-    walk_bool(node, cont, env, ctx, emit)
+    walk_bool(node, cont, env, ctx, run)
 }
 
 fn walk_in(
@@ -350,7 +414,7 @@ fn walk_in(
     cont: &Cont<'_>,
     env: &mut Env,
     ctx: &WalkCtx<'_>,
-    emit: &mut Emit<'_>,
+    run: &mut Run<'_>,
 ) -> Result<()> {
     if let Some((name, keys)) = ctx.assign_target(elem)
         && keys.is_empty()
@@ -359,17 +423,17 @@ fn walk_in(
         if env.get(&key).is_none() {
             let dom = eval_set(set, env, ctx.defs)?;
             for val in dom {
-                if ctx.satisfied(emit) {
+                if ctx.satisfied(run) {
                     break;
                 }
                 env.insert(key.clone(), val);
-                advance(cont, env, ctx, emit)?;
+                advance(cont, env, ctx, run)?;
             }
             env.remove(&key);
             return Ok(());
         }
     }
-    walk_bool(node, cont, env, ctx, emit)
+    walk_bool(node, cont, env, ctx, run)
 }
 
 /// Bind `name'` (possibly at a nested key path) to the value of `rhs`, or, if it
@@ -381,7 +445,7 @@ fn assign_or_constrain(
     cont: &Cont<'_>,
     env: &mut Env,
     ctx: &WalkCtx<'_>,
-    emit: &mut Emit<'_>,
+    run: &mut Run<'_>,
 ) -> Result<()> {
     let key = ctx.key_for(name);
     let rhs_val = eval(rhs, env, ctx.defs)?;
@@ -390,13 +454,13 @@ fn assign_or_constrain(
         match env.get(&key).cloned() {
             None => {
                 env.insert(key.clone(), rhs_val);
-                advance(cont, env, ctx, emit)?;
+                advance(cont, env, ctx, run)?;
                 env.remove(&key);
                 Ok(())
             }
             Some(existing) => {
                 if existing == rhs_val {
-                    advance(cont, env, ctx, emit)
+                    advance(cont, env, ctx, run)
                 } else {
                     Ok(())
                 }
@@ -417,7 +481,7 @@ fn assign_or_constrain(
         let updated = update_nested_value(&base, &key_vals, rhs_val)?;
         let prev = env.get(&key).cloned();
         env.insert(key.clone(), updated);
-        advance(cont, env, ctx, emit)?;
+        advance(cont, env, ctx, run)?;
         restore(env, &key, prev);
         Ok(())
     }
@@ -432,7 +496,7 @@ fn walk_qualified_call(
     cont: &Cont<'_>,
     env: &mut Env,
     ctx: &WalkCtx<'_>,
-    emit: &mut Emit<'_>,
+    run: &mut Run<'_>,
 ) -> Result<()> {
     use super::global_state::{PARAMETERIZED_INSTANCES, RESOLVED_INSTANCES};
 
@@ -464,13 +528,13 @@ fn walk_qualified_call(
         // which produces the evaluator's own diagnostic.
         let fallback =
             Expr::QualifiedCall(Box::new(instance_expr.clone()), op.clone(), args.to_vec());
-        return walk_bool(&fallback, cont, env, ctx, emit);
+        return walk_bool(&fallback, cont, env, ctx, run);
     };
 
     if params.len() != args.len() {
         let fallback =
             Expr::QualifiedCall(Box::new(instance_expr.clone()), op.clone(), args.to_vec());
-        return walk_bool(&fallback, cont, env, ctx, emit);
+        return walk_bool(&fallback, cont, env, ctx, run);
     }
 
     let subs: Vec<(Arc<str>, Expr)> = params.into_iter().zip(args.iter().cloned()).collect();
@@ -487,7 +551,7 @@ fn walk_qualified_call(
         phase: ctx.phase,
         require_total: ctx.require_total,
     };
-    walk(&bound_body, cont, env, &sub_ctx, emit)
+    walk(&bound_body, cont, env, &sub_ctx, run)
 }
 
 /// If `expr` is a bare state variable, or an indexed access rooted at one,

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use super::Definitions;
-use super::ast_utils::{collect_disjuncts_with_labels, contains_prime_ref};
+use super::ast_utils::{collect_disjuncts_with_labels, contains_prime_ref, parameterized_let_op};
 use super::core::{eval, expand_unchanged_vars};
 use super::error::{EvalError, Result};
 use super::helpers::{eval_bool, eval_set, get_nested, update_nested_value};
@@ -340,6 +340,18 @@ fn walk(
         }
 
         Expr::Let(name, binding, body) => {
+            if let Some((params, op_body)) = parameterized_let_op(binding) {
+                let mut merged = ctx.defs.clone();
+                merged.insert(name.clone(), (params, op_body.clone()));
+                let sub_ctx = WalkCtx {
+                    vars: ctx.vars,
+                    state_keys: ctx.state_keys,
+                    defs: &merged,
+                    phase: ctx.phase,
+                    require_total: ctx.require_total,
+                };
+                return walk(body, cont, env, &sub_ctx, run);
+            }
             let bound = substitute_expr(body, &[(name.clone(), (**binding).clone())]);
             walk(&bound, cont, env, ctx, run)
         }

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -569,26 +569,45 @@ fn walk_in(
     ctx: &WalkCtx<'_>,
     run: &mut Run<'_>,
 ) -> Result<()> {
-    if let Some((name, keys)) = ctx.assign_target(elem)
-        && keys.is_empty()
-    {
-        let key = ctx.key_for(&name);
-        if env.get(&key).is_none() {
+    if let Some((name, keys)) = ctx.assign_target(elem) {
+        if keys.is_empty() {
+            let key = ctx.key_for(&name);
+            if env.get(&key).is_none() {
+                let dom = eval_set(set, env, ctx.defs)?;
+                run.fully_assigned.push(key.clone());
+                let mut result = Ok(());
+                for val in dom {
+                    if ctx.satisfied(run) {
+                        break;
+                    }
+                    env.insert(key.clone(), val);
+                    result = advance(cont, env, ctx, run);
+                    if result.is_err() {
+                        break;
+                    }
+                }
+                run.fully_assigned.pop();
+                env.remove(&key);
+                return result;
+            }
+        } else {
+            // `name'[k..] \in S` is the indexed counterpart of `name'[k..] = v`:
+            // it binds the path to each element of S, i.e. one branch per witness
+            // of `\E v \in S : name'[k..] = v`. Each branch goes through the same
+            // path that a `name'[k..] = v` equality would, so an indexed
+            // assignment, an indexed re-constraint, and a whole-variable
+            // assignment on the same key all interact the same way here.
             let dom = eval_set(set, env, ctx.defs)?;
-            run.fully_assigned.push(key.clone());
             let mut result = Ok(());
             for val in dom {
                 if ctx.satisfied(run) {
                     break;
                 }
-                env.insert(key.clone(), val);
-                result = advance(cont, env, ctx, run);
+                result = assign_or_constrain(&name, &keys, &Expr::Lit(val), cont, env, ctx, run);
                 if result.is_err() {
                     break;
                 }
             }
-            run.fully_assigned.pop();
-            env.remove(&key);
             return result;
         }
     }

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -229,13 +229,6 @@ fn walk(
     if ctx.satisfied(run) {
         return Ok(());
     }
-    // Hoist prime-free conjuncts: a node that assigns nothing is a guard, so
-    // evaluate it in place instead of branching structurally. Without this a
-    // prime-free `\A i \in 1..n : (P \/ Q)` walked as an action discharges the
-    // whole continuation once per disjunct — O(2^n). If evaluating it errors,
-    // fall through to the structural walk (which produces the real diagnostic
-    // and preserves conjunct order). Only in `Next`, where "assigns nothing"
-    // is exactly "contains no prime".
     if ctx.phase == Phase::Next
         && !matches!(node, Expr::And(_, _))
         && !contains_prime_ref(node, ctx.defs)
@@ -248,20 +241,11 @@ fn walk(
         };
     }
     match node {
-        // Conjunction: discharge left-to-right. Push the rest onto the
-        // continuation and recurse into the head, so every later conjunct sees
-        // the primes the earlier ones bound.
         Expr::And(l, r) => {
             let mark = run.journal.len();
             walk(l, &Cont::Cons(r, mark, cont), env, ctx, run)
         }
 
-        // Disjunction: each branch explored with the same continuation and the
-        // same partial successor. When no enclosing action has named these
-        // transitions yet, recover each disjunct's action name — operator bodies
-        // are inlined before the walk, so the name is matched back structurally,
-        // the same way the inference engine attributes actions. This is what pins
-        // `\E rm : A(rm) \/ B(rm)` to A and B instead of a single unnamed lump.
         Expr::Or(_, _) if run.action.is_none() => {
             for (disjunct, label) in collect_disjuncts_with_labels(node, ctx.defs) {
                 match label {
@@ -276,10 +260,6 @@ fn walk(
             walk(r, cont, env, ctx, run)
         }
 
-        // A named-but-unparameterised action reference, or an action operator:
-        // substitute the arguments into the body and walk it. Entering a named
-        // action names the transitions it produces (for fairness attribution and
-        // the per-action histogram) unless an enclosing action already named them.
         Expr::Var(name) => match ctx.defs.get(name) {
             Some((params, body)) if params.is_empty() => {
                 walk_named(name.clone(), &body.clone(), cont, env, ctx, run)
@@ -303,16 +283,10 @@ fn walk(
         },
         Expr::LabeledAction(label, inner) => walk_named(label.clone(), inner, cont, env, ctx, run),
 
-        // Instance operator in action position: resolve the operator body (with
-        // WITH-substitutions and, for parameterized instances, the instance
-        // arguments applied), substitute the call arguments, and walk it.
         Expr::QualifiedCall(instance_expr, op, args) => {
             walk_qualified_call(instance_expr, op, args, cont, env, ctx, run)
         }
 
-        // Existential in action position: one branch per witness. The binding
-        // is journalled so a continuation item pushed in an enclosing scope that
-        // is discharged inside this `\E` still sees its own binding, not ours.
         Expr::Exists(var, domain, body) => {
             let dom = eval_set(domain, env, ctx.defs)?;
             for val in dom {
@@ -329,8 +303,6 @@ fn walk(
             Ok(())
         }
 
-        // Universal in action position: the body must hold for every element,
-        // so expand to a conjunction over the (concrete) domain.
         Expr::Forall(var, domain, body) => {
             let dom = eval_set(domain, env, ctx.defs)?;
             let items: Vec<Expr> = dom
@@ -341,8 +313,6 @@ fn walk(
             advance(&Cont::Slice(&items, mark, cont), env, ctx, run)
         }
 
-        // UNCHANGED assigns each variable its pre-state value (the evaluator's
-        // own arm is a *constraint*, which needs the primes already bound).
         Expr::Unchanged(vars) => {
             let items: Vec<Expr> = expand_unchanged_vars(vars, ctx.defs)
                 .into_iter()
@@ -352,8 +322,6 @@ fn walk(
             advance(&Cont::Slice(&items, mark, cont), env, ctx, run)
         }
 
-        // IF: guard is a boolean read in the current partial state; recurse into
-        // exactly one branch.
         Expr::If(c, t, e) => {
             if eval_bool(c, env, ctx.defs)? {
                 walk(t, cont, env, ctx, run)
@@ -362,8 +330,6 @@ fn walk(
             }
         }
 
-        // CASE: first branch whose guard holds; a non-exhaustive CASE is a hard
-        // error (as in the evaluator).
         Expr::Case(branches) => {
             for (guard, body) in branches {
                 if eval_bool(guard, env, ctx.defs)? {
@@ -373,21 +339,15 @@ fn walk(
             Err(EvalError::domain_error("CASE: no matching branch"))
         }
 
-        // LET: bind the definition into the body and walk it.
         Expr::Let(name, binding, body) => {
             let bound = substitute_expr(body, &[(name.clone(), (**binding).clone())]);
             walk(&bound, cont, env, ctx, run)
         }
 
-        // Equality: an assignment when one side is an (indexed) unbound prime,
-        // a constraint otherwise.
         Expr::Eq(l, r) => walk_eq(node, l, r, cont, env, ctx, run),
 
-        // Membership: a binding construct that enumerates the set when the
-        // element is an unbound prime, a constraint otherwise.
         Expr::In(elem, set) => walk_in(node, elem, set, cont, env, ctx, run),
 
-        // Everything else is a boolean predicate: evaluate, prune on false.
         _ => walk_bool(node, cont, env, ctx, run),
     }
 }
@@ -503,13 +463,10 @@ fn discharge(
     ctx: &WalkCtx<'_>,
     run: &mut Run<'_>,
 ) -> Result<()> {
-    // Fast path: nothing was shadowed since the item was pushed.
     if run.journal.len() == mark {
         return walk(head, tail, env, ctx, run);
     }
 
-    // Unwind to `mark`, remembering both the shadowed value (to redo the
-    // journal) and the shadowing value currently in env (to redo env).
     let mut undone: Vec<(Arc<str>, Option<Value>, Option<Value>)> = Vec::new();
     while run.journal.len() > mark {
         let (name, shadowed) = run.journal.pop().expect("journal longer than mark");
@@ -520,7 +477,6 @@ fn discharge(
 
     let r = walk(head, tail, env, ctx, run);
 
-    // Redo, bottom-of-the-unwound-suffix first, restoring env and journal exactly.
     for (name, shadowed, shadowing) in undone.into_iter().rev() {
         restore(env, &name, shadowing);
         run.journal.push((name, shadowed));
@@ -591,12 +547,6 @@ fn walk_in(
                 return result;
             }
         } else {
-            // `name'[k..] \in S` is the indexed counterpart of `name'[k..] = v`:
-            // it binds the path to each element of S, i.e. one branch per witness
-            // of `\E v \in S : name'[k..] = v`. Each branch goes through the same
-            // path that a `name'[k..] = v` equality would, so an indexed
-            // assignment, an indexed re-constraint, and a whole-variable
-            // assignment on the same key all interact the same way here.
             let dom = eval_set(set, env, ctx.defs)?;
             let mut result = Ok(());
             for val in dom {
@@ -647,17 +597,11 @@ fn assign_or_constrain(
             }
         }
     } else {
-        // Indexed assignment `name'[k..] = rhs`.
         let key_vals: Vec<Value> = keys
             .iter()
             .map(|k| eval(k, env, ctx.defs))
             .collect::<Result<_>>()?;
 
-        // The equality is a *constraint* (the value already there must match, or
-        // the branch has no successor) when either the whole variable was already
-        // assigned — `f' = g /\ f'[1] = 5` requires `g[1] = 5`, it does not rebind
-        // index 1 — or this exact indexed path was already assigned on this branch
-        // (`f'[1] = 5 /\ f'[1] = 6` is unsatisfiable).
         let already_assigned = run.fully_assigned.contains(&key)
             || run
                 .assigned_paths
@@ -675,8 +619,6 @@ fn assign_or_constrain(
             };
         }
 
-        // A fresh path: extend the partial function. Base is the current binding
-        // of `name'` if any, otherwise the pre-state value of `name`.
         let base = match env.get(&key).cloned().or_else(|| env.get(name).cloned()) {
             Some(v) => v,
             None => return Ok(()),
@@ -713,13 +655,6 @@ fn walk_qualified_call(
             Some((instance_defs.clone(), params.clone(), body.clone()))
         }),
         Expr::FnCall(instance_name, instance_args) => {
-            // Resolve with the arguments' concrete values, not their expressions.
-            // A `WITH p <- f[arg]` substitution puts `arg` under a prime, and
-            // `prime_expr` primes every variable it contains, so a symbolic
-            // `Var` argument becomes an undefined `arg'`; a `Lit` value is rigid
-            // under priming. The inference engine resolves with values for the
-            // same reason. Arguments in action position are always bound here; if
-            // one is not evaluable, fall back to the symbolic resolution.
             let concrete: Option<Vec<Value>> = instance_args
                 .iter()
                 .map(|a| eval(a, env, ctx.defs).ok())
@@ -747,8 +682,6 @@ fn walk_qualified_call(
     };
 
     let Some((instance_defs, params, body)) = resolved else {
-        // Not resolvable as an action call; fall back to boolean evaluation,
-        // which produces the evaluator's own diagnostic.
         let fallback =
             Expr::QualifiedCall(Box::new(instance_expr.clone()), op.clone(), args.to_vec());
         return walk_bool(&fallback, cont, env, ctx, run);

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -130,6 +130,11 @@ struct Run<'r> {
     /// overwrite — `f'[1] = 5 /\ f'[1] = 6` is unsatisfiable, and a `\A` that
     /// sets every index must not be silently overwritten by a later `f'[i] = e`.
     assigned_paths: Vec<(Arc<str>, Vec<Value>)>,
+    /// State keys bound as a *whole* on this branch (`f' = g`, `f' \in S`, or an
+    /// `UNCHANGED f`). A later indexed reference to such a key is a constraint on
+    /// the value already there, not an overwrite — `f' = g /\ f'[1] = 5` requires
+    /// `g[1] = 5`, it does not rebind index 1 to 5.
+    fully_assigned: Vec<Arc<str>>,
 }
 
 /// Walk one action (a top-level disjunct, already labelled by the caller) and
@@ -146,6 +151,7 @@ pub(crate) fn walk_next(
         results,
         journal: Vec::new(),
         assigned_paths: Vec::new(),
+        fully_assigned: Vec::new(),
     };
     walk(action_expr, &Cont::Nil, env, ctx, &mut run)
 }
@@ -173,6 +179,7 @@ pub(crate) fn walk_init(
             results: &mut results,
             journal: Vec::new(),
             assigned_paths: Vec::new(),
+            fully_assigned: Vec::new(),
         };
         walk(init, &Cont::Nil, env, &ctx, &mut run)?;
     }
@@ -206,6 +213,7 @@ pub(crate) fn walk_action_enabled(
         results: &mut results,
         journal: Vec::new(),
         assigned_paths: Vec::new(),
+        fully_assigned: Vec::new(),
     };
     walk(action, &Cont::Nil, env, &ctx, &mut run)?;
     Ok(!results.is_empty())
@@ -567,15 +575,21 @@ fn walk_in(
         let key = ctx.key_for(&name);
         if env.get(&key).is_none() {
             let dom = eval_set(set, env, ctx.defs)?;
+            run.fully_assigned.push(key.clone());
+            let mut result = Ok(());
             for val in dom {
                 if ctx.satisfied(run) {
                     break;
                 }
                 env.insert(key.clone(), val);
-                advance(cont, env, ctx, run)?;
+                result = advance(cont, env, ctx, run);
+                if result.is_err() {
+                    break;
+                }
             }
+            run.fully_assigned.pop();
             env.remove(&key);
-            return Ok(());
+            return result;
         }
     }
     walk_bool(node, cont, env, ctx, run)
@@ -599,9 +613,11 @@ fn assign_or_constrain(
         match env.get(&key).cloned() {
             None => {
                 env.insert(key.clone(), rhs_val);
-                advance(cont, env, ctx, run)?;
+                run.fully_assigned.push(key.clone());
+                let r = advance(cont, env, ctx, run);
+                run.fully_assigned.pop();
                 env.remove(&key);
-                Ok(())
+                r
             }
             Some(existing) => {
                 if existing == rhs_val {
@@ -618,13 +634,16 @@ fn assign_or_constrain(
             .map(|k| eval(k, env, ctx.defs))
             .collect::<Result<_>>()?;
 
-        // If this exact path was already assigned on this branch, the equality is
-        // a *constraint*: the value already there must match, or the branch has no
-        // successor. (`f'[1] = 5 /\ f'[1] = 6` is unsatisfiable.)
-        let already_assigned = run
-            .assigned_paths
-            .iter()
-            .any(|(k, p)| *k == key && *p == key_vals);
+        // The equality is a *constraint* (the value already there must match, or
+        // the branch has no successor) when either the whole variable was already
+        // assigned — `f' = g /\ f'[1] = 5` requires `g[1] = 5`, it does not rebind
+        // index 1 — or this exact indexed path was already assigned on this branch
+        // (`f'[1] = 5 /\ f'[1] = 6` is unsatisfiable).
+        let already_assigned = run.fully_assigned.contains(&key)
+            || run
+                .assigned_paths
+                .iter()
+                .any(|(k, p)| *k == key && *p == key_vals);
         if already_assigned {
             let matches = env
                 .get(&key)

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -9,12 +9,13 @@
 //! assigned. Dependencies like `b' = a' + 10` need no analysis: `a'` is already
 //! bound when `b'`'s conjunct is reached.
 //!
-//! Gated behind `TLA_WALK` while both engines coexist (design commits 3–10).
+//! The default engine; the legacy candidate-inference engine remains available
+//! for one release as an escape hatch (`TLA_ENGINE=inference`).
 
 use std::sync::Arc;
 
 use super::Definitions;
-use super::ast_utils::contains_prime_ref;
+use super::ast_utils::{collect_disjuncts_with_labels, contains_prime_ref};
 use super::core::{eval, expand_unchanged_vars};
 use super::error::{EvalError, Result};
 use super::helpers::{eval_bool, eval_set, get_nested, update_nested_value};
@@ -23,13 +24,20 @@ use crate::ast::{Env, Expr, Transition, Value};
 use crate::intern::primed_name;
 use crate::substitution::substitute_expr;
 
-/// Whether the walker engine is selected.
-pub(crate) fn walk_enabled() -> bool {
-    std::env::var_os("TLA_WALK").is_some()
+thread_local! {
+    static USE_INFERENCE_ENGINE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static ALLOW_UNASSIGNED_STUTTER: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
-thread_local! {
-    static ALLOW_UNASSIGNED_STUTTER: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+/// Select the legacy candidate-inference engine instead of the default walker.
+/// Retained for one release as an escape hatch (`TLA_ENGINE=inference`).
+pub fn set_use_inference_engine(use_inference: bool) {
+    USE_INFERENCE_ENGINE.with(|c| c.set(use_inference));
+}
+
+/// Whether the walker engine is selected. Default; the inference engine is opt-in.
+pub(crate) fn walk_enabled() -> bool {
+    !USE_INFERENCE_ENGINE.with(std::cell::Cell::get)
 }
 
 /// Opt into treating a variable an action leaves unassigned as an implicit
@@ -241,27 +249,51 @@ fn walk(
         }
 
         // Disjunction: each branch explored with the same continuation and the
-        // same partial successor.
+        // same partial successor. When no enclosing action has named these
+        // transitions yet, recover each disjunct's action name — operator bodies
+        // are inlined before the walk, so the name is matched back structurally,
+        // the same way the inference engine attributes actions. This is what pins
+        // `\E rm : A(rm) \/ B(rm)` to A and B instead of a single unnamed lump.
+        Expr::Or(_, _) if run.action.is_none() => {
+            for (disjunct, label) in collect_disjuncts_with_labels(node, ctx.defs) {
+                match label {
+                    Some(name) => walk_named(name, disjunct, cont, env, ctx, run)?,
+                    None => walk(disjunct, cont, env, ctx, run)?,
+                }
+            }
+            Ok(())
+        }
         Expr::Or(l, r) => {
             walk(l, cont, env, ctx, run)?;
             walk(r, cont, env, ctx, run)
         }
 
         // A named-but-unparameterised action reference, or an action operator:
-        // substitute the arguments into the body and walk it.
+        // substitute the arguments into the body and walk it. Entering a named
+        // action names the transitions it produces (for fairness attribution and
+        // the per-action histogram) unless an enclosing action already named them.
         Expr::Var(name) => match ctx.defs.get(name) {
-            Some((params, body)) if params.is_empty() => walk(&body.clone(), cont, env, ctx, run),
+            Some((params, body)) if params.is_empty() => {
+                walk_named(name.clone(), &body.clone(), cont, env, ctx, run)
+            }
             _ => walk_bool(node, cont, env, ctx, run),
         },
         Expr::FnCall(name, args) => match ctx.defs.get(name) {
             Some((params, body)) if params.len() == args.len() => {
                 let subs: Vec<(Arc<str>, Expr)> =
                     params.iter().cloned().zip(args.iter().cloned()).collect();
-                walk(&substitute_expr(body, &subs), cont, env, ctx, run)
+                walk_named(
+                    name.clone(),
+                    &substitute_expr(body, &subs),
+                    cont,
+                    env,
+                    ctx,
+                    run,
+                )
             }
             _ => walk_bool(node, cont, env, ctx, run),
         },
-        Expr::LabeledAction(_, inner) => walk(inner, cont, env, ctx, run),
+        Expr::LabeledAction(label, inner) => walk_named(label.clone(), inner, cont, env, ctx, run),
 
         // Instance operator in action position: resolve the operator body (with
         // WITH-substitutions and, for parameterized instances, the instance
@@ -350,6 +382,28 @@ fn walk(
         // Everything else is a boolean predicate: evaluate, prune on false.
         _ => walk_bool(node, cont, env, ctx, run),
     }
+}
+
+/// Walk a named action's body, attributing the successors it emits to `label`
+/// unless an enclosing action already claimed them. The label is restored on the
+/// way out (including on error) so sibling disjuncts are attributed independently.
+/// Matches the inference engine, which labels a transition by the innermost named
+/// disjunct that produced it (`sub_action.or(action)`).
+fn walk_named(
+    label: Arc<str>,
+    body: &Expr,
+    cont: &Cont<'_>,
+    env: &mut Env,
+    ctx: &WalkCtx<'_>,
+    run: &mut Run<'_>,
+) -> Result<()> {
+    if run.action.is_some() {
+        return walk(body, cont, env, ctx, run);
+    }
+    run.action = Some(label);
+    let result = walk(body, cont, env, ctx, run);
+    run.action = None;
+    result
 }
 
 /// Discharge the continuation: pop the next pending conjunct, or run a

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -42,6 +42,20 @@ pub(crate) struct WalkCtx<'a> {
     pub state_keys: &'a [Arc<str>],
     pub defs: &'a Definitions,
     pub phase: Phase,
+    /// Whether a successor requires *every* variable assigned. Generating states
+    /// (`Next`/`Init`) demands totality — an unassigned variable is not a state.
+    /// `ENABLED A` is `\E vars' : A`, so a partial assignment is a legitimate
+    /// witness; there totality is not required and the walk short-circuits on the
+    /// first witness.
+    pub require_total: bool,
+}
+
+impl WalkCtx<'_> {
+    /// True once a witness has been found and no further search is needed
+    /// (the `ENABLED` case).
+    fn satisfied(&self, emit: &Emit<'_>) -> bool {
+        !self.require_total && !emit.results.is_empty()
+    }
 }
 
 impl WalkCtx<'_> {
@@ -107,6 +121,7 @@ pub(crate) fn walk_init(
         state_keys: vars,
         defs,
         phase: Phase::Init,
+        require_total: true,
     };
     let mut results = Vec::new();
     {
@@ -123,6 +138,32 @@ pub(crate) fn walk_init(
     Ok(seen.into_iter().collect())
 }
 
+/// `ENABLED action` in the current state: does the action have any successor?
+/// `ENABLED A` is `\E vars' : A`, so a partial assignment counts — an action
+/// that leaves some variable unconstrained is still enabled.
+pub(crate) fn walk_action_enabled(
+    action: &Expr,
+    env: &mut Env,
+    vars: &[Arc<str>],
+    state_keys: &[Arc<str>],
+    defs: &Definitions,
+) -> Result<bool> {
+    let ctx = WalkCtx {
+        vars,
+        state_keys,
+        defs,
+        phase: Phase::Next,
+        require_total: false,
+    };
+    let mut results = Vec::new();
+    let mut emit = Emit {
+        action: None,
+        results: &mut results,
+    };
+    walk(action, &Cont::Nil, env, &ctx, &mut emit)?;
+    Ok(!results.is_empty())
+}
+
 fn walk(
     node: &Expr,
     cont: &Cont<'_>,
@@ -130,6 +171,9 @@ fn walk(
     ctx: &WalkCtx<'_>,
     emit: &mut Emit<'_>,
 ) -> Result<()> {
+    if ctx.satisfied(emit) {
+        return Ok(());
+    }
     match node {
         // Conjunction: discharge left-to-right. Push the rest onto the
         // continuation and recurse into the head, so every later conjunct sees
@@ -171,6 +215,9 @@ fn walk(
             let dom = eval_set(domain, env, ctx.defs)?;
             let prev = env.get(var).cloned();
             for val in dom {
+                if ctx.satisfied(emit) {
+                    break;
+                }
                 env.insert(var.clone(), val);
                 walk(body, cont, env, ctx, emit)?;
             }
@@ -249,10 +296,11 @@ fn advance(cont: &Cont<'_>, env: &mut Env, ctx: &WalkCtx<'_>, emit: &mut Emit<'_
             Some((head, rest)) => walk(head, &Cont::Slice(rest, tail), env, ctx, emit),
         },
         Cont::Nil => {
-            // A successor exists only if every variable was assigned. The walker
-            // never invents a stutter for an unassigned variable; a loud
-            // diagnostic for that case lands in a later commit.
-            if ctx.state_keys.iter().all(|k| env.get(k).is_some()) {
+            // Generating a state requires every variable assigned — the walker
+            // never invents a stutter for an unassigned variable (a loud
+            // diagnostic for that lands in a later commit). `ENABLED`
+            // (require_total = false) accepts a partial assignment as a witness.
+            if !ctx.require_total || ctx.state_keys.iter().all(|k| env.get(k).is_some()) {
                 emit.results.push(Transition {
                     state: env_to_next_state(env, ctx.vars, ctx.state_keys),
                     action: emit.action.clone(),
@@ -311,6 +359,9 @@ fn walk_in(
         if env.get(&key).is_none() {
             let dom = eval_set(set, env, ctx.defs)?;
             for val in dom {
+                if ctx.satisfied(emit) {
+                    break;
+                }
                 env.insert(key.clone(), val);
                 advance(cont, env, ctx, emit)?;
             }
@@ -434,6 +485,7 @@ fn walk_qualified_call(
         state_keys: ctx.state_keys,
         defs: &merged,
         phase: ctx.phase,
+        require_total: ctx.require_total,
     };
     walk(&bound_body, cont, env, &sub_ctx, emit)
 }

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -519,10 +519,20 @@ fn walk_eq(
     ctx: &WalkCtx<'_>,
     run: &mut Run<'_>,
 ) -> Result<()> {
-    if let Some((name, keys)) = ctx.assign_target(l) {
+    let lt = ctx.assign_target(l);
+    let rt = ctx.assign_target(r);
+    let unbound_whole = |t: &Option<(Arc<str>, Vec<Expr>)>| matches!(t, Some((n, k)) if k.is_empty() && env.get(&ctx.key_for(n)).is_none());
+    if !unbound_whole(&lt)
+        && let Some((name, keys)) = &rt
+        && keys.is_empty()
+        && env.get(&ctx.key_for(name)).is_none()
+    {
+        return assign_or_constrain(name, keys, l, cont, env, ctx, run);
+    }
+    if let Some((name, keys)) = lt {
         return assign_or_constrain(&name, &keys, r, cont, env, ctx, run);
     }
-    if let Some((name, keys)) = ctx.assign_target(r) {
+    if let Some((name, keys)) = rt {
         return assign_or_constrain(&name, &keys, l, cont, env, ctx, run);
     }
     walk_bool(node, cont, env, ctx, run)
@@ -620,11 +630,11 @@ fn assign_or_constrain(
                 .iter()
                 .any(|(k, p)| *k == key && *p == key_vals);
         if already_assigned {
-            let matches = env
-                .get(&key)
-                .and_then(|v| get_nested(v, &key_vals).ok())
-                .is_some_and(|existing| existing == rhs_val);
-            return if matches {
+            let current = match env.get(&key) {
+                Some(v) => get_nested(v, &key_vals)?,
+                None => return Ok(()),
+            };
+            return if current == rhs_val {
                 advance(cont, env, ctx, run)
             } else {
                 Ok(())

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -28,6 +28,21 @@ pub(crate) fn walk_enabled() -> bool {
     std::env::var_os("TLA_WALK").is_some()
 }
 
+thread_local! {
+    static ALLOW_UNASSIGNED_STUTTER: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Opt into treating a variable an action leaves unassigned as an implicit
+/// `UNCHANGED` (a stutter of that variable) instead of a hard error. Off by
+/// default: an unassigned variable is a malformed action, as in TLC.
+pub fn set_allow_unassigned_stutter(allow: bool) {
+    ALLOW_UNASSIGNED_STUTTER.with(|c| c.set(allow));
+}
+
+fn allow_unassigned_stutter() -> bool {
+    ALLOW_UNASSIGNED_STUTTER.with(std::cell::Cell::get)
+}
+
 /// Whether the walker is generating successors (`x' = e` binds `x'`) or initial
 /// states (`x = e` binds `x`). The machine is otherwise identical, as in TLC.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -348,20 +363,69 @@ fn advance(cont: &Cont<'_>, env: &mut Env, ctx: &WalkCtx<'_>, run: &mut Run<'_>)
                 discharge(head, &Cont::Slice(rest, *mark, tail), *mark, env, ctx, run)
             }
         },
-        Cont::Nil => {
-            // Generating a state requires every variable assigned — the walker
-            // never invents a stutter for an unassigned variable (a loud
-            // diagnostic for that lands in a later commit). `ENABLED`
-            // (require_total = false) accepts a partial assignment as a witness.
-            if !ctx.require_total || ctx.state_keys.iter().all(|k| env.get(k).is_some()) {
-                run.results.push(Transition {
-                    state: env_to_next_state(env, ctx.vars, ctx.state_keys),
-                    action: run.action.clone(),
-                });
-            }
-            Ok(())
-        }
+        Cont::Nil => emit(env, ctx, run),
     }
+}
+
+/// Record a successor once the whole relation is discharged. `ENABLED`
+/// (`require_total = false`) accepts any partial assignment as a witness.
+/// Generating a state (`Next`/`Init`) demands every variable assigned: a
+/// variable the action left unbound is a malformed action and a hard error,
+/// unless `--allow-unassigned-stutter` opts into treating it as an implicit
+/// `UNCHANGED` — only possible in `Next`, where the current value exists.
+fn emit(env: &mut Env, ctx: &WalkCtx<'_>, run: &mut Run<'_>) -> Result<()> {
+    if !ctx.require_total {
+        run.results.push(Transition {
+            state: env_to_next_state(env, ctx.vars, ctx.state_keys),
+            action: run.action.clone(),
+        });
+        return Ok(());
+    }
+
+    let missing: Vec<usize> = (0..ctx.state_keys.len())
+        .filter(|&i| env.get(&ctx.state_keys[i]).is_none())
+        .collect();
+
+    if missing.is_empty() {
+        run.results.push(Transition {
+            state: env_to_next_state(env, ctx.vars, ctx.state_keys),
+            action: run.action.clone(),
+        });
+        return Ok(());
+    }
+
+    if ctx.phase == Phase::Next && allow_unassigned_stutter() {
+        for &i in &missing {
+            if let Some(current) = env.get(&ctx.vars[i]).cloned() {
+                env.insert(ctx.state_keys[i].clone(), current);
+            }
+        }
+        if ctx.state_keys.iter().all(|k| env.get(k).is_some()) {
+            run.results.push(Transition {
+                state: env_to_next_state(env, ctx.vars, ctx.state_keys),
+                action: run.action.clone(),
+            });
+        }
+        for &i in &missing {
+            env.remove(&ctx.state_keys[i]);
+        }
+        return Ok(());
+    }
+
+    let names = missing
+        .iter()
+        .map(|&i| ctx.vars[i].to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let action = run
+        .action
+        .as_ref()
+        .map(|a| format!(" in action {a}"))
+        .unwrap_or_default();
+    Err(EvalError::domain_error(format!(
+        "variable(s) not assigned{action}: {names} \
+         (pass --allow-unassigned-stutter to treat as UNCHANGED)"
+    )))
 }
 
 /// Discharge a continuation item that was pushed at scope `mark`. The journal

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -342,7 +342,7 @@ fn walk(
         Expr::Let(name, binding, body) => {
             if let Some((params, op_body)) = parameterized_let_op(binding) {
                 let mut merged = ctx.defs.clone();
-                merged.insert(name.clone(), (params, op_body.clone()));
+                merged.insert(name.clone(), (params, Arc::new(op_body.clone())));
                 let sub_ctx = WalkCtx {
                     vars: ctx.vars,
                     state_keys: ctx.state_keys,
@@ -664,7 +664,7 @@ fn walk_qualified_call(
 ) -> Result<()> {
     use super::global_state::{PARAMETERIZED_INSTANCES, RESOLVED_INSTANCES};
 
-    let resolved: Option<(Definitions, Vec<Arc<str>>, Expr)> = match instance_expr {
+    let resolved: Option<(Definitions, Vec<Arc<str>>, Arc<Expr>)> = match instance_expr {
         Expr::Var(instance_name) => RESOLVED_INSTANCES.with(|r| {
             let instances = r.borrow();
             let instance_defs = instances.get(instance_name)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,6 +302,9 @@ fn main() -> ExitCode {
     }
 
     let mut config = CheckerConfig::new();
+    if std::env::var("TLA_ENGINE").ok().as_deref() == Some("inference") {
+        config.use_inference_engine = true;
+    }
     let mut spec_path = None;
     let mut constants: Vec<(Arc<str>, Value)> = Vec::new();
     let mut scenario_input: Option<String> = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -418,6 +418,9 @@ fn main() -> ExitCode {
                 config.allow_deadlock = true;
                 cli_allow_deadlock = true;
             }
+            "--allow-unassigned-stutter" => {
+                config.allow_unassigned_stutter = true;
+            }
             "--check-liveness" => {
                 config.check_liveness = true;
             }
@@ -604,6 +607,9 @@ fn main() -> ExitCode {
                 );
                 println!("  --replay FILE              Replay a counterexample interactively");
                 println!("  --allow-deadlock           Allow states with no successors");
+                println!(
+                    "  --allow-unassigned-stutter Treat a variable an action leaves unassigned as UNCHANGED"
+                );
                 println!("  --check-liveness           Check liveness and fairness properties");
                 println!("  --quick, -q                Quick exploration (limit: 10,000 states)");
                 println!("  --verbose, -v              Verbose output (show more details)");

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -223,14 +223,14 @@ mod tests {
             var("Op"),
             (
                 vec![],
-                Expr::Add(Box::new(var_expr("N")), Box::new(lit_int(1))),
+                Expr::Add(Box::new(var_expr("N")), Box::new(lit_int(1))).into(),
             ),
         );
         module_defs.insert(
             var("Helper"),
             (
                 vec![var("x")],
-                Expr::Mul(Box::new(var_expr("x")), Box::new(var_expr("N"))),
+                Expr::Mul(Box::new(var_expr("x")), Box::new(var_expr("N"))).into(),
             ),
         );
 
@@ -288,13 +288,13 @@ mod tests {
         let s_defs = resolved.get(&Arc::from("S") as &Arc<str>).unwrap();
         let (_, op_body) = s_defs.get(&var("Op")).unwrap();
         assert_eq!(
-            *op_body,
+            **op_body,
             Expr::Add(Box::new(lit_int(5)), Box::new(lit_int(1)))
         );
         let (params, helper_body) = s_defs.get(&var("Helper")).unwrap();
         assert_eq!(params, &vec![var("x")]);
         assert_eq!(
-            *helper_body,
+            **helper_body,
             Expr::Mul(Box::new(var_expr("x")), Box::new(lit_int(5)))
         );
 

--- a/src/parser/lexing.rs
+++ b/src/parser/lexing.rs
@@ -24,6 +24,10 @@ pub struct Parser {
     pub(super) quantified_temporal: Vec<(Arc<str>, Expr, Expr)>,
     pub(super) warnings: Vec<Spanned<String>>,
     pub(super) fresh_counter: u64,
+    /// Names bound by an enclosing `LET`. An operator reference whose name is in
+    /// scope here must not be inlined from the top-level definitions — the local
+    /// `LET` binding shadows it, and inlining would use the wrong (top-level) body.
+    pub(super) let_scope: Vec<Arc<str>>,
 }
 
 impl Parser {
@@ -47,6 +51,7 @@ impl Parser {
             quantified_temporal: Vec::new(),
             warnings: Vec::new(),
             fresh_counter: 0,
+            let_scope: Vec::new(),
         })
     }
 

--- a/src/parser/primary.rs
+++ b/src/parser/primary.rs
@@ -151,6 +151,7 @@ impl Parser {
                 if *self.peek() == Token::LParen {
                     let is_recursive = self.recursive_names.contains(&name);
                     if !is_recursive
+                        && !self.let_scope.contains(&name)
                         && let Some((params, body)) = self.fn_definitions.get(&name).cloned()
                     {
                         self.advance();
@@ -186,7 +187,9 @@ impl Parser {
                     }
                     self.expect(Token::RParen)?;
                     Ok(Expr::FnCall(name, args))
-                } else if let Some(def) = self.definitions.get(&name) {
+                } else if !self.let_scope.contains(&name)
+                    && let Some(def) = self.definitions.get(&name)
+                {
                     Ok(def.clone())
                 } else {
                     Ok(Expr::Var(name))
@@ -603,6 +606,7 @@ impl Parser {
 
     pub(super) fn parse_let(&mut self) -> Result<Expr> {
         let mut bindings = Vec::new();
+        let scope_start = self.let_scope.len();
 
         loop {
             if *self.peek() == Token::Recursive {
@@ -622,6 +626,7 @@ impl Parser {
                 self.expect(Token::EqEq)?;
                 let body = self.parse_expr()?;
                 let fn_def = Expr::FnDef(param, Box::new(domain), Box::new(body));
+                self.let_scope.push(var.clone());
                 bindings.push((var, fn_def));
             } else if *self.peek() == Token::LParen {
                 self.advance();
@@ -634,6 +639,7 @@ impl Parser {
                 self.expect(Token::EqEq)?;
                 let body = self.parse_expr()?;
                 let fn_val = Expr::TupleLit(params.into_iter().map(Expr::Var).collect());
+                self.let_scope.push(var.clone());
                 bindings.push((
                     var,
                     Expr::Let("_params".into(), Box::new(fn_val), Box::new(body)),
@@ -641,6 +647,7 @@ impl Parser {
             } else {
                 self.expect(Token::EqEq)?;
                 let binding = self.parse_expr()?;
+                self.let_scope.push(var.clone());
                 bindings.push((var, binding));
             }
 
@@ -662,7 +669,9 @@ impl Parser {
         }
 
         self.expect(Token::Def)?;
-        let mut body = self.parse_expr()?;
+        let body_result = self.parse_expr();
+        self.let_scope.truncate(scope_start);
+        let mut body = body_result?;
 
         for (var, binding) in bindings.into_iter().rev() {
             body = Expr::Let(var, Box::new(binding), Box::new(body));

--- a/src/parser/spec.rs
+++ b/src/parser/spec.rs
@@ -229,9 +229,13 @@ impl Parser {
             }
         }
 
-        let mut all_defs = self.fn_definitions.clone();
+        let mut all_defs: crate::eval::Definitions = self
+            .fn_definitions
+            .iter()
+            .map(|(name, (params, body))| (name.clone(), (params.clone(), Arc::new(body.clone()))))
+            .collect();
         for (name, expr) in &self.definitions {
-            all_defs.insert(name.clone(), (vec![], expr.clone()));
+            all_defs.insert(name.clone(), (vec![], std::sync::Arc::new(expr.clone())));
         }
 
         Ok(Spec {

--- a/src/substitution.rs
+++ b/src/substitution.rs
@@ -4,6 +4,20 @@ use std::sync::Arc;
 use crate::ast::Expr;
 use crate::eval::{Definitions, expr_references};
 
+/// A `$`-suffixed name derived from `base` that no `clashes` predicate rejects.
+/// The `$` cannot appear in a source identifier, so a name that also avoids every
+/// caller-supplied clash source is guaranteed fresh in scope.
+fn fresh_name(base: &Arc<str>, clashes: impl Fn(&Arc<str>) -> bool) -> Arc<str> {
+    let mut i = 0u64;
+    loop {
+        let cand: Arc<str> = Arc::from(format!("{base}${i}"));
+        if !clashes(&cand) {
+            return cand;
+        }
+        i += 1;
+    }
+}
+
 /// Substitute into the body of a binder that binds `var`, avoiding capture.
 /// `subs` must already exclude any substitution of `var` itself. If `var` occurs
 /// free in a replacement, binding it here would capture that occurrence (`{c \in S
@@ -14,18 +28,12 @@ fn substitute_bound(var: &Arc<str>, body: &Expr, subs: &[(Arc<str>, Expr)]) -> (
     if !subs.iter().any(|(_, repl)| expr_references(repl, var)) {
         return (var.clone(), substitute_expr(body, subs));
     }
-    let mut i = 0u64;
-    let fresh = loop {
-        let cand: Arc<str> = Arc::from(format!("{var}${i}"));
-        let clashes = expr_references(body, &cand)
+    let fresh = fresh_name(var, |cand| {
+        expr_references(body, cand)
             || subs
                 .iter()
-                .any(|(p, r)| *p == cand || expr_references(r, &cand));
-        if !clashes {
-            break cand;
-        }
-        i += 1;
-    };
+                .any(|(p, r)| p == cand || expr_references(r, cand))
+    });
     let renamed = substitute_expr(body, &[(var.clone(), Expr::Var(fresh.clone()))]);
     (fresh, substitute_expr(&renamed, subs))
 }
@@ -411,19 +419,13 @@ pub fn substitute_expr(expr: &Expr, subs: &[(Arc<str>, Expr)]) -> Expr {
             let mut new_params: Vec<Arc<str>> = Vec::with_capacity(params.len());
             for prm in params {
                 if filtered_subs.iter().any(|(_, r)| expr_references(r, prm)) {
-                    let mut i = 0u64;
-                    let fresh = loop {
-                        let cand: Arc<str> = Arc::from(format!("{prm}${i}"));
-                        let clashes = expr_references(body, &cand)
-                            || new_params.contains(&cand)
+                    let fresh = fresh_name(prm, |cand| {
+                        expr_references(body, cand)
+                            || new_params.contains(cand)
                             || filtered_subs
                                 .iter()
-                                .any(|(p, r)| *p == cand || expr_references(r, &cand));
-                        if !clashes {
-                            break cand;
-                        }
-                        i += 1;
-                    };
+                                .any(|(p, r)| p == cand || expr_references(r, cand))
+                    });
                     renames.push((prm.clone(), Expr::Var(fresh.clone())));
                     new_params.push(fresh);
                 } else {

--- a/src/substitution.rs
+++ b/src/substitution.rs
@@ -407,7 +407,6 @@ pub fn substitute_expr(expr: &Expr, subs: &[(Arc<str>, Expr)]) -> Expr {
                 .filter(|(p, _)| !params.contains(p))
                 .cloned()
                 .collect();
-            // Rename any parameter captured by a replacement before substituting.
             let mut renames: Vec<(Arc<str>, Expr)> = Vec::new();
             let mut new_params: Vec<Arc<str>> = Vec::with_capacity(params.len());
             for prm in params {

--- a/src/substitution.rs
+++ b/src/substitution.rs
@@ -33,7 +33,7 @@ fn substitute_bound(var: &Arc<str>, body: &Expr, subs: &[(Arc<str>, Expr)]) -> (
 pub fn apply_substitutions(module_defs: &Definitions, subs: &[(Arc<str>, Expr)]) -> Definitions {
     let mut result = BTreeMap::new();
     for (name, (params, body)) in module_defs {
-        let new_body = substitute_expr(body, subs);
+        let new_body = Arc::new(substitute_expr(body, subs));
         result.insert(name.clone(), (params.clone(), new_body));
     }
     result
@@ -723,14 +723,14 @@ mod tests {
             var("Op"),
             (
                 vec![],
-                Expr::Add(Box::new(var_expr("N")), Box::new(lit_int(1))),
+                Expr::Add(Box::new(var_expr("N")), Box::new(lit_int(1))).into(),
             ),
         );
         let subs = vec![(var("N"), lit_int(10))];
         let result = apply_substitutions(&defs, &subs);
         let (_, body) = result.get(&var("Op")).expect("Op should exist");
         assert_eq!(
-            *body,
+            **body,
             Expr::Add(Box::new(lit_int(10)), Box::new(lit_int(1)))
         );
     }

--- a/src/substitution.rs
+++ b/src/substitution.rs
@@ -2,7 +2,33 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::ast::Expr;
-use crate::eval::Definitions;
+use crate::eval::{Definitions, expr_references};
+
+/// Substitute into the body of a binder that binds `var`, avoiding capture.
+/// `subs` must already exclude any substitution of `var` itself. If `var` occurs
+/// free in a replacement, binding it here would capture that occurrence (`{c \in S
+/// : c # author}` with `author <- c` would become `c # c`), so `var` is first
+/// renamed to a fresh name that clashes with nothing in scope. Returns the
+/// (possibly renamed) bound variable and the substituted body.
+fn substitute_bound(var: &Arc<str>, body: &Expr, subs: &[(Arc<str>, Expr)]) -> (Arc<str>, Expr) {
+    if !subs.iter().any(|(_, repl)| expr_references(repl, var)) {
+        return (var.clone(), substitute_expr(body, subs));
+    }
+    let mut i = 0u64;
+    let fresh = loop {
+        let cand: Arc<str> = Arc::from(format!("{var}${i}"));
+        let clashes = expr_references(body, &cand)
+            || subs
+                .iter()
+                .any(|(p, r)| *p == cand || expr_references(r, &cand));
+        if !clashes {
+            break cand;
+        }
+        i += 1;
+    };
+    let renamed = substitute_expr(body, &[(var.clone(), Expr::Var(fresh.clone()))]);
+    (fresh, substitute_expr(&renamed, subs))
+}
 
 pub fn apply_substitutions(module_defs: &Definitions, subs: &[(Arc<str>, Expr)]) -> Definitions {
     let mut result = BTreeMap::new();
@@ -280,18 +306,20 @@ pub fn substitute_expr(expr: &Expr, subs: &[(Arc<str>, Expr)]) -> Expr {
         ),
         Expr::SetFilter(var, domain, pred) => {
             let filtered_subs: Vec<_> = subs.iter().filter(|(p, _)| p != var).cloned().collect();
+            let (nvar, npred) = substitute_bound(var, pred, &filtered_subs);
             Expr::SetFilter(
-                var.clone(),
+                nvar,
                 Box::new(substitute_expr(domain, subs)),
-                Box::new(substitute_expr(pred, &filtered_subs)),
+                Box::new(npred),
             )
         }
         Expr::SetMap(var, domain, body) => {
             let filtered_subs: Vec<_> = subs.iter().filter(|(p, _)| p != var).cloned().collect();
+            let (nvar, nbody) = substitute_bound(var, body, &filtered_subs);
             Expr::SetMap(
-                var.clone(),
+                nvar,
                 Box::new(substitute_expr(domain, subs)),
-                Box::new(substitute_expr(body, &filtered_subs)),
+                Box::new(nbody),
             )
         }
         Expr::Union(l, r) => Expr::Union(
@@ -325,31 +353,35 @@ pub fn substitute_expr(expr: &Expr, subs: &[(Arc<str>, Expr)]) -> Expr {
 
         Expr::Exists(var, domain, body) => {
             let filtered_subs: Vec<_> = subs.iter().filter(|(p, _)| p != var).cloned().collect();
+            let (nvar, nbody) = substitute_bound(var, body, &filtered_subs);
             Expr::Exists(
-                var.clone(),
+                nvar,
                 Box::new(substitute_expr(domain, subs)),
-                Box::new(substitute_expr(body, &filtered_subs)),
+                Box::new(nbody),
             )
         }
         Expr::Forall(var, domain, body) => {
             let filtered_subs: Vec<_> = subs.iter().filter(|(p, _)| p != var).cloned().collect();
+            let (nvar, nbody) = substitute_bound(var, body, &filtered_subs);
             Expr::Forall(
-                var.clone(),
+                nvar,
                 Box::new(substitute_expr(domain, subs)),
-                Box::new(substitute_expr(body, &filtered_subs)),
+                Box::new(nbody),
             )
         }
         Expr::Choose(var, domain, body) => {
             let filtered_subs: Vec<_> = subs.iter().filter(|(p, _)| p != var).cloned().collect();
+            let (nvar, nbody) = substitute_bound(var, body, &filtered_subs);
             Expr::Choose(
-                var.clone(),
+                nvar,
                 Box::new(substitute_expr(domain, subs)),
-                Box::new(substitute_expr(body, &filtered_subs)),
+                Box::new(nbody),
             )
         }
         Expr::ChooseUnbounded(var, body) => {
             let filtered_subs: Vec<_> = subs.iter().filter(|(p, _)| p != var).cloned().collect();
-            Expr::ChooseUnbounded(var.clone(), Box::new(substitute_expr(body, &filtered_subs)))
+            let (nvar, nbody) = substitute_bound(var, body, &filtered_subs);
+            Expr::ChooseUnbounded(nvar, Box::new(nbody))
         }
 
         Expr::FnApp(f, arg) => Expr::FnApp(
@@ -358,10 +390,11 @@ pub fn substitute_expr(expr: &Expr, subs: &[(Arc<str>, Expr)]) -> Expr {
         ),
         Expr::FnDef(var, domain, body) => {
             let filtered_subs: Vec<_> = subs.iter().filter(|(p, _)| p != var).cloned().collect();
+            let (nvar, nbody) = substitute_bound(var, body, &filtered_subs);
             Expr::FnDef(
-                var.clone(),
+                nvar,
                 Box::new(substitute_expr(domain, subs)),
-                Box::new(substitute_expr(body, &filtered_subs)),
+                Box::new(nbody),
             )
         }
         Expr::FnCall(name, args) => Expr::FnCall(
@@ -374,9 +407,38 @@ pub fn substitute_expr(expr: &Expr, subs: &[(Arc<str>, Expr)]) -> Expr {
                 .filter(|(p, _)| !params.contains(p))
                 .cloned()
                 .collect();
+            // Rename any parameter captured by a replacement before substituting.
+            let mut renames: Vec<(Arc<str>, Expr)> = Vec::new();
+            let mut new_params: Vec<Arc<str>> = Vec::with_capacity(params.len());
+            for prm in params {
+                if filtered_subs.iter().any(|(_, r)| expr_references(r, prm)) {
+                    let mut i = 0u64;
+                    let fresh = loop {
+                        let cand: Arc<str> = Arc::from(format!("{prm}${i}"));
+                        let clashes = expr_references(body, &cand)
+                            || new_params.contains(&cand)
+                            || filtered_subs
+                                .iter()
+                                .any(|(p, r)| *p == cand || expr_references(r, &cand));
+                        if !clashes {
+                            break cand;
+                        }
+                        i += 1;
+                    };
+                    renames.push((prm.clone(), Expr::Var(fresh.clone())));
+                    new_params.push(fresh);
+                } else {
+                    new_params.push(prm.clone());
+                }
+            }
+            let renamed = if renames.is_empty() {
+                (**body).clone()
+            } else {
+                substitute_expr(body, &renames)
+            };
             Expr::Lambda(
-                params.clone(),
-                Box::new(substitute_expr(body, &filtered_subs)),
+                new_params,
+                Box::new(substitute_expr(&renamed, &filtered_subs)),
             )
         }
         Expr::FnMerge(l, r) => Expr::FnMerge(
@@ -460,10 +522,11 @@ pub fn substitute_expr(expr: &Expr, subs: &[(Arc<str>, Expr)]) -> Expr {
         ),
         Expr::Let(var, binding, body) => {
             let filtered_subs: Vec<_> = subs.iter().filter(|(p, _)| p != var).cloned().collect();
+            let (nvar, nbody) = substitute_bound(var, body, &filtered_subs);
             Expr::Let(
-                var.clone(),
+                nvar,
                 Box::new(substitute_expr(binding, subs)),
-                Box::new(substitute_expr(body, &filtered_subs)),
+                Box::new(nbody),
             )
         }
         Expr::Case(branches) => Expr::Case(

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -430,6 +430,17 @@ fn result_to_wasm(
             format!("Assume {} error: {}", idx, format_eval_error(&e)),
             warnings,
         ),
+        CheckResult::PrepareError(PrepareSpecError::NonModelValueSymmetry(name, values)) => {
+            WasmCheckResult::err(
+                "NonModelValueSymmetry",
+                format!(
+                    "Symmetry set {} contains non-model values: {}",
+                    name,
+                    values.join(", ")
+                ),
+                warnings,
+            )
+        }
     }
 }
 

--- a/test_cases/should_error/indexed_out_of_domain.tla
+++ b/test_cases/should_error/indexed_out_of_domain.tla
@@ -1,0 +1,6 @@
+---- MODULE indexed_out_of_domain ----
+VARIABLE f
+Init == f = [i \in {1, 2} |-> 0]
+Next == f' = [i \in {1, 2} |-> 9] /\ f'[5] = 9
+Inv == TRUE
+====

--- a/test_cases/should_pass/double_whole_after_indexed.tla
+++ b/test_cases/should_pass/double_whole_after_indexed.tla
@@ -1,0 +1,8 @@
+---- MODULE double_whole_after_indexed ----
+g == <<5, 9>>
+h == <<5, 2>>
+VARIABLE f
+Init == f = <<0, 0>>
+Next == (f'[1] = 5 /\ f' = g /\ f' = h) \/ UNCHANGED f
+Inv == f[2] # 2
+====

--- a/test_cases/should_pass/equality_binds_unbound_prime.tla
+++ b/test_cases/should_pass/equality_binds_unbound_prime.tla
@@ -1,0 +1,7 @@
+---- MODULE equality_binds_unbound_prime ----
+EXTENDS Naturals
+VARIABLES x, y
+Init == x = 0 /\ y = 0
+Next == x' = 1 /\ x' = y'
+Inv == TRUE
+====

--- a/test_cases/should_pass/let_shadows_toplevel.tla
+++ b/test_cases/should_pass/let_shadows_toplevel.tla
@@ -1,0 +1,9 @@
+---- MODULE let_shadows_toplevel ----
+EXTENDS Naturals
+VARIABLE x
+G(n) == 1000
+c == 1000
+Init == x = 0
+Next == x' = x + 1 /\ x < 3
+Inv == (LET G(n) == 0 IN G(x) < 50) /\ (LET c == 0 IN c < 50)
+====

--- a/test_cases/should_pass/parameterized_instance.cfg
+++ b/test_cases/should_pass/parameterized_instance.cfg
@@ -1,0 +1,1 @@
+CONSTANT Ids = {a, b}

--- a/test_cases/should_violate/indexed_then_whole_assignment.tla
+++ b/test_cases/should_violate/indexed_then_whole_assignment.tla
@@ -1,0 +1,7 @@
+---- MODULE indexed_then_whole_assignment ----
+g == <<5, 9>>
+VARIABLE f
+Init == f = <<0, 0>>
+Next == (f'[1] = 5 /\ f' = g) \/ UNCHANGED f
+Inv == f[2] # 9
+====

--- a/test_cases/should_violate/let_operator_invariant.tla
+++ b/test_cases/should_violate/let_operator_invariant.tla
@@ -1,0 +1,7 @@
+---- MODULE let_operator_invariant ----
+EXTENDS Naturals
+VARIABLE x
+Init == x = 0
+Next == x' = x + 1
+Inv == LET Double(n) == n * 2 IN Double(x) < 8
+====

--- a/test_cases/should_violate/let_shadows_toplevel_violation.tla
+++ b/test_cases/should_violate/let_shadows_toplevel_violation.tla
@@ -1,0 +1,8 @@
+---- MODULE let_shadows_toplevel_violation ----
+EXTENDS Naturals
+VARIABLE x
+G(n) == 0
+Init == x = 0
+Next == x' = x + 1 /\ x < 3
+Inv == LET G(n) == 1000 IN G(x) < 50
+====

--- a/test_cases/should_violate/operator_arg_capture.tla
+++ b/test_cases/should_violate/operator_arg_capture.tla
@@ -1,0 +1,18 @@
+---- MODULE operator_arg_capture ----
+VARIABLES sub, pd
+
+Init ==
+    /\ sub = [c \in {"c1", "c2"} |-> {"d1"}]
+    /\ pd = [c \in {"c1", "c2"} |-> {}]
+
+Mutate(author, d) ==
+    /\ d \in sub[author]
+    /\ LET recipients == {c \in {"c1", "c2"} : d \in sub[c] /\ c /= author}
+       IN pd' = [c \in {"c1", "c2"} |->
+                    IF c \in recipients THEN pd[c] \cup {d} ELSE pd[c]]
+    /\ UNCHANGED sub
+
+Next == \E c \in {"c1", "c2"}, d \in {"d1"} : Mutate(c, d)
+
+Inv == \A c \in {"c1", "c2"} : pd[c] = {}
+====

--- a/test_cases/walker/capture_disjunct.tla
+++ b/test_cases/walker/capture_disjunct.tla
@@ -1,0 +1,12 @@
+---- MODULE capture_disjunct ----
+EXTENDS Naturals
+VARIABLES x, y, z
+Pick(a) == \E i \in {5, 6} : a = i
+Init == x = 0 /\ y = 0 /\ z = 0
+Step == \E i \in {1, 2} :
+          /\ x' = i
+          /\ Pick(y')
+          /\ (z' = i \/ z' = i + 10)
+Next == Step \/ UNCHANGED <<x, y, z>>
+Inv == (x # 0) => (z = x \/ z = x + 10)
+====

--- a/test_cases/walker/capture_scope.tla
+++ b/test_cases/walker/capture_scope.tla
@@ -1,0 +1,12 @@
+---- MODULE capture_scope ----
+EXTENDS Naturals
+VARIABLES x, y, z
+Pick(a) == \E i \in {5, 6} : a = i
+Init == x = 0 /\ y = 0 /\ z = 0
+Step == \E i \in {1, 2} :
+          /\ x' = i
+          /\ Pick(y')
+          /\ z' = i
+Next == Step \/ UNCHANGED <<x, y, z>>
+Inv == z = x
+====

--- a/test_cases/walker/cliff_guard.tla
+++ b/test_cases/walker/cliff_guard.tla
@@ -1,0 +1,8 @@
+---- MODULE cliff_guard ----
+EXTENDS Naturals
+VARIABLE x
+Guard == \A i \in 1..24 : (i > 0 \/ i < 100)
+Init == x = 0
+Next == Guard /\ x' = 1
+Inv == TRUE
+====

--- a/test_cases/walker/cliff_guard_recursive.tla
+++ b/test_cases/walker/cliff_guard_recursive.tla
@@ -1,0 +1,10 @@
+---- MODULE cliff_guard_recursive ----
+EXTENDS Naturals
+VARIABLE x
+RECURSIVE Sum(_)
+Sum(n) == IF n = 0 THEN 0 ELSE n + Sum(n - 1)
+Guard == \A i \in 1..30 : (Sum(3) >= 0 \/ i < 100)
+Init == x = 0
+Next == Guard /\ x' = 1
+Inv == TRUE
+====

--- a/test_cases/walker/dep_assign.tla
+++ b/test_cases/walker/dep_assign.tla
@@ -1,0 +1,8 @@
+---- MODULE dep_assign ----
+EXTENDS Naturals
+VARIABLES a, b
+vars == <<a, b>>
+Init == a = 0 /\ b = 0
+Next == (a' \in {1, 2} /\ b' = a' + 10) \/ UNCHANGED vars
+Inv == b # 12
+====

--- a/test_cases/walker/disj_dep.tla
+++ b/test_cases/walker/disj_dep.tla
@@ -1,0 +1,8 @@
+---- MODULE disj_dep ----
+EXTENDS Naturals
+VARIABLES x, y
+vars == <<x, y>>
+Init == x = 0 /\ y = 0
+Next == (x' \in {1,2} /\ (y' = x' * 3 \/ y' = x' * 5)) \/ UNCHANGED vars
+Inv == y # 10
+====

--- a/test_cases/walker/enabled_holds.tla
+++ b/test_cases/walker/enabled_holds.tla
@@ -1,0 +1,7 @@
+---- MODULE enabled_holds ----
+VARIABLES x, y
+Guard == x' = 1
+Init == x = 0 /\ y = 0
+Next == (x' = 1 /\ y' = y) \/ UNCHANGED <<x,y>>
+Inv == (x = 0) => ENABLED Guard
+====

--- a/test_cases/walker/enabled_partial.tla
+++ b/test_cases/walker/enabled_partial.tla
@@ -1,0 +1,7 @@
+---- MODULE enabled_partial ----
+VARIABLES x, y
+Act == x' = 1
+Init == x = 0 /\ y = 0
+Next == (x' = 1 /\ y' = y) \/ (UNCHANGED <<x,y>>)
+Inv == ~(ENABLED Act)
+====

--- a/test_cases/walker/five_chain.tla
+++ b/test_cases/walker/five_chain.tla
@@ -1,0 +1,8 @@
+---- MODULE five_chain ----
+EXTENDS Naturals
+VARIABLES a, b, c, d, e
+vars == <<a, b, c, d, e>>
+Init == a=0 /\ b=0 /\ c=0 /\ d=0 /\ e=0
+Next == (a'=1 /\ b'=a'+1 /\ c'=b'+1 /\ d'=c'+1 /\ e'=d'+1) \/ UNCHANGED vars
+Inv == e # 5
+====

--- a/test_cases/walker/if_rhs.tla
+++ b/test_cases/walker/if_rhs.tla
@@ -1,0 +1,8 @@
+---- MODULE if_rhs ----
+EXTENDS Naturals
+VARIABLES x, y
+vars == <<x, y>>
+Init == x = 0 /\ y = 0
+Next == (x' \in {1, 2} /\ y' = (IF x' = 1 THEN 10 ELSE 20)) \/ UNCHANGED vars
+Inv == y # 20
+====

--- a/test_cases/walker/indexed_conflict.tla
+++ b/test_cases/walker/indexed_conflict.tla
@@ -1,0 +1,7 @@
+---- MODULE indexed_conflict ----
+EXTENDS Naturals
+VARIABLE f
+Init == f = <<0, 0>>
+Next == (f'[1] = 5 /\ f'[1] = 6) \/ UNCHANGED f
+Inv == f[1] # 6
+====

--- a/test_cases/walker/indexed_distinct.tla
+++ b/test_cases/walker/indexed_distinct.tla
@@ -1,0 +1,7 @@
+---- MODULE indexed_distinct ----
+EXTENDS Naturals
+VARIABLE f
+Init == f = <<0, 0>>
+Next == (f'[1] = 5 /\ f'[2] = 6) \/ UNCHANGED f
+Inv == f[1] # 5
+====

--- a/test_cases/walker/indexed_forall_conflict.tla
+++ b/test_cases/walker/indexed_forall_conflict.tla
@@ -1,0 +1,7 @@
+---- MODULE indexed_forall_conflict ----
+EXTENDS Naturals
+VARIABLE f
+Init == f = <<0, 0>>
+Next == ((\A p \in {1,2} : f'[p] = 0) /\ f'[1] = 9) \/ UNCHANGED f
+Inv == f[1] # 9
+====

--- a/test_cases/walker/indexed_in.tla
+++ b/test_cases/walker/indexed_in.tla
@@ -1,0 +1,6 @@
+---- MODULE indexed_in ----
+VARIABLE f
+Init == f = [i \in {1, 2} |-> 0]
+Next == f'[1] \in {5, 6} /\ f'[2] = 0
+Inv == f[1] # 5
+====

--- a/test_cases/walker/init_disjunct.tla
+++ b/test_cases/walker/init_disjunct.tla
@@ -1,0 +1,7 @@
+---- MODULE init_disjunct ----
+EXTENDS Naturals
+VARIABLES x, y
+Init == x = 0 /\ (y = 1 \/ \E v \in {2, 3} : y = v)
+Next == UNCHANGED <<x, y>>
+Inv == y # 3
+====

--- a/test_cases/walker/init_exists.tla
+++ b/test_cases/walker/init_exists.tla
@@ -1,0 +1,7 @@
+---- MODULE init_exists ----
+EXTENDS Naturals
+VARIABLES x
+Init == \E v \in {1, 2} : x = v
+Next == UNCHANGED x
+Inv == x # 2
+====

--- a/test_cases/walker/init_if.tla
+++ b/test_cases/walker/init_if.tla
@@ -1,0 +1,7 @@
+---- MODULE init_if ----
+EXTENDS Naturals
+VARIABLES x
+Init == IF TRUE THEN x = 2 ELSE x = 1
+Next == UNCHANGED x
+Inv == x # 2
+====

--- a/test_cases/walker/init_indexed_no_base.tla
+++ b/test_cases/walker/init_indexed_no_base.tla
@@ -1,0 +1,6 @@
+---- MODULE init_indexed_no_base ----
+VARIABLE f
+Init == f[1] = 5 /\ f[2] = 0
+Next == UNCHANGED f
+Inv == TRUE
+====

--- a/test_cases/walker/let_operator_action.tla
+++ b/test_cases/walker/let_operator_action.tla
@@ -1,0 +1,7 @@
+---- MODULE let_operator_action ----
+EXTENDS Naturals
+VARIABLE x
+Init == x = 0
+Next == LET Bump(n) == n + 1 IN x' = Bump(x)
+Inv == x < 3
+====

--- a/test_cases/walker/quant_wrap.tla
+++ b/test_cases/walker/quant_wrap.tla
@@ -1,0 +1,8 @@
+---- MODULE quant_wrap ----
+EXTENDS Naturals
+VARIABLES x, y
+vars == <<x, y>>
+Init == x = 0 /\ y = 0
+Next == (\A i \in {1} : x' \in {1,2} /\ y' = x' + 50) \/ UNCHANGED vars
+Inv == y # 52
+====

--- a/test_cases/walker/reverse_order.tla
+++ b/test_cases/walker/reverse_order.tla
@@ -1,0 +1,8 @@
+---- MODULE reverse_order ----
+EXTENDS Naturals
+VARIABLES a, b
+vars == <<a, b>>
+Init == a = 0 /\ b = 0
+Next == (b' \in {1, 2} /\ a' = b' + 100) \/ UNCHANGED vars
+Inv == a # 102
+====

--- a/test_cases/walker/seq_index.tla
+++ b/test_cases/walker/seq_index.tla
@@ -1,0 +1,8 @@
+---- MODULE seq_index ----
+EXTENDS Naturals, Sequences
+VARIABLES s, n
+vars == <<s, n>>
+Init == s = <<0, 0>> /\ n = 0
+Next == (s' \in {<<1,1>>, <<2,2>>} /\ n' = s'[1] + 100) \/ UNCHANGED vars
+Inv == n # 102
+====

--- a/test_cases/walker/unassigned_var.tla
+++ b/test_cases/walker/unassigned_var.tla
@@ -1,0 +1,8 @@
+---- MODULE unassigned_var ----
+EXTENDS Naturals
+VARIABLES x, y
+Init == x = 0 /\ y = 0
+Bump == x' = 1 - x
+Next == Bump \/ (x' = x /\ y' = y)
+Inv == TRUE
+====

--- a/test_cases/walker/whole_then_indexed.tla
+++ b/test_cases/walker/whole_then_indexed.tla
@@ -1,0 +1,6 @@
+---- MODULE whole_then_indexed ----
+VARIABLE f
+Init == f = [i \in {1, 2} |-> 0]
+Next == f' = [i \in {1, 2} |-> 9] /\ f'[1] = 5
+Inv == TRUE
+====

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -498,6 +498,40 @@ fn test_equality_binds_unbound_prime() {
     }
 }
 
+/// An indexed assignment followed by a whole-variable assignment to the same
+/// variable — `f'[1] = 5 /\ f' = g` — must let the whole assignment be
+/// authoritative: `f' = g` (when `g[1] = 5`), not the partial value the indexed
+/// assignment built from the current state. Building `f'` from the pre-state and
+/// then rejecting the whole assignment as a mismatched constraint drops a valid
+/// successor — a false pass. Both engines must reach the violating `<<5, 9>>`.
+#[test]
+fn test_indexed_then_whole_assignment_is_authoritative() {
+    let path = Path::new("test_cases/should_violate/indexed_then_whole_assignment.tla");
+    assert!(
+        matches!(
+            check_spec_file_allow_deadlock(path),
+            CheckResult::InvariantViolation(..)
+        ),
+        "f'[1] = 5 /\\ f' = g must reach f' = g, not silently drop the successor"
+    );
+}
+
+/// A second whole assignment after an indexed-then-whole override must be a full
+/// equality constraint, not a partial path check: `f'[1] = 5 /\ f' = g /\ f' = h`
+/// with `g # h` is unsatisfiable (no `f'` equals both), so TLC yields no successor
+/// and the invariant holds. Once the first whole assignment makes `f'` authoritative
+/// the walker must compare the second whole value in full, not merely at the earlier
+/// indexed path — otherwise it emits a phantom successor and reports a spurious
+/// violation. Both engines must find no violation.
+#[test]
+fn test_double_whole_after_indexed_is_full_equality() {
+    let path = Path::new("test_cases/should_pass/double_whole_after_indexed.tla");
+    assert!(
+        matches!(check_spec_file_allow_deadlock(path), CheckResult::Ok(_)),
+        "f' = g /\\ f' = h with g # h must yield no successor, not a phantom state"
+    );
+}
+
 /// An indexed constraint on a whole-assigned variable whose index is outside the
 /// value's domain — `f' = g /\ f'[k] = v` with `k` not in `DOMAIN g` — is an
 /// out-of-domain application, which must be reported, not silently pruned as an

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -82,16 +82,16 @@ fn test_should_pass_counter() {
 #[test]
 fn test_walker_dependent_next_state_probes() {
     if inference_engine_selected() {
-        return; // corpus asserts walker-correct behaviour the inference engine gets wrong
+        return;
     }
     for name in [
-        "dep_assign",    // a' \in S /\ b' = a' + 10
-        "reverse_order", // b' \in S /\ a' = b' + 100  (dependency against declaration order)
-        "if_rhs",        // y' = IF x' = 1 THEN .. ELSE ..
-        "disj_dep",      // x' \in S /\ (y' = f(x') \/ y' = g(x'))
-        "seq_index",     // n' = s'[1] + 100
-        "quant_wrap",    // \A i \in {1} : x' \in S /\ y' = x' + 50
-        "five_chain",    // a'=1 /\ b'=a'+1 /\ ... /\ e'=d'+1
+        "dep_assign",
+        "reverse_order",
+        "if_rhs",
+        "disj_dep",
+        "seq_index",
+        "quant_wrap",
+        "five_chain",
     ] {
         let path = format!("test_cases/walker/{name}.tla");
         let result = check_spec_file_allow_deadlock(Path::new(&path));
@@ -141,10 +141,7 @@ fn test_walker_no_cross_scope_capture() {
     if inference_engine_selected() {
         return;
     }
-    for name in [
-        "capture_scope",    // z' = i, i rebound by Pick(y')
-        "capture_disjunct", // (z' = i \/ z' = i + 10) — exercises the journal redo
-    ] {
+    for name in ["capture_scope", "capture_disjunct"] {
         let path = format!("test_cases/walker/{name}.tla");
         let result = check_spec_file_allow_deadlock(Path::new(&path));
         assert!(
@@ -165,7 +162,6 @@ fn test_walker_enabled_partial_assignment() {
     if inference_engine_selected() {
         return;
     }
-    // `Act == x' = 1` leaves y' free, yet ENABLED Act must be true.
     let violated =
         check_spec_file_allow_deadlock(Path::new("test_cases/walker/enabled_partial.tla"));
     assert!(
@@ -189,11 +185,7 @@ fn test_walker_init_probes() {
     if inference_engine_selected() {
         return;
     }
-    for name in [
-        "init_disjunct", // x = 0 /\ (y = 1 \/ \E v \in {2,3} : y = v)
-        "init_exists",   // \E v \in {1,2} : x = v
-        "init_if",       // IF TRUE THEN x = 2 ELSE x = 1
-    ] {
+    for name in ["init_disjunct", "init_exists", "init_if"] {
         let path = format!("test_cases/walker/{name}.tla");
         let result = check_spec_file_allow_deadlock(Path::new(&path));
         assert!(

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -1620,6 +1620,24 @@ fn test_parameterized_instance_in_init() {
     );
 }
 
+/// A parameterized-instance action in the next-state relation
+/// (`Channel(id)!Send(msg)` under `\E id \in Ids`). The `WITH buffer <-
+/// channels[id]` substitution places `id` under a prime, so resolving the
+/// instance with `id` as a symbolic variable rather than its bound value makes
+/// `prime_expr` produce an undefined `id'`. Both engines must reach the same 9
+/// reachable states.
+#[test]
+fn test_parameterized_instance_in_next() {
+    let path = Path::new("test_cases/should_pass/parameterized_instance.tla");
+    match check_spec_file_allow_deadlock(path) {
+        CheckResult::Ok(stats) => assert_eq!(
+            stats.states_explored, 9,
+            "parameterized_instance.tla should reach 9 states"
+        ),
+        other => panic!("parameterized_instance.tla should pass, got: {other:?}"),
+    }
+}
+
 #[test]
 fn test_parameterized_instance_init_unbound_var() {
     let path = Path::new("test_cases/should_pass/param_instance_init_unbound.tla");

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -196,6 +196,24 @@ fn test_walker_init_probes() {
     }
 }
 
+/// An indexed assignment in Init with nothing to update — `Init == f[1] = 5`,
+/// where `f` has no prior whole value and Init has no pre-state — cannot build
+/// `f` and must be reported, not silently dropped. Dropping the branch is a
+/// silent false pass when it is one disjunct of an otherwise-satisfiable Init.
+/// Walker only; the legacy engine drops it silently.
+#[test]
+fn test_walker_init_indexed_without_base_is_loud() {
+    if inference_engine_selected() {
+        return;
+    }
+    let result =
+        check_spec_file_allow_deadlock(Path::new("test_cases/walker/init_indexed_no_base.tla"));
+    assert!(
+        matches!(result, CheckResult::InitError(_)),
+        "an indexed Init assignment with no base must be reported, got: {result:?}"
+    );
+}
+
 /// Cliff guard: a wide prime-free guard (`\A i \in 1..24 : ...`) conjoined with a
 /// single assignment. A structural walk of the guard branches on every inner
 /// disjunct — O(2^24) dead work — before pruning. Hoisting prime-free conjuncts

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -86,6 +86,31 @@ fn test_walker_dependent_next_state_probes() {
     }
 }
 
+/// Cross-scope variable capture. A continuation conjunct (`z' = i`) pushed under
+/// an outer `\E i` must keep seeing that `i` even when it is discharged inside an
+/// operator body that rebinds `i` (`Pick(a) == \E i \in {5,6} : a = i`). With one
+/// flat env and no scope journal the walker fabricates a bogus counterexample on
+/// a valid spec. Both specs are valid — no violation exists — so this asserts the
+/// walker does *not* report one. Asserted only under the walker engine.
+#[test]
+fn test_walker_no_cross_scope_capture() {
+    if std::env::var_os("TLA_WALK").is_none() {
+        return;
+    }
+    for name in [
+        "capture_scope",    // z' = i, i rebound by Pick(y')
+        "capture_disjunct", // (z' = i \/ z' = i + 10) — exercises the journal redo
+    ] {
+        let path = format!("test_cases/walker/{name}.tla");
+        let result = check_spec_file_allow_deadlock(Path::new(&path));
+        assert!(
+            matches!(result, CheckResult::Ok(_)),
+            "{name}.tla is valid; the walker must not fabricate a counterexample by \
+             capturing a rebound quantifier variable, got: {result:?}"
+        );
+    }
+}
+
 /// `ENABLED A` is `\E vars' : A`, so an action that does not constrain every
 /// variable is still enabled — a partial assignment is a legitimate witness.
 /// Routed through the walker with a partial-assignment completion rule (the

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -482,6 +482,38 @@ fn test_membership_in_invariant_uses_shared_dispatch() {
     );
 }
 
+/// An equality between two primed variables assigns whichever side is unbound.
+/// `x' = 1 /\ x' = y'` binds `x'` first, then `x' = y'` must bind `y'` to `x'`
+/// (`= 1`), not evaluate the unbound `y'` as a constraint. Both engines and TLC
+/// reach the successor `(1, 1)`, so the run has two states.
+#[test]
+fn test_equality_binds_unbound_prime() {
+    let path = Path::new("test_cases/should_pass/equality_binds_unbound_prime.tla");
+    match check_spec_file_allow_deadlock(path) {
+        CheckResult::Ok(stats) => assert_eq!(
+            stats.states_explored, 2,
+            "x' = 1 /\\ x' = y' must bind y' and reach (1, 1)"
+        ),
+        other => panic!("equality_binds_unbound_prime.tla should pass, got: {other:?}"),
+    }
+}
+
+/// An indexed constraint on a whole-assigned variable whose index is outside the
+/// value's domain — `f' = g /\ f'[k] = v` with `k` not in `DOMAIN g` — is an
+/// out-of-domain application, which must be reported, not silently pruned as an
+/// unsatisfiable constraint (a swallowed modeling error).
+#[test]
+fn test_indexed_out_of_domain_is_an_error() {
+    let path = Path::new("test_cases/should_error/indexed_out_of_domain.tla");
+    assert!(
+        matches!(
+            check_spec_file_allow_deadlock(path),
+            CheckResult::NextError(..)
+        ),
+        "f'[5] with 5 not in the domain must be reported, not silently dropped"
+    );
+}
+
 #[test]
 fn test_next_from_non_enumerable_set_is_an_error() {
     let path = Path::new("test_cases/should_error/next_not_enumerable.tla");

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -259,6 +259,22 @@ fn test_walker_unassigned_variable_is_loud() {
     );
 }
 
+/// A whole-variable prime assignment followed by an indexed reference to the
+/// same variable is a *constraint* on the value already there, not an overwrite.
+/// `f' = [i \in {1,2} |-> 9] /\ f'[1] = 5` is contradictory (`9 # 5`), so it has
+/// no successor. The walker must not fabricate `[g EXCEPT ![1] = 5]`, which
+/// satisfies the index but violates `f' = g` — a phantom successor and a false
+/// pass. Both engines reach the same verdict here, so it is asserted on either.
+#[test]
+fn test_whole_assignment_then_index_is_a_constraint() {
+    let result = check_spec_file(Path::new("test_cases/walker/whole_then_indexed.tla"));
+    assert!(
+        matches!(result, CheckResult::Deadlock(..)),
+        "a whole assignment then a conflicting indexed constraint must yield no successor, \
+         got: {result:?}"
+    );
+}
+
 /// Engine-equivalence gate for the default flip. On well-formed specs the
 /// inference engine handles correctly, the walker and the inference engine must
 /// agree exactly: same reachable-state count, same transition count, and the same

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -1340,7 +1340,7 @@ fn test_pingpong_action_labels_not_unnamed() {
         .get(&Arc::from("NotFinished") as &str)
         .expect("NotFinished should be defined")
         .clone();
-    spec.invariants = vec![not_finished.1];
+    spec.invariants = vec![(*not_finished.1).clone()];
     spec.invariant_names = vec![Some(Arc::from("NotFinished"))];
 
     let mut config = CheckerConfig {

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -196,6 +196,37 @@ fn test_walker_init_probes() {
     }
 }
 
+/// A parameterized `LET` operator (`LET Double(n) == n * 2 IN Double(x) < 8`)
+/// used in an invariant must resolve on both engines — the parser encodes it as a
+/// `_params` marker that the evaluator now expands into a definition.
+#[test]
+fn test_should_violate_let_operator_invariant() {
+    let path = Path::new("test_cases/should_violate/let_operator_invariant.tla");
+    assert!(
+        matches!(check_spec_file(path), CheckResult::InvariantViolation(..)),
+        "let_operator_invariant.tla must resolve the parameterized LET operator and violate"
+    );
+}
+
+/// A parameterized `LET` operator in a next-state assignment
+/// (`LET Bump(n) == n + 1 IN x' = Bump(x)`). The walker registers the operator as
+/// a definition and enumerates the successor; the inference engine cannot infer a
+/// candidate through the call, so this is asserted only under the walker.
+#[test]
+fn test_walker_let_operator_in_action() {
+    if inference_engine_selected() {
+        return;
+    }
+    let path = Path::new("test_cases/walker/let_operator_action.tla");
+    assert!(
+        matches!(
+            check_spec_file_allow_deadlock(path),
+            CheckResult::InvariantViolation(..)
+        ),
+        "the walker must enumerate `x' = Bump(x)` for a parameterized LET operator"
+    );
+}
+
 /// An indexed assignment in Init with nothing to update — `Init == f[1] = 5`,
 /// where `f` has no prior whole value and Init has no pre-state — cannot build
 /// `f` and must be reported, not silently dropped. Dropping the branch is a

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -8,6 +8,12 @@ use tla_checker::checker::{CheckResult, CheckerConfig, PrepareSpecError, check};
 use tla_checker::config::{apply_config, parse_cfg};
 use tla_checker::parser::{parse, parse_with_warnings};
 
+/// The suite runs under the walker by default; `TLA_ENGINE=inference` runs the
+/// whole suite under the legacy engine so both can be exercised in CI.
+fn inference_engine_selected() -> bool {
+    std::env::var("TLA_ENGINE").ok().as_deref() == Some("inference")
+}
+
 fn check_spec_file(path: &Path) -> CheckResult {
     check_spec_file_with_config(path, CheckerConfig::default())
 }
@@ -21,6 +27,16 @@ fn check_spec_file_allow_deadlock(path: &Path) -> CheckResult {
 }
 
 fn check_spec_file_with_config(path: &Path, mut config: CheckerConfig) -> CheckResult {
+    if inference_engine_selected() {
+        config.use_inference_engine = true;
+    }
+    check_loaded(path, config)
+}
+
+/// Parse a spec (with its adjacent cfg) and check it under exactly the engine the
+/// caller's config names — no `TLA_ENGINE` override. Used by the differential test
+/// that must exercise both engines in one process.
+fn check_loaded(path: &Path, mut config: CheckerConfig) -> CheckResult {
     let input = fs::read_to_string(path).expect("failed to read spec file");
     let mut spec = match parse(&input) {
         Ok(s) => s,
@@ -57,7 +73,7 @@ fn test_should_pass_counter() {
     );
 }
 
-/// Differential corpus for the continuation-passing walker (TLA_WALK). Each of
+/// Differential corpus for the continuation-passing walker. Each of
 /// these is a next-state relation where a primed variable's value depends on
 /// another primed variable, an operator argument, an IF, or a chain — the shapes
 /// the candidate-inference engine under-approximates into a silent false pass.
@@ -65,8 +81,8 @@ fn test_should_pass_counter() {
 /// engine, since the inference engine reports these as passing.
 #[test]
 fn test_walker_dependent_next_state_probes() {
-    if std::env::var_os("TLA_WALK").is_none() {
-        return; // corpus is meaningful only under the walker engine
+    if inference_engine_selected() {
+        return; // corpus asserts walker-correct behaviour the inference engine gets wrong
     }
     for name in [
         "dep_assign",    // a' \in S /\ b' = a' + 10
@@ -94,7 +110,7 @@ fn test_walker_dependent_next_state_probes() {
 /// not have) must still work. Asserted only under the walker engine.
 #[test]
 fn test_walker_indexed_prime_is_a_constraint() {
-    if std::env::var_os("TLA_WALK").is_none() {
+    if inference_engine_selected() {
         return;
     }
     for name in ["indexed_conflict", "indexed_forall_conflict"] {
@@ -122,7 +138,7 @@ fn test_walker_indexed_prime_is_a_constraint() {
 /// walker does *not* report one. Asserted only under the walker engine.
 #[test]
 fn test_walker_no_cross_scope_capture() {
-    if std::env::var_os("TLA_WALK").is_none() {
+    if inference_engine_selected() {
         return;
     }
     for name in [
@@ -146,7 +162,7 @@ fn test_walker_no_cross_scope_capture() {
 /// walker engine.
 #[test]
 fn test_walker_enabled_partial_assignment() {
-    if std::env::var_os("TLA_WALK").is_none() {
+    if inference_engine_selected() {
         return;
     }
     // `Act == x' = 1` leaves y' free, yet ENABLED Act must be true.
@@ -170,7 +186,7 @@ fn test_walker_enabled_partial_assignment() {
 /// the walker engine.
 #[test]
 fn test_walker_init_probes() {
-    if std::env::var_os("TLA_WALK").is_none() {
+    if inference_engine_selected() {
         return;
     }
     for name in [
@@ -196,7 +212,7 @@ fn test_walker_init_probes() {
 /// return to exponential behaviour (which runs for minutes). Walker engine only.
 #[test]
 fn test_walker_hoists_prime_free_guard() {
-    if std::env::var_os("TLA_WALK").is_none() {
+    if inference_engine_selected() {
         return;
     }
     let start = std::time::Instant::now();
@@ -218,7 +234,7 @@ fn test_walker_hoists_prime_free_guard() {
 /// must recover the lenient "unassigned means UNCHANGED" behaviour. Walker only.
 #[test]
 fn test_walker_unassigned_variable_is_loud() {
-    if std::env::var_os("TLA_WALK").is_none() {
+    if inference_engine_selected() {
         return;
     }
     let path = Path::new("test_cases/walker/unassigned_var.tla");
@@ -241,6 +257,46 @@ fn test_walker_unassigned_variable_is_loud() {
         matches!(lenient, CheckResult::Ok(_)),
         "--allow-unassigned-stutter must treat y as UNCHANGED, got: {lenient:?}"
     );
+}
+
+/// Engine-equivalence gate for the default flip. On well-formed specs the
+/// inference engine handles correctly, the walker and the inference engine must
+/// agree exactly: same reachable-state count, same transition count, and the same
+/// per-action transition histogram (the "label histogram" — a stronger check than
+/// the state count alone, since it pins which action produced each edge). Runs
+/// both engines explicitly, so it is independent of `TLA_ENGINE`.
+#[test]
+fn test_engines_agree_on_known_correct_specs() {
+    for name in [
+        "official/TwoPhase",
+        "should_pass/counter",
+        "should_pass/two_bit",
+    ] {
+        let owned = format!("test_cases/{name}.tla");
+        let path = Path::new(&owned);
+        let cfg = |use_inference_engine| CheckerConfig {
+            allow_deadlock: true,
+            use_inference_engine,
+            ..Default::default()
+        };
+        let walker = check_loaded(path, cfg(false));
+        let infer = check_loaded(path, cfg(true));
+        let (CheckResult::Ok(w), CheckResult::Ok(i)) = (&walker, &infer) else {
+            panic!("{name}: both engines must complete; walker={walker:?} infer={infer:?}");
+        };
+        assert_eq!(
+            w.states_explored, i.states_explored,
+            "{name}: reachable-state count must match across engines"
+        );
+        assert_eq!(
+            w.transitions, i.transitions,
+            "{name}: transition count must match across engines"
+        );
+        assert_eq!(
+            w.transitions_by_action, i.transitions_by_action,
+            "{name}: per-action transition histogram must match across engines"
+        );
+    }
 }
 
 #[test]

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -86,6 +86,34 @@ fn test_walker_dependent_next_state_probes() {
     }
 }
 
+/// Indexed-prime assignment is a *constraint* on a repeated key path, not an
+/// overwrite. `f'[1] = 5 /\ f'[1] = 6` is unsatisfiable, and a `\A` that assigns
+/// every index must not be silently overwritten by a later `f'[i] = e`. An
+/// overwriting walker fabricates a successor satisfying neither conjunct. A
+/// distinct-key assignment (`f'[1] = 5 /\ f'[2] = 6`, a tla-rs extension TLC does
+/// not have) must still work. Asserted only under the walker engine.
+#[test]
+fn test_walker_indexed_prime_is_a_constraint() {
+    if std::env::var_os("TLA_WALK").is_none() {
+        return;
+    }
+    for name in ["indexed_conflict", "indexed_forall_conflict"] {
+        let path = format!("test_cases/walker/{name}.tla");
+        let result = check_spec_file_allow_deadlock(Path::new(&path));
+        assert!(
+            matches!(result, CheckResult::Ok(_)),
+            "{name}.tla: conflicting indexed assignments are unsatisfiable and must \
+             yield no successor, got: {result:?}"
+        );
+    }
+    let distinct =
+        check_spec_file_allow_deadlock(Path::new("test_cases/walker/indexed_distinct.tla"));
+    assert!(
+        matches!(distinct, CheckResult::InvariantViolation(_, _)),
+        "distinct indexed assignments must still combine into one successor, got: {distinct:?}"
+    );
+}
+
 /// Cross-scope variable capture. A continuation conjunct (`z' = i`) pushed under
 /// an outer `\E i` must keep seeing that `i` even when it is discharged inside an
 /// operator body that rebinds `i` (`Pick(a) == \E i \in {5,6} : a = i`). With one

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -86,6 +86,31 @@ fn test_walker_dependent_next_state_probes() {
     }
 }
 
+/// Init-phase differential corpus. The candidate-inference init collector has no
+/// arms for `\E`/`IF`/`LET`, so an initial state reached only through one of
+/// those is silently dropped (a clean pass, or a bogus "no initial states").
+/// The walker runs the same machine for Init as for Next. Asserted only under
+/// the walker engine.
+#[test]
+fn test_walker_init_probes() {
+    if std::env::var_os("TLA_WALK").is_none() {
+        return;
+    }
+    for name in [
+        "init_disjunct", // x = 0 /\ (y = 1 \/ \E v \in {2,3} : y = v)
+        "init_exists",   // \E v \in {1,2} : x = v
+        "init_if",       // IF TRUE THEN x = 2 ELSE x = 1
+    ] {
+        let path = format!("test_cases/walker/{name}.tla");
+        let result = check_spec_file_allow_deadlock(Path::new(&path));
+        assert!(
+            matches!(result, CheckResult::InvariantViolation(_, _)),
+            "{name}.tla: the walker must reach the initial state the inference \
+             collector drops, got: {result:?}"
+        );
+    }
+}
+
 #[test]
 fn test_should_pass_counter_instantiated() {
     let path = Path::new("test_cases/should_pass/counter_instance.tla");

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -57,6 +57,35 @@ fn test_should_pass_counter() {
     );
 }
 
+/// Differential corpus for the continuation-passing walker (TLA_WALK). Each of
+/// these is a next-state relation where a primed variable's value depends on
+/// another primed variable, an operator argument, an IF, or a chain — the shapes
+/// the candidate-inference engine under-approximates into a silent false pass.
+/// The walker must reach the violating successor. Asserted only under the walker
+/// engine, since the inference engine reports these as passing.
+#[test]
+fn test_walker_dependent_next_state_probes() {
+    if std::env::var_os("TLA_WALK").is_none() {
+        return; // corpus is meaningful only under the walker engine
+    }
+    for name in [
+        "dep_assign",    // a' \in S /\ b' = a' + 10
+        "reverse_order", // b' \in S /\ a' = b' + 100  (dependency against declaration order)
+        "if_rhs",        // y' = IF x' = 1 THEN .. ELSE ..
+        "disj_dep",      // x' \in S /\ (y' = f(x') \/ y' = g(x'))
+        "seq_index",     // n' = s'[1] + 100
+        "quant_wrap",    // \A i \in {1} : x' \in S /\ y' = x' + 50
+        "five_chain",    // a'=1 /\ b'=a'+1 /\ ... /\ e'=d'+1
+    ] {
+        let path = format!("test_cases/walker/{name}.tla");
+        let result = check_spec_file_allow_deadlock(Path::new(&path));
+        assert!(
+            matches!(result, CheckResult::InvariantViolation(_, _)),
+            "{name}.tla must reach the violating successor under the walker, got: {result:?}"
+        );
+    }
+}
+
 #[test]
 fn test_should_pass_counter_instantiated() {
     let path = Path::new("test_cases/should_pass/counter_instance.tla");

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -259,6 +259,23 @@ fn test_walker_unassigned_variable_is_loud() {
     );
 }
 
+/// Indexed-prime membership `f'[k] \in S` enumerates the index over the set,
+/// one successor per element — `f'[1] \in {5,6} /\ f'[2] = 0` reaches `[5,0]` and
+/// `[6,0]`, so an invariant `f[1] # 5` is violated. The inference engine has no
+/// arm for an indexed element and drops the successors (a clean pass, a false
+/// pass); asserted only under the walker.
+#[test]
+fn test_walker_indexed_prime_membership() {
+    if inference_engine_selected() {
+        return;
+    }
+    let result = check_spec_file_allow_deadlock(Path::new("test_cases/walker/indexed_in.tla"));
+    assert!(
+        matches!(result, CheckResult::InvariantViolation(_, _)),
+        "the walker must reach the successor `f'[1] \\in {{5,6}}` enumerates, got: {result:?}"
+    );
+}
+
 /// A whole-variable prime assignment followed by an indexed reference to the
 /// same variable is a *constraint* on the value already there, not an overwrite.
 /// `f' = [i \in {1,2} |-> 9] /\ f'[1] = 5` is contradictory (`9 # 5`), so it has

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -269,6 +269,30 @@ fn test_walker_hoists_prime_free_guard() {
     );
 }
 
+/// The prime-free-guard hoist must still fire when the guard calls a recursive
+/// operator (`Sum`). `contains_prime_ref` bails on the recursive cycle, and if it
+/// bailed to "has a prime" the hoist would be skipped and the wide `\A` would
+/// branch O(2^n). The recursive operator is prime-free, so the cycle contributes
+/// no prime and the guard is hoisted. Walker only.
+#[test]
+fn test_walker_hoists_guard_with_recursive_operator() {
+    if inference_engine_selected() {
+        return;
+    }
+    let start = std::time::Instant::now();
+    let result =
+        check_spec_file_allow_deadlock(Path::new("test_cases/walker/cliff_guard_recursive.tla"));
+    let elapsed = start.elapsed();
+    assert!(
+        matches!(result, CheckResult::Ok(_)),
+        "cliff_guard_recursive.tla should pass, got: {result:?}"
+    );
+    assert!(
+        elapsed.as_secs_f64() < 1.0,
+        "a prime-free guard calling a recursive operator must still hoist; took {elapsed:?}"
+    );
+}
+
 /// A variable an action leaves unassigned is a malformed action: TLC raises a
 /// hard error, and the inference engine silently drops the successor (a false
 /// pass). The walker must fail loudly by default, and `--allow-unassigned-stutter`

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -212,6 +212,37 @@ fn test_walker_hoists_prime_free_guard() {
     );
 }
 
+/// A variable an action leaves unassigned is a malformed action: TLC raises a
+/// hard error, and the inference engine silently drops the successor (a false
+/// pass). The walker must fail loudly by default, and `--allow-unassigned-stutter`
+/// must recover the lenient "unassigned means UNCHANGED" behaviour. Walker only.
+#[test]
+fn test_walker_unassigned_variable_is_loud() {
+    if std::env::var_os("TLA_WALK").is_none() {
+        return;
+    }
+    let path = Path::new("test_cases/walker/unassigned_var.tla");
+
+    let strict = check_spec_file_allow_deadlock(path);
+    assert!(
+        matches!(strict, CheckResult::NextError(..)),
+        "unassigned_var.tla must fail loudly when Bump leaves y unassigned, got: {strict:?}"
+    );
+
+    let lenient = check_spec_file_with_config(
+        path,
+        CheckerConfig {
+            allow_deadlock: true,
+            allow_unassigned_stutter: true,
+            ..Default::default()
+        },
+    );
+    assert!(
+        matches!(lenient, CheckResult::Ok(_)),
+        "--allow-unassigned-stutter must treat y as UNCHANGED, got: {lenient:?}"
+    );
+}
+
 #[test]
 fn test_should_pass_counter_instantiated() {
     let path = Path::new("test_cases/should_pass/counter_instance.tla");

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -590,6 +590,21 @@ fn test_negation_in_precedence() {
     );
 }
 
+/// Operator-argument capture. `Mutate(c, d)` is called with the `\E`-bound
+/// variable `c`, whose name also binds inside the body (`{c \in S : c # author}`,
+/// `[c \in S |-> ...]`). Inlining the operator must not capture: `c # author`
+/// must stay `c # <the argument>`, not collapse to `c # c`. If it captures,
+/// `recipients` is always empty, no pending diagram is ever produced, and the
+/// reachable violation is missed — a false pass. Must violate on either engine.
+#[test]
+fn test_should_violate_operator_arg_capture() {
+    let path = Path::new("test_cases/should_violate/operator_arg_capture.tla");
+    assert!(
+        matches!(check_spec_file(path), CheckResult::InvariantViolation(..)),
+        "operator_arg_capture.tla must reach the violation; a captured argument hides it"
+    );
+}
+
 #[test]
 fn test_should_violate_counter_overflow() {
     let path = Path::new("test_cases/should_violate/counter_overflow.tla");

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -208,6 +208,33 @@ fn test_should_violate_let_operator_invariant() {
     );
 }
 
+/// A `LET`-local operator or value must shadow a same-named top-level
+/// definition. `LET G(n) == 0 IN G(x)` with a top-level `G(n) == 1000` must use
+/// the local `0`, not the top-level `1000`. The parser inlines operator
+/// applications from the top-level definitions, so it must skip a name that an
+/// enclosing `LET` binds. Covers both the parameterized and the zero-arg form.
+#[test]
+fn test_should_pass_let_shadows_toplevel() {
+    let path = Path::new("test_cases/should_pass/let_shadows_toplevel.tla");
+    assert!(
+        matches!(check_spec_file_allow_deadlock(path), CheckResult::Ok(_)),
+        "let_shadows_toplevel.tla: LET-local G/c (== 0) must shadow the top-level (== 1000)"
+    );
+}
+
+/// The other direction: a `LET`-local operator whose body *causes* a violation
+/// the top-level definition would not. `LET G(n) == 1000 IN G(x) < 50` with a
+/// top-level `G(n) == 0` must violate — if the top-level `0` were used it would
+/// be a false pass.
+#[test]
+fn test_should_violate_let_shadows_toplevel() {
+    let path = Path::new("test_cases/should_violate/let_shadows_toplevel_violation.tla");
+    assert!(
+        matches!(check_spec_file(path), CheckResult::InvariantViolation(..)),
+        "let_shadows_toplevel_violation.tla: the LET-local G (== 1000) must be used and violate"
+    );
+}
+
 /// A parameterized `LET` operator in a next-state assignment
 /// (`LET Bump(n) == n + 1 IN x' = Bump(x)`). The walker registers the operator as
 /// a definition and enumerates the successor; the inference engine cannot infer a

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -188,6 +188,30 @@ fn test_walker_init_probes() {
     }
 }
 
+/// Cliff guard: a wide prime-free guard (`\A i \in 1..24 : ...`) conjoined with a
+/// single assignment. A structural walk of the guard branches on every inner
+/// disjunct — O(2^24) dead work — before pruning. Hoisting prime-free conjuncts
+/// evaluates the guard as one boolean instead, so the check finishes instantly.
+/// Bound is generous to stay stable across machines while still catching a
+/// return to exponential behaviour (which runs for minutes). Walker engine only.
+#[test]
+fn test_walker_hoists_prime_free_guard() {
+    if std::env::var_os("TLA_WALK").is_none() {
+        return;
+    }
+    let start = std::time::Instant::now();
+    let result = check_spec_file_allow_deadlock(Path::new("test_cases/walker/cliff_guard.tla"));
+    let elapsed = start.elapsed();
+    assert!(
+        matches!(result, CheckResult::Ok(_)),
+        "cliff_guard.tla should pass, got: {result:?}"
+    );
+    assert!(
+        elapsed.as_secs_f64() < 1.0,
+        "cliff_guard.tla must not branch on the prime-free guard; took {elapsed:?}"
+    );
+}
+
 #[test]
 fn test_should_pass_counter_instantiated() {
     let path = Path::new("test_cases/should_pass/counter_instance.tla");

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -86,6 +86,30 @@ fn test_walker_dependent_next_state_probes() {
     }
 }
 
+/// `ENABLED A` is `\E vars' : A`, so an action that does not constrain every
+/// variable is still enabled — a partial assignment is a legitimate witness.
+/// Routed through the walker with a partial-assignment completion rule (the
+/// state-generating rule would wrongly demand totality). Asserted only under the
+/// walker engine.
+#[test]
+fn test_walker_enabled_partial_assignment() {
+    if std::env::var_os("TLA_WALK").is_none() {
+        return;
+    }
+    // `Act == x' = 1` leaves y' free, yet ENABLED Act must be true.
+    let violated =
+        check_spec_file_allow_deadlock(Path::new("test_cases/walker/enabled_partial.tla"));
+    assert!(
+        matches!(violated, CheckResult::InvariantViolation(_, _)),
+        "ENABLED of an action that leaves a variable free must be true, got: {violated:?}"
+    );
+    let holds = check_spec_file_allow_deadlock(Path::new("test_cases/walker/enabled_holds.tla"));
+    assert!(
+        matches!(holds, CheckResult::Ok(_)),
+        "ENABLED must still hold where the action is genuinely enabled, got: {holds:?}"
+    );
+}
+
 /// Init-phase differential corpus. The candidate-inference init collector has no
 /// arms for `\E`/`IF`/`LET`, so an initial state reached only through one of
 /// those is silently dropped (a clean pass, or a bogus "no initial states").


### PR DESCRIPTION
Replaces the candidate-inference state generator with a continuation-passing
walker (a port of TLC's getNextStates) and makes it the default.

## Why

The inference engine inferred a candidate set per primed variable and filtered
their cross product. Filtering can only ever *reject* a successor, so any
shortfall in the inference produced too few successors and reported a clean run
on a spec that actually violates its invariant — a silent false pass.

## What the walker fixes

- Primed variables whose value depends on another primed variable
  (`a' \in S /\ b' = a' + 10`), an operator argument, or an IF/CASE.
- Initial states reached only through `\E` / `IF` / `LET`.
- Action attribution for quantified actions (`\E rm \in RM : A(rm) \/ B(rm)`).
  The inference engine reached these states but the walker also names the action
  that produced each edge, which fairness/liveness needs. An engine-equivalence
  gate pins identical per-action transition histograms on known-correct specs.
- A variable an action leaves unassigned is now a reported error naming the
  variable and action (matching TLC), not a silently dropped successor.
  `--allow-unassigned-stutter` recovers the old lenient behaviour.
- A wide prime-free guard (`\A i \in 1..n : ...`) no longer branches O(2^n);
  prime-free conjuncts are hoisted and evaluated as guards.

## Safety

- `TLA_ENGINE=inference` selects the previous engine for one release.
- Debug builds assert every emitted successor satisfies Next.
- Both engine suites green (release and debug); clippy and fmt clean.
- Walker is faster or neutral on the corpus (TwoPhase 5RM ~0.35s vs ~0.54s).

## Follow-up

The inference engine (~900 lines) is removed in the next release, after the
escape hatch has shipped.
