### PR TITLE
precompute line starts so line lookup is not quadratic

### DIFF
--- a/src/parser/lexing.rs
+++ b/src/parser/lexing.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use crate::ast::{Expr, FairnessConstraint, InstanceDecl};
 use crate::lexer::{Lexer, Token};
+use crate::source::Source;
 use crate::span::{Span, Spanned};
 
 use super::error::{ParseError, Result};
@@ -10,7 +11,6 @@ use super::error::{ParseError, Result};
 pub struct Parser {
     pub(super) tokens: Vec<Spanned<Token>>,
     pub(super) pos: usize,
-    pub(super) source: Arc<str>,
     pub(super) paren_depth: u32,
     pub(super) definitions: BTreeMap<Arc<str>, Expr>,
     pub(super) fn_definitions: BTreeMap<Arc<str>, (Vec<Arc<str>>, Expr)>,
@@ -24,6 +24,11 @@ pub struct Parser {
     pub(super) quantified_temporal: Vec<(Arc<str>, Expr, Expr)>,
     pub(super) warnings: Vec<Spanned<String>>,
     pub(super) fresh_counter: u64,
+    /// The source text with its precomputed line-start index, so `line_of` and
+    /// `column_of` resolve a byte offset by binary search instead of rescanning
+    /// from the start on every token — the difference between O(n) and O(n²)
+    /// parsing over a large module.
+    pub(super) source: Source,
     /// Names bound by an enclosing `LET`. An operator reference whose name is in
     /// scope here must not be inlined from the top-level definitions — the local
     /// `LET` binding shadows it, and inlining would use the wrong (top-level) body.
@@ -43,7 +48,7 @@ impl Parser {
         Ok(Self {
             tokens,
             pos: 0,
-            source: Arc::from(input),
+            source: Source::new("", input),
             paren_depth: 0,
             definitions: BTreeMap::new(),
             fn_definitions: BTreeMap::new(),
@@ -77,20 +82,11 @@ impl Parser {
     }
 
     pub(super) fn column_of(&self, byte_offset: u32) -> u32 {
-        let offset = byte_offset as usize;
-        let src = &self.source[..offset.min(self.source.len())];
-        match src.rfind('\n') {
-            Some(nl) => (offset - nl - 1) as u32,
-            None => offset as u32,
-        }
+        self.source.line_col(byte_offset).1 as u32 - 1
     }
 
     pub(super) fn line_of(&self, byte_offset: u32) -> u32 {
-        let offset = byte_offset as usize;
-        self.source[..offset.min(self.source.len())]
-            .bytes()
-            .filter(|&b| b == b'\n')
-            .count() as u32
+        self.source.line_col(byte_offset).0 as u32 - 1
     }
 
     pub(super) fn current_column(&self) -> u32 {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -52,6 +52,18 @@ mod tests {
     }
 
     #[test]
+    fn line_and_column_from_byte_offset() {
+        // "ab\ncde\nf": line starts at bytes 0, 3, 7.
+        let parser = Parser::new("ab\ncde\nf").unwrap();
+        let at = |o| (parser.line_of(o), parser.column_of(o));
+        assert_eq!(at(0), (0, 0));
+        assert_eq!(at(1), (0, 1));
+        assert_eq!(at(3), (1, 0));
+        assert_eq!(at(5), (1, 2));
+        assert_eq!(at(7), (2, 0));
+    }
+
+    #[test]
     fn parse_set_enum() {
         let expr = parse_expr("{1, 2, 3}").unwrap();
         if let Expr::SetEnum(elems) = expr {


### PR DESCRIPTION
The parser mapped a token's byte offset to (line, column) by scanning the source from the start on every call — `line_of` counted newlines in `source[..offset]` (O(offset)) and `column_of` sliced it too. Junction-list parsing calls these per conjunct, so validating a large module was O(n²): a synthetic 96k-line module took 26s, and a 120k-line one (the scale in #81's perf note) extrapolated to minutes.

Precompute `line_starts` (the byte offset of each line start) once in `Parser::new` (O(n)). `line_of` is now a binary search (O(log n)) and `column_of` is `offset - line_starts[line]`. The unused `source` field is removed.

Result: the 96k-line module drops from 26s to 0.30s and the 120k-line one to 0.39s; time now grows linearly with size. Reported error line:column is unchanged — verified by the existing diagnostic tests, a new unit test for the offset→(line, column) mapping, and an adversarial check comparing the new formula against the old over every offset across many inputs (empty, CRLF, multi-byte UTF-8, EOF): no differences. The new code is also panic-free where the old could panic slicing a multi-byte char.

Fixes the parsing-speed item noted in #81.