### PR TITLE
fix parser gaps that reject valid TLA+ (#81)

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -311,6 +311,23 @@ impl<'a> Lexer<'a> {
         self.input[self.pos..].chars().next()
     }
 
+    /// Whether the `_` at the current position begins an identifier rather than
+    /// a standalone `_` token. A TLA+ identifier is a run of letters, digits and
+    /// `_` containing at least one letter, so `__node` is an identifier while a
+    /// lone `_` is not. The `_` is also standalone in the stuttering-subscript
+    /// forms `[A]_v` and `<<A>>_v`, where it follows `]` or `>>` — there it is
+    /// the subscript operator, not the head of the variable name.
+    fn underscore_begins_ident(&self) -> bool {
+        let before = &self.input[..self.pos];
+        if before.ends_with(']') || before.ends_with(">>") {
+            return false;
+        }
+        self.input[self.pos..]
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .any(char::is_alphabetic)
+    }
+
     fn advance(&mut self) -> Option<char> {
         let c = self.peek_char()?;
         self.pos += c.len_utf8();
@@ -657,7 +674,7 @@ impl<'a> Lexer<'a> {
             self.advance();
             return Ok(Token::Prime);
         }
-        if c == '_' {
+        if c == '_' && !self.underscore_begins_ident() {
             self.advance();
             return Ok(Token::Underscore);
         }
@@ -1135,7 +1152,7 @@ impl<'a> Lexer<'a> {
             self.advance();
             return Ok(Token::Prime);
         }
-        if c == '_' {
+        if c == '_' && !self.underscore_begins_ident() {
             self.advance();
             return Ok(Token::Underscore);
         }
@@ -1375,6 +1392,58 @@ impl From<LexError> for String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lex_leading_underscore_identifier() {
+        let mut lexer = Lexer::new("Bump(__n)");
+        let tokens = lexer.tokenize().unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Ident("Bump".into()),
+                Token::LParen,
+                Token::Ident("__n".into()),
+                Token::RParen,
+                Token::Eof,
+            ]
+        );
+    }
+
+    #[test]
+    fn lex_bare_underscore_is_placeholder() {
+        let mut lexer = Lexer::new("Op(_, _)");
+        let tokens = lexer.tokenize().unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Ident("Op".into()),
+                Token::LParen,
+                Token::Underscore,
+                Token::Comma,
+                Token::Underscore,
+                Token::RParen,
+                Token::Eof,
+            ]
+        );
+    }
+
+    #[test]
+    fn lex_box_subscript_keeps_underscore() {
+        let mut lexer = Lexer::new("[][Next]_vars");
+        let tokens = lexer.tokenize().unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Always,
+                Token::LBracket,
+                Token::Ident("Next".into()),
+                Token::RBracket,
+                Token::Underscore,
+                Token::Ident("vars".into()),
+                Token::Eof,
+            ]
+        );
+    }
 
     #[test]
     fn lex_basic() {

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -100,6 +100,12 @@ impl Parser {
             {
                 break;
             }
+            if self.paren_depth == 0
+                && let Some(&ec) = self.list_col_stack.last()
+                && self.current_column() <= ec
+            {
+                break;
+            }
             self.advance();
             let right = self.parse_comparison()?;
             result = Expr::And(Box::new(result), Box::new(right));
@@ -108,6 +114,13 @@ impl Parser {
     }
 
     pub(super) fn parse_and_item(&mut self, list_col: u32) -> Result<Expr> {
+        self.list_col_stack.push(list_col);
+        let result = self.parse_and_item_inner(list_col);
+        self.list_col_stack.pop();
+        result
+    }
+
+    fn parse_and_item_inner(&mut self, list_col: u32) -> Result<Expr> {
         let start_line = self.current_line();
         let mut item = self.parse_and_conjunct(Some(list_col))?;
         while *self.peek() == Token::Or {
@@ -141,6 +154,12 @@ impl Parser {
         loop {
             match self.peek() {
                 Token::And => {
+                    if self.paren_depth == 0
+                        && let Some(&ec) = self.list_col_stack.last()
+                        && self.current_column() <= ec
+                    {
+                        break;
+                    }
                     if let Some((lc, _)) = list_anchor {
                         if self.paren_depth == 0 && self.current_column() != lc {
                             break;

--- a/src/parser/lexing.rs
+++ b/src/parser/lexing.rs
@@ -28,6 +28,12 @@ pub struct Parser {
     /// scope here must not be inlined from the top-level definitions — the local
     /// `LET` binding shadows it, and inlining would use the wrong (top-level) body.
     pub(super) let_scope: Vec<Arc<str>>,
+    /// Bullet columns of the junction lists whose items are currently being
+    /// parsed, innermost last. A `/\` or `\/` at or left of the innermost column
+    /// ends the current item, so a nested expression — a `LET` body, an `IF`
+    /// branch — stops there instead of swallowing the next bullet of an
+    /// enclosing list. Empty at paren depth, where alignment does not apply.
+    pub(super) list_col_stack: Vec<u32>,
 }
 
 impl Parser {
@@ -52,6 +58,7 @@ impl Parser {
             warnings: Vec::new(),
             fresh_counter: 0,
             let_scope: Vec::new(),
+            list_col_stack: Vec::new(),
         })
     }
 

--- a/src/parser/primary.rs
+++ b/src/parser/primary.rs
@@ -282,24 +282,21 @@ impl Parser {
             Token::Colon => {
                 self.advance();
                 let after_colon = self.parse_expr()?;
-                self.expect(Token::RBrace)?;
                 if let Expr::In(var_expr, domain) = &first
                     && let Some(binder) = extract_binder(var_expr)
                 {
+                    self.expect(Token::RBrace)?;
                     let domain = domain.as_ref().clone();
                     let (var, wrapped) = wrap_binder(self, binder, after_colon)?;
                     return Ok(Expr::SetFilter(var, Box::new(domain), Box::new(wrapped)));
                 }
-                if let Expr::In(var_expr, domain) = after_colon
-                    && let Some(binder) = extract_binder(&var_expr)
-                {
-                    let (var, wrapped) = wrap_binder(self, binder, first)?;
-                    return Ok(Expr::SetMap(var, domain, Box::new(wrapped)));
+                let mut bounds = vec![after_colon];
+                while *self.peek() == Token::Comma {
+                    self.advance();
+                    bounds.push(self.parse_expr()?);
                 }
-                Err(ParseError::new(
-                    "expected {x \\in S : P} or {e : x \\in S} in set comprehension",
-                )
-                .with_span(self.current_span()))
+                self.expect(Token::RBrace)?;
+                self.build_set_map(first, bounds)
             }
             Token::RBrace => {
                 self.advance();
@@ -311,6 +308,36 @@ impl Parser {
                 Err(ParseError::new(format!("unexpected {tok} in set literal")).with_span(span))
             }
         }
+    }
+
+    /// Build a set-image comprehension `{e : x \in S, y \in T, ...}` from the
+    /// mapped expression and its bounds. A single bound is one `SetMap`; each
+    /// enclosing bound maps the accumulated set and flattens it, so
+    /// `{e : x \in S, y \in T}` is `UNION {{e : y \in T} : x \in S}`.
+    fn build_set_map(&mut self, body: Expr, bounds: Vec<Expr>) -> Result<Expr> {
+        let mut iter = bounds.into_iter().rev();
+        let (var, domain) = match iter.next() {
+            Some(Expr::In(var_expr, domain)) => (var_expr, domain),
+            _ => return Err(self.set_map_error()),
+        };
+        let binder = extract_binder(&var).ok_or_else(|| self.set_map_error())?;
+        let (var, wrapped) = wrap_binder(self, binder, body)?;
+        let mut result = Expr::SetMap(var, domain, Box::new(wrapped));
+        for bound in iter {
+            let (var, domain) = match bound {
+                Expr::In(var_expr, domain) => (var_expr, domain),
+                _ => return Err(self.set_map_error()),
+            };
+            let binder = extract_binder(&var).ok_or_else(|| self.set_map_error())?;
+            let (var, wrapped) = wrap_binder(self, binder, result)?;
+            result = Expr::BigUnion(Box::new(Expr::SetMap(var, domain, Box::new(wrapped))));
+        }
+        Ok(result)
+    }
+
+    fn set_map_error(&self) -> ParseError {
+        ParseError::new("expected {e : x \\in S, ...} in set comprehension")
+            .with_span(self.current_span())
     }
 
     pub(super) fn parse_record_or_fn(&mut self) -> Result<Expr> {

--- a/test_cases/should_pass/let_in_conjunction_list.tla
+++ b/test_cases/should_pass/let_in_conjunction_list.tla
@@ -1,0 +1,8 @@
+---- MODULE let_in_conjunction_list ----
+EXTENDS Integers
+VARIABLES x, y
+Init == /\ x = LET f == 6 IN f
+        /\ y = 0
+Next == UNCHANGED <<x, y>>
+Inv == x = 6 /\ y = 0
+====

--- a/test_cases/should_pass/underscore_identifiers.tla
+++ b/test_cases/should_pass/underscore_identifiers.tla
@@ -1,0 +1,8 @@
+---- MODULE underscore_identifiers ----
+EXTENDS Integers
+VARIABLE x
+Bump(__n) == __n + 1
+Init == x = 0
+Next == \E __p \in {1, 2} : x' = Bump(__p)
+Inv == x < 10
+====

--- a/test_cases/should_violate/let_in_conjunction_list_violation.tla
+++ b/test_cases/should_violate/let_in_conjunction_list_violation.tla
@@ -1,0 +1,8 @@
+---- MODULE let_in_conjunction_list_violation ----
+EXTENDS Integers
+VARIABLES x, y
+Init == /\ x = LET f == 6 IN f
+        /\ y = 0
+Next == UNCHANGED <<x, y>>
+Inv == y = 6
+====

--- a/test_cases/should_violate/multi_bound_set_comprehension.tla
+++ b/test_cases/should_violate/multi_bound_set_comprehension.tla
@@ -1,0 +1,8 @@
+---- MODULE multi_bound_set_comprehension ----
+EXTENDS Integers
+VARIABLE x
+S == { a * 10 + b : a \in {1, 2}, b \in {3, 4} }
+Init == x \in S
+Next == UNCHANGED x
+Inv == x # 24
+====

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -763,6 +763,23 @@ fn test_should_violate_operator_arg_capture() {
     );
 }
 
+/// A set-image comprehension may bind more than one variable —
+/// `{a * 10 + b : a \in {1, 2}, b \in {3, 4}}` ranges over the product of the
+/// domains, yielding `{13, 14, 23, 24}`. The parser must accept the extra bounds
+/// (not stop at the first comma) and enumerate every combination, so `x = 24` is
+/// reachable and the invariant `x # 24` is violated.
+#[test]
+fn test_should_violate_multi_bound_set_comprehension() {
+    let path = Path::new("test_cases/should_violate/multi_bound_set_comprehension.tla");
+    assert!(
+        matches!(
+            check_spec_file_allow_deadlock(path),
+            CheckResult::InvariantViolation(..)
+        ),
+        "{{e : x \\in S, y \\in T}} must enumerate the product of the domains"
+    );
+}
+
 #[test]
 fn test_should_violate_counter_overflow() {
     let path = Path::new("test_cases/should_violate/counter_overflow.tla");

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -1670,6 +1670,21 @@ fn test_should_pass_extends_file_module() {
     );
 }
 
+/// A TLA+ identifier may begin with `_` as long as it contains a letter
+/// (`__n`, `__p`). The lexer must read such a name as one identifier, not as the
+/// standalone `_` placeholder token followed by an identifier — while still
+/// treating a lone `_` and the `[A]_v` / `<<A>>_v` subscripts as `_` tokens.
+#[test]
+fn test_should_pass_underscore_identifiers() {
+    let path = Path::new("test_cases/should_pass/underscore_identifiers.tla");
+    let result = check_spec_file_allow_deadlock(path);
+    assert!(
+        matches!(result, CheckResult::Ok(_)),
+        "leading-underscore identifiers must lex as identifiers, got: {:?}",
+        result
+    );
+}
+
 #[test]
 fn test_should_pass_extends_transitive() {
     let path = Path::new("test_cases/should_pass/extends_transitive/extends_transitive.tla");

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -763,6 +763,35 @@ fn test_should_violate_operator_arg_capture() {
     );
 }
 
+/// A `LET`/`IN` expression as a conjunction-list item must not swallow the next
+/// item: `/\ x = LET f == 6 IN f` followed by `/\ y = 0` is two conjuncts, so
+/// the `LET` body is just `f`. The next bullet, aligned at the list column, ends
+/// the body. Here `x = 6 /\ y = 0`, so the invariant holds.
+#[test]
+fn test_should_pass_let_in_conjunction_list() {
+    let path = Path::new("test_cases/should_pass/let_in_conjunction_list.tla");
+    assert!(
+        matches!(check_spec_file_allow_deadlock(path), CheckResult::Ok(_)),
+        "a LET body must end at the next junction bullet, not swallow it"
+    );
+}
+
+/// The companion to [`test_should_pass_let_in_conjunction_list`]: if the `LET`
+/// body swallowed `/\ y = 0`, `y` would be unconstrained and this invariant
+/// unreachable. Because the bullet ends the body, `y = 0` binds `y`, so `y = 6`
+/// is violated — proving the second conjunct is parsed, not absorbed.
+#[test]
+fn test_should_violate_let_in_conjunction_list() {
+    let path = Path::new("test_cases/should_violate/let_in_conjunction_list_violation.tla");
+    assert!(
+        matches!(
+            check_spec_file_allow_deadlock(path),
+            CheckResult::InvariantViolation(..)
+        ),
+        "the conjunct after a LET body must bind y, making y = 6 violated"
+    );
+}
+
 /// A set-image comprehension may bind more than one variable —
 /// `{a * 10 + b : a \in {1, 2}, b \in {3, 4}}` ranges over the product of the
 /// domains, yielding `{13, 14, 23, 24}`. The parser must accept the extra bounds


### PR DESCRIPTION
Fixes three constructs from #81 that TLC accepts but tla-rs rejected. Each is independent, with a regression spec and oracle test.

- Leading-underscore identifiers (`__n`, `Bump(__n)`, `\E __p \in ...`) now lex as identifiers. The lexer had intercepted every `_` as the standalone placeholder token; it now does so only for a bare `_` and the `[A]_v` / `<<A>>_v` subscripts, where `_` follows `]` or `>>`.

- A `LET`/`IN` (or any nested expression) as a conjunction-list item no longer swallows the next bullet. The parser tracks the enclosing junction bullet columns; a `/\` or `\/` at or left of an enclosing bullet ends the current item, matching TLA+'s alignment rule.

- Set-image comprehensions may bind more than one variable — `{e : x \in S, y \in T}` — ranging over the product of the domains, desugared to nested `SetMap`/`UNION`.

Two other items from #81 were already resolved: `\E`/`LET`-enclosed Init predicates by the continuation-passing walker, and recursive function definitions no longer silently check the wrong spec or OOM (they now error).

Verified: full suite green (200 unit + 111 oracle + debug validator), and a 163-spec corpus A/B against the pre-change baseline shows the junction-parser change is behavior-preserving except for the intended fixes.