### PR TITLE
add regression for LET operator on assignment RHS (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.8.1] - 2026-09-01
+
+### Added
+
+- Regression coverage for a parameterized `LET` operator defined and called on the right-hand side of a next-state assignment (`x' = LET add10(a) == a + 10 IN add10(10)`, #70). The construct already resolves as of the 0.8.0 walker; this pins the behavior with a dedicated test.
+
 ## [0.8.0] - 2026-08-31
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"

--- a/test_cases/should_violate/let_operator_in_assignment_rhs.tla
+++ b/test_cases/should_violate/let_operator_in_assignment_rhs.tla
@@ -1,0 +1,8 @@
+---- MODULE let_operator_in_assignment_rhs ----
+EXTENDS Integers
+VARIABLE x
+Init == x = 0
+Update == x' = LET add10(a) == a + 10 IN add10(10)
+InvTest == x # 20
+Next == Update
+====

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -208,6 +208,26 @@ fn test_should_violate_let_operator_invariant() {
     );
 }
 
+/// A parameterized `LET` operator defined and called on the right-hand side of a
+/// next-state assignment — `x' = LET add10(a) == a + 10 IN add10(10)` — must
+/// resolve, binding `x'` to `20`. The `LET` is the assignment's value expression,
+/// not a wrapper around the action, and the call uses a literal argument.
+#[test]
+fn test_should_violate_let_operator_in_assignment_rhs() {
+    let path = Path::new("test_cases/should_violate/let_operator_in_assignment_rhs.tla");
+    match check_spec_file_allow_deadlock(path) {
+        CheckResult::InvariantViolation(cex, _) => {
+            let x = cex.trace.last().and_then(|s| s.values.first());
+            assert_eq!(
+                x,
+                Some(&Value::Int(20)),
+                "x' = LET add10(a) == a + 10 IN add10(10) must bind x to 20"
+            );
+        }
+        other => panic!("expected InvariantViolation for #70, got {:?}", other),
+    }
+}
+
 /// A `LET`-local operator or value must shadow a same-named top-level
 /// definition. `LET G(n) == 0 IN G(x)` with a top-level `G(n) == 1000` must use
 /// the local `0`, not the top-level `1000`. The parser inlines operator


### PR DESCRIPTION
#70's construct — a parameterized LET operator defined and called on the RHS of a next-state assignment, `x' = LET add10(a) == a + 10 IN add10(10)` — already resolves as of the 0.8.0 walker (both engines reach x = 20 and violate the test invariant). The existing LET tests wrap the LET around the whole action (`LET Bump IN x' = Bump(x)`); none covered the LET as the assignment's value expression, so this pins that shape with a dedicated should_violate spec + oracle test.

Also bumps the version to 0.8.1 and adds the changelog entry.

Verified: 113 oracle + debug validator, clippy/fmt clean.