### PR TITLE
add regression for primed arg to EXTENDS-imported operator

### DIFF
--- a/test_cases/should_violate/imported_op_primed_arg/Helper.tla
+++ b/test_cases/should_violate/imported_op_primed_arg/Helper.tla
@@ -1,0 +1,4 @@
+---- MODULE Helper ----
+EXTENDS Naturals
+IsTwice(a, b) == a = 2 * b
+====

--- a/test_cases/should_violate/imported_op_primed_arg/imported_op_primed_arg.tla
+++ b/test_cases/should_violate/imported_op_primed_arg/imported_op_primed_arg.tla
@@ -1,0 +1,10 @@
+---- MODULE imported_op_primed_arg ----
+EXTENDS Naturals, Helper
+VARIABLES x, y
+vars == <<x, y>>
+Init == x = 0 /\ y = 0
+Step == /\ x' \in {1, 2}
+        /\ (y' = 5 \/ IsTwice(y', x'))
+Next == Step \/ UNCHANGED vars
+Inv == y # 4
+====

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -792,6 +792,26 @@ fn test_should_violate_let_in_conjunction_list() {
     );
 }
 
+/// An operator imported via `EXTENDS` and applied to a primed variable
+/// (`IsTwice(y', x')`, with `IsTwice(a, b) == a = 2 * b`) must have its
+/// argument treated as prime-bearing even though the operator body has no
+/// prime. A same-file operator is inlined by the parser before use, so this
+/// only surfaces across a module boundary: `contains_prime_ref` must inspect
+/// the call arguments, not just recurse into the definition body, or the
+/// conjunct that binds `y'` is skipped and the reachable violation is missed.
+#[test]
+fn test_should_violate_imported_op_primed_arg() {
+    let path =
+        Path::new("test_cases/should_violate/imported_op_primed_arg/imported_op_primed_arg.tla");
+    assert!(
+        matches!(
+            check_spec_file_allow_deadlock(path),
+            CheckResult::InvariantViolation(..)
+        ),
+        "a primed variable passed to an EXTENDS-imported operator must be visible"
+    );
+}
+
 /// A set-image comprehension may bind more than one variable —
 /// `{a * 10 + b : a \in {1, 2}, b \in {3, 4}}` ranges over the product of the
 /// domains, yielding `{13, 14, 23, 24}`. The parser must accept the extra bounds


### PR DESCRIPTION
Locks in the fix for #74 (already resolved in the walker engine, 6d9651c): a primed variable passed to an operator imported via EXTENDS must be visible to state generation even when the operator body contains no prime.

contains_prime_ref now inspects call arguments (FnCall and QualifiedCall) before recursing into the definition body. A same-file operator is inlined before use, so this false pass only surfaced across a module boundary — hence a dedicated directory-based spec (Helper.tla + main).

Verified on the default walker: violation found for the false-pass repro, the top-level-conjunct crash variant, and a forall-guard variant targeting the prime-free hoist. walker 108/108, debug validator 108/108.