### PR TITLE
apply engine selection across all entry points and scope it per run (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Regression coverage for a parameterized `LET` operator defined and called on the right-hand side of a next-state assignment (`x' = LET add10(a) == a + 10 IN add10(10)`, #70). The construct already resolves as of the 0.8.0 walker; this pins the behavior with a dedicated test.
 
+### Fixed
+
+- `TLA_ENGINE=inference` now applies in the scenario, interactive, and validate paths, not only in `check()` — the engine selection is set once from configuration before any mode runs (#79). The selection is also scoped so a run that sets it no longer leaks the choice into a later state generation on the same thread.
+
 ## [0.8.0] - 2026-08-31
 
 ### Changed

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -341,8 +341,10 @@ pub fn prepare_spec(
 }
 
 pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult {
-    crate::eval::set_use_inference_engine(config.use_inference_engine);
-    crate::eval::set_allow_unassigned_stutter(config.allow_unassigned_stutter);
+    let _engine = crate::eval::EngineOverride::new(
+        config.use_inference_engine,
+        config.allow_unassigned_stutter,
+    );
     #[cfg(not(target_arch = "wasm32"))]
     let prep = prepare_spec(spec, domains, config.spec_path.as_ref(), config.quiet);
     #[cfg(target_arch = "wasm32")]

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -48,7 +48,7 @@ pub use self::state::{
 };
 
 pub(crate) use self::ast_utils::{contains_prime_ref, expr_references};
-pub use self::walk::{set_allow_unassigned_stutter, set_use_inference_engine};
+pub use self::walk::{EngineOverride, set_allow_unassigned_stutter, set_use_inference_engine};
 
 pub(crate) fn resolve_parameterized_defs(
     param_inst: &ParameterizedInstance,
@@ -93,6 +93,23 @@ mod tests {
 
     fn var(name: &str) -> Arc<str> {
         Arc::from(name)
+    }
+
+    #[test]
+    fn engine_override_restores_previous_selection_on_drop() {
+        let before = super::walk::walk_enabled();
+        {
+            let _override = EngineOverride::new(true, false);
+            assert!(
+                !super::walk::walk_enabled(),
+                "an EngineOverride selecting inference must deselect the walker while held"
+            );
+        }
+        assert_eq!(
+            super::walk::walk_enabled(),
+            before,
+            "the previous engine selection must be restored when the override drops"
+        );
     }
 
     fn lit_int(n: i64) -> Expr {

--- a/src/eval/walk.rs
+++ b/src/eval/walk.rs
@@ -53,6 +53,36 @@ fn allow_unassigned_stutter() -> bool {
     ALLOW_UNASSIGNED_STUTTER.with(std::cell::Cell::get)
 }
 
+/// Applies an engine/stutter selection to the current thread for as long as it is
+/// held, restoring the previous values on drop. The selection lives in
+/// thread-locals read throughout state generation; scoping it here keeps a run
+/// that sets it (a `check()` call, say) from leaking that choice into a later
+/// state generation on the same thread.
+pub struct EngineOverride {
+    prev_inference: bool,
+    prev_stutter: bool,
+}
+
+impl EngineOverride {
+    pub fn new(use_inference: bool, allow_stutter: bool) -> Self {
+        let prev_inference = USE_INFERENCE_ENGINE.with(std::cell::Cell::get);
+        let prev_stutter = ALLOW_UNASSIGNED_STUTTER.with(std::cell::Cell::get);
+        set_use_inference_engine(use_inference);
+        set_allow_unassigned_stutter(allow_stutter);
+        Self {
+            prev_inference,
+            prev_stutter,
+        }
+    }
+}
+
+impl Drop for EngineOverride {
+    fn drop(&mut self) {
+        set_use_inference_engine(self.prev_inference);
+        set_allow_unassigned_stutter(self.prev_stutter);
+    }
+}
+
 /// Whether the walker is generating successors (`x' = e` binds `x'`) or initial
 /// states (`x = e` binds `x`). The machine is otherwise identical, as in TLC.
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -681,6 +681,9 @@ fn main() -> ExitCode {
         i += 1;
     }
 
+    tla_checker::eval::set_use_inference_engine(config.use_inference_engine);
+    tla_checker::eval::set_allow_unassigned_stutter(config.allow_unassigned_stutter);
+
     #[cfg(not(target_arch = "wasm32"))]
     if let Some(manifest_path) = present_path {
         if let Some(out) = export_html_path {


### PR DESCRIPTION
Fixes both parts of #79.

(a) `TLA_ENGINE=inference` (and `--allow-unassigned-stutter`) reached only `check()`; the scenario, interactive, and validate paths call state generation directly and silently ran the walker default. main.rs now sets the engine/stutter thread-locals from the finalized config once, before dispatching to any mode, so every CLI path honors the flags.

(b) The engine/stutter selection lives in thread-locals; `check()` set them and left them, so a later state generation on the same thread that did not go through `check()` inherited the stale choice. `check()` now applies the selection through an RAII `EngineOverride` that restores the previous values on drop, so the choice cannot leak. A unit test verifies restore-on-drop.

Priority was low (the walker is the correct default in those modes), but (b) was a latent correctness hazard.

Verified: 202 unit + 113 oracle + debug validator green, host and wasm builds clean, clippy/fmt clean. No version bump — this is more unreleased-0.8.1 content; added a 0.8.1 changelog entry.