### PR TITLE
add refinement checking (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## [0.8.1] - 2026-09-01
+## [0.9.0] - 2026-09-05
 
 ### Added
+
+- Refinement checking: `--check-refinement ALIAS` verifies `Spec => ALIAS!Spec` for a non-parameterized `INSTANCE` alias (#22). During the concrete BFS, every initial state's abstract image (via the refinement mapping) must satisfy the abstract `Init`, and every concrete transition must satisfy the abstract `Next` or leave the abstract image unchanged (a stutter — an internal step the abstract spec cannot observe). The abstract module's `Init`/`Next` are found by canonical name (`Init`/`Next` or `<Prefix>Init`/`<Prefix>Next`); a violation is reported with a counterexample trace. The stutter comparison covers every abstract variable, including those left to TLA+'s implicit same-name substitution rather than named in a `WITH` clause.
 
 - Regression coverage for a parameterized `LET` operator defined and called on the right-hand side of a next-state assignment (`x' = LET add10(a) == a + 10 IN add10(10)`, #70). The construct already resolves as of the 0.8.0 walker; this pins the behavior with a dedicated test.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tla-checker"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 description = "A TLA+ model checker written in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -50,6 +50,12 @@ pub struct CheckerConfig {
     pub state_constraints: Vec<Expr>,
     pub allow_unassigned_stutter: bool,
     pub use_inference_engine: bool,
+    /// Verify that the concrete spec refines the abstract spec reached through the
+    /// named non-parameterized `INSTANCE` alias — `Spec => Alias!Spec`. Each
+    /// concrete transition must satisfy the abstract `Next` or leave the abstract
+    /// state unchanged (a stutter), and every initial state must satisfy the
+    /// abstract `Init`.
+    pub check_refinement: Option<Arc<str>>,
 }
 
 impl Default for CheckerConfig {
@@ -77,6 +83,7 @@ impl Default for CheckerConfig {
             state_constraints: Vec::new(),
             allow_unassigned_stutter: false,
             use_inference_engine: false,
+            check_refinement: None,
         }
     }
 }
@@ -92,6 +99,17 @@ pub struct Counterexample {
     pub trace: Vec<State>,
     pub actions: Vec<Option<Arc<str>>>,
     pub violated_invariant: usize,
+}
+
+/// A concrete behavior that breaks the refinement `Spec => Alias!Spec`: either an
+/// initial state whose abstract image fails the abstract `Init`, or a transition
+/// whose abstract image is neither an abstract `Next` step nor a stutter.
+#[derive(Debug)]
+pub struct RefinementViolation {
+    pub trace: Vec<State>,
+    pub actions: Vec<Option<Arc<str>>>,
+    pub alias: Arc<str>,
+    pub at_init: bool,
 }
 
 #[derive(Debug)]
@@ -122,6 +140,7 @@ pub struct PropertyStats {
 pub enum CheckResult {
     Ok(CheckStats),
     InvariantViolation(Counterexample, CheckStats),
+    RefinementViolation(RefinementViolation, CheckStats),
     LivenessViolation(LivenessViolation, CheckStats),
     Deadlock(Vec<State>, Vec<Option<Arc<str>>>, CheckStats),
     InitError(EvalError),
@@ -141,6 +160,7 @@ pub enum PrepareSpecError {
     AssumeViolation(usize),
     AssumeError(usize, EvalError),
     NonModelValueSymmetry(Arc<str>, Vec<String>),
+    RefinementConfigError(String),
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -292,13 +312,14 @@ pub fn prepare_spec(
             }
         }
         match resolve_instances(spec, &registry) {
-            Ok((static_instances, param_instances)) => {
+            Ok((static_instances, param_instances, instance_vars)) => {
                 let total = static_instances.len() + param_instances.len();
                 if total > 0 && !quiet {
                     eprintln!("  Resolved {} instance(s)", total);
                 }
                 set_resolved_instances(static_instances);
                 set_parameterized_instances(param_instances);
+                crate::eval::set_resolved_instance_vars(instance_vars);
             }
             Err(e) => {
                 if !quiet {
@@ -494,6 +515,28 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
     let primed_vars = make_primed_names(&spec.vars);
     let mut reusable_env = base_env.clone();
 
+    let refinement = match &config.check_refinement {
+        Some(alias) => {
+            if !config.symmetric_constants.is_empty() {
+                return CheckResult::PrepareError(PrepareSpecError::RefinementConfigError(
+                    "--check-refinement cannot be combined with --symmetry: symmetry reduction \
+                     prunes symmetric transitions, so a refinement violation on a pruned sibling \
+                     could be missed"
+                        .to_string(),
+                ));
+            }
+            match crate::refinement::RefinementSpec::resolve(alias, spec) {
+                Ok(resolved) => Some(resolved),
+                Err(message) => {
+                    return CheckResult::PrepareError(PrepareSpecError::RefinementConfigError(
+                        message,
+                    ));
+                }
+            }
+        }
+        None => None,
+    };
+
     let mut violation_counts_by_inv: Vec<usize> = vec![0; spec.invariants.len()];
     let max_violation_traces: usize = 10;
 
@@ -563,6 +606,24 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
             Ok(true) => {}
             Ok(false) => continue,
             Err(e) => return CheckResult::InitError(e),
+        }
+        if let Some(refinement) = &refinement {
+            match refinement.init_holds(&state, &spec.vars, &base_env, &defs) {
+                Ok(true) => {}
+                Ok(false) => {
+                    stats.elapsed_secs = elapsed_secs();
+                    return CheckResult::RefinementViolation(
+                        RefinementViolation {
+                            trace: vec![state.clone()],
+                            actions: vec![None],
+                            alias: refinement.alias(),
+                            at_init: true,
+                        },
+                        stats,
+                    );
+                }
+                Err(e) => return CheckResult::InitError(e),
+            }
         }
         let canonical = symmetry.canonicalize(&state).into_owned();
         let (idx, is_new) = states.insert_full(canonical);
@@ -838,6 +899,39 @@ pub fn check(spec: &Spec, domains: &Env, config: &CheckerConfig) -> CheckResult 
                         reconstruct_trace(current_idx, &states, &parent, &parent_action);
                     let dot = do_export(&states, &parent, Some(current_idx), &all_edges);
                     return CheckResult::NextError(e, trace, dot);
+                }
+            }
+            if let Some(refinement) = &refinement {
+                match refinement.step_refines(
+                    &ctx.current_state,
+                    &transition.state,
+                    &spec.vars,
+                    &base_env,
+                    &defs,
+                ) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        let (mut trace, mut actions) =
+                            reconstruct_trace(current_idx, &states, &parent, &parent_action);
+                        trace.push(transition.state.clone());
+                        actions.push(transition.action.clone());
+                        stats.elapsed_secs = elapsed_secs();
+                        return CheckResult::RefinementViolation(
+                            RefinementViolation {
+                                trace,
+                                actions,
+                                alias: refinement.alias(),
+                                at_init: false,
+                            },
+                            stats,
+                        );
+                    }
+                    Err(e) => {
+                        let (trace, _actions) =
+                            reconstruct_trace(current_idx, &states, &parent, &parent_action);
+                        let dot = do_export(&states, &parent, Some(current_idx), &all_edges);
+                        return CheckResult::NextError(e, trace, dot);
+                    }
                 }
             }
             let canonical = symmetry.canonicalize(&transition.state).into_owned();
@@ -1472,6 +1566,19 @@ pub fn check_result_to_json(result: &CheckResult, spec: &Spec) -> String {
                 stats.elapsed_secs
             )
         }
+        CheckResult::RefinementViolation(violation, stats) => {
+            let kind = if violation.at_init { "init" } else { "step" };
+            format!(
+                r#"{{"status": "refinement_violation", "alias": "{}", "at": "{}", "trace": {}, "stats": {{"states_explored": {}, "transitions": {}, "max_depth": {}, "elapsed_secs": {:.3}}}}}"#,
+                violation.alias,
+                kind,
+                trace_to_json_with_actions(&violation.trace, &violation.actions, &spec.vars),
+                stats.states_explored,
+                stats.transitions,
+                stats.max_depth_reached,
+                stats.elapsed_secs
+            )
+        }
         CheckResult::Deadlock(trace, actions, stats) => {
             format!(
                 r#"{{"status": "deadlock", "trace": {}, "stats": {{"states_explored": {}, "transitions": {}, "max_depth": {}, "elapsed_secs": {:.3}}}}}"#,
@@ -1565,6 +1672,12 @@ pub fn check_result_to_json(result: &CheckResult, spec: &Spec) -> String {
                 r#"{{"status": "non_model_value_symmetry", "constant": "{}", "members": [{}]}}"#,
                 name,
                 quoted.join(", ")
+            )
+        }
+        CheckResult::PrepareError(PrepareSpecError::RefinementConfigError(message)) => {
+            format!(
+                r#"{{"status": "refinement_config_error", "error": "{}"}}"#,
+                message.replace('"', "\\\"")
             )
         }
         CheckResult::LivenessViolation(violation, stats) => {

--- a/src/eval/global_state.rs
+++ b/src/eval/global_state.rs
@@ -72,6 +72,11 @@ thread_local! {
     pub(super) static CHECKER_STATS: RefCell<CheckerStats> = const { RefCell::new(CheckerStats::new()) };
     pub(super) static RESOLVED_INSTANCES: RefCell<ResolvedInstances> = const { RefCell::new(BTreeMap::new()) };
     pub(super) static PARAMETERIZED_INSTANCES: RefCell<ParameterizedInstances> = const { RefCell::new(BTreeMap::new()) };
+    /// The declared variables of each non-parameterized `INSTANCE` alias's
+    /// abstract module — needed by refinement checking to detect a stutter over
+    /// *all* abstract variables, including those left to the implicit same-name
+    /// substitution rather than named in a `WITH` clause.
+    pub(super) static RESOLVED_INSTANCE_VARS: RefCell<BTreeMap<Arc<str>, Vec<Arc<str>>>> = const { RefCell::new(BTreeMap::new()) };
     #[cfg(feature = "profiling")]
     pub(super) static PROFILING_STATS: RefCell<ProfilingStats> = const { RefCell::new(ProfilingStats::new()) };
 }
@@ -99,10 +104,32 @@ pub fn set_resolved_instances(instances: ResolvedInstances) {
 pub fn clear_resolved_instances() {
     RESOLVED_INSTANCES.with(|inst| inst.borrow_mut().clear());
     PARAMETERIZED_INSTANCES.with(|inst| inst.borrow_mut().clear());
+    RESOLVED_INSTANCE_VARS.with(|v| v.borrow_mut().clear());
 }
 
 pub fn set_parameterized_instances(instances: ParameterizedInstances) {
     PARAMETERIZED_INSTANCES.with(|inst| *inst.borrow_mut() = instances);
+}
+
+pub fn set_resolved_instance_vars(vars: BTreeMap<Arc<str>, Vec<Arc<str>>>) {
+    RESOLVED_INSTANCE_VARS.with(|v| *v.borrow_mut() = vars);
+}
+
+/// The definition names resolved for a non-parameterized `INSTANCE` alias, or
+/// `None` if the alias was not resolved. Lets refinement checking discover the
+/// abstract module's `Init`/`Next` operators without re-loading the module.
+pub fn resolved_instance_def_names(alias: &str) -> Option<Vec<Arc<str>>> {
+    RESOLVED_INSTANCES.with(|inst| {
+        inst.borrow()
+            .get(alias)
+            .map(|defs| defs.keys().cloned().collect())
+    })
+}
+
+/// The declared variables of a non-parameterized `INSTANCE` alias's abstract
+/// module, or `None` if the alias was not resolved.
+pub fn resolved_instance_vars(alias: &str) -> Option<Vec<Arc<str>>> {
+    RESOLVED_INSTANCE_VARS.with(|v| v.borrow().get(alias).cloned())
 }
 
 #[cfg(feature = "profiling")]

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -35,8 +35,10 @@ pub use self::core::eval;
 pub use self::diagnostics::explain_invariant_failure;
 pub use self::error::EvalError;
 pub use self::global_state::{
-    CheckerStats, EvalContext, clear_resolved_instances, reset_tlc_state, set_checker_level,
-    set_parameterized_instances, set_random_seed, set_resolved_instances, update_checker_stats,
+    CheckerStats, EvalContext, clear_resolved_instances, reset_tlc_state,
+    resolved_instance_def_names, resolved_instance_vars, set_checker_level,
+    set_parameterized_instances, set_random_seed, set_resolved_instance_vars,
+    set_resolved_instances, update_checker_stats,
 };
 #[cfg(feature = "profiling")]
 pub use self::global_state::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod mcp;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod modules;
 pub mod parser;
+pub mod refinement;
 pub mod scc;
 pub mod scenario;
 pub mod source;

--- a/src/main.rs
+++ b/src/main.rs
@@ -427,6 +427,14 @@ fn main() -> ExitCode {
             "--check-liveness" => {
                 config.check_liveness = true;
             }
+            "--check-refinement" => {
+                i += 1;
+                if missing_value(&args, i) {
+                    eprintln!("--check-refinement requires an INSTANCE alias");
+                    return ExitCode::FAILURE;
+                }
+                config.check_refinement = Some(args[i].clone().into());
+            }
             "--quick" | "-q" => {
                 config.max_states = 10_000;
                 config.quick_mode = true;
@@ -614,6 +622,9 @@ fn main() -> ExitCode {
                     "  --allow-unassigned-stutter Treat a variable an action leaves unassigned as UNCHANGED"
                 );
                 println!("  --check-liveness           Check liveness and fairness properties");
+                println!(
+                    "  --check-refinement ALIAS   Verify Spec => ALIAS!Spec for an INSTANCE alias"
+                );
                 println!("  --quick, -q                Quick exploration (limit: 10,000 states)");
                 println!("  --verbose, -v              Verbose output (show more details)");
                 println!("  -vv                        Debug output (show all details)");
@@ -1145,6 +1156,32 @@ fn main() -> ExitCode {
             println!("  Time: {:.3}s", stats.elapsed_secs);
             ExitCode::FAILURE
         }
+        CheckResult::RefinementViolation(violation, stats) => {
+            if violation.at_init {
+                println!(
+                    "Refinement violated: an initial state does not satisfy {}!Init",
+                    violation.alias
+                );
+            } else {
+                println!(
+                    "Refinement violated: a transition is neither a {}!Next step nor a stutter",
+                    violation.alias
+                );
+            }
+            println!();
+            println!("Counterexample trace ({} states):", violation.trace.len());
+            println!("  (* marks changed variables)");
+            println!();
+            print!(
+                "{}",
+                format_trace_with_actions(&violation.trace, &violation.actions, &spec.vars)
+            );
+            println!();
+            println!("  States explored: {}", stats.states_explored);
+            println!("  Transitions: {}", stats.transitions);
+            println!("  Time: {:.3}s", stats.elapsed_secs);
+            ExitCode::FAILURE
+        }
         CheckResult::LivenessViolation(violation, stats) => {
             println!("Liveness property violated: {}", violation.property);
             println!();
@@ -1346,6 +1383,13 @@ fn main() -> ExitCode {
                 name
             ));
             eprintln!("{}", diag.render_colored(&source, &colors));
+            ExitCode::FAILURE
+        }
+        CheckResult::PrepareError(PrepareSpecError::RefinementConfigError(message)) => {
+            eprintln!(
+                "{}",
+                Diagnostic::error(message).render_colored(&source, &colors)
+            );
             ExitCode::FAILURE
         }
     }

--- a/src/mcp/runner.rs
+++ b/src/mcp/runner.rs
@@ -310,6 +310,21 @@ fn map_check_result(result: CheckResult, spec: &Spec, source: &Source) -> CheckO
                 stats: summarize_stats(&stats),
             }
         }
+        CheckResult::RefinementViolation(violation, stats) => {
+            let where_ = if violation.at_init {
+                "an initial state does not satisfy the abstract Init"
+            } else {
+                "a transition is neither an abstract Next step nor a stutter"
+            };
+            CheckOutcome::Error {
+                phase: ErrorPhase::Init,
+                error: StructuredError::internal(format!(
+                    "refinement violation ({}!Spec): {}",
+                    violation.alias, where_
+                )),
+                partial_stats: Some(summarize_stats(&stats)),
+            }
+        }
         CheckResult::Deadlock(trace, actions, stats) => CheckOutcome::Deadlock {
             trace: trace
                 .iter()
@@ -419,6 +434,9 @@ fn map_prepare_error(err: PrepareSpecError, source: &Source) -> CheckOutcome {
                 name
             )),
         ),
+        PrepareSpecError::RefinementConfigError(message) => {
+            (ErrorPhase::Config, StructuredError::internal(message))
+        }
     };
     CheckOutcome::Error {
         phase: outcome.0,

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -88,12 +88,20 @@ impl Default for ModuleRegistry {
     }
 }
 
+type InstanceVars = BTreeMap<Arc<str>, Vec<Arc<str>>>;
+type ResolvedInstances = (
+    BTreeMap<Arc<str>, Definitions>,
+    ParameterizedInstances,
+    InstanceVars,
+);
+
 pub fn resolve_instances(
     spec: &Spec,
     registry: &ModuleRegistry,
-) -> std::result::Result<(BTreeMap<Arc<str>, Definitions>, ParameterizedInstances), ModuleError> {
+) -> std::result::Result<ResolvedInstances, ModuleError> {
     let mut resolved = BTreeMap::new();
     let mut parameterized = BTreeMap::new();
+    let mut instance_vars = BTreeMap::new();
 
     for inst in &spec.instances {
         let alias = match &inst.alias {
@@ -104,7 +112,8 @@ pub fn resolve_instances(
         if let Some(module) = registry.get(&inst.module_name) {
             if inst.params.is_empty() {
                 let substituted = apply_substitutions(&module.definitions, &inst.substitutions);
-                resolved.insert(alias, substituted);
+                resolved.insert(alias.clone(), substituted);
+                instance_vars.insert(alias, module.vars.clone());
             } else {
                 parameterized.insert(
                     alias,
@@ -118,7 +127,7 @@ pub fn resolve_instances(
         }
     }
 
-    Ok((resolved, parameterized))
+    Ok((resolved, parameterized, instance_vars))
 }
 
 #[cfg(test)]
@@ -282,7 +291,7 @@ mod tests {
             quantified_temporal: vec![],
         };
 
-        let (resolved, parameterized) = resolve_instances(&spec, &registry).unwrap();
+        let (resolved, parameterized, _vars) = resolve_instances(&spec, &registry).unwrap();
 
         assert_eq!(resolved.len(), 1);
         let s_defs = resolved.get(&Arc::from("S") as &Arc<str>).unwrap();

--- a/src/refinement.rs
+++ b/src/refinement.rs
@@ -1,0 +1,213 @@
+//! Refinement checking: verify `Spec => Alias!Spec` for a non-parameterized
+//! `INSTANCE` alias.
+//!
+//! The abstract module reached through `Alias == INSTANCE M WITH v <- mapping`
+//! keeps its `Init`/`Next` as ordinary definitions with the refinement mapping
+//! substituted (primes pushed through the mapping too), so `Alias!Init` and
+//! `Alias!Next` evaluate directly against a concrete state's environment. This
+//! module wires those evaluations into the concrete BFS as a transition
+//! invariant: every initial state's abstract image must satisfy the abstract
+//! `Init`, and every concrete transition must satisfy the abstract `Next` or
+//! leave the abstract image unchanged (a stutter step the abstract spec cannot
+//! observe).
+
+use std::sync::Arc;
+
+use crate::ast::{Env, Expr, Spec, State, Value};
+use crate::eval::{
+    Definitions, EvalError, eval, resolved_instance_def_names, resolved_instance_vars,
+};
+use crate::intern::primed_name;
+
+/// A module name prefix — an all-uppercase run, or one ending in `_` — as the
+/// parser uses to recognise `<Prefix>Init` / `<Prefix>Next`.
+fn is_module_prefix(s: &str) -> bool {
+    !s.is_empty() && (s.chars().all(|c| c.is_ascii_uppercase()) || s.ends_with('_'))
+}
+
+fn is_init_name(name: &str) -> bool {
+    name == "Init" || (name.ends_with("Init") && is_module_prefix(&name[..name.len() - 4]))
+}
+
+fn is_next_name(name: &str) -> bool {
+    name == "Next" || (name.ends_with("Next") && is_module_prefix(&name[..name.len() - 4]))
+}
+
+/// Pick the abstract module's `Init`/`Next` operator: prefer the exact canonical
+/// name, else the unique `<Prefix>Init`/`<Prefix>Next`. Ambiguity (several
+/// matches, none exactly canonical) is an error rather than an alphabetical guess.
+fn select_op(
+    names: &[Arc<str>],
+    canonical: &str,
+    is_match: impl Fn(&str) -> bool,
+    alias: &Arc<str>,
+) -> Result<Arc<str>, String> {
+    if let Some(name) = names.iter().find(|n| n.as_ref() == canonical) {
+        return Ok(name.clone());
+    }
+    let mut matches = names.iter().filter(|n| is_match(n));
+    match (matches.next(), matches.next()) {
+        (Some(only), None) => Ok(only.clone()),
+        (None, _) => Err(format!(
+            "--check-refinement: the abstract module of `{alias}` has no {canonical} definition"
+        )),
+        (Some(_), Some(_)) => Err(format!(
+            "--check-refinement: the abstract module of `{alias}` has more than one \
+             {canonical}-like definition; name the intended one exactly `{canonical}`"
+        )),
+    }
+}
+
+/// A resolved refinement target: the abstract `Init`/`Next` operators reached
+/// through `alias`, and the refinement mapping used to detect stutter steps.
+///
+/// `mapping` covers *every* abstract variable, not only the `WITH` clauses: an
+/// abstract variable omitted from `WITH` takes TLA+'s implicit same-name
+/// substitution (abstract `v` ← concrete `v`), and a stutter must hold the whole
+/// abstract image fixed, so those implicit identity mappings must be compared too.
+pub struct RefinementSpec {
+    alias: Arc<str>,
+    init_name: Arc<str>,
+    next_name: Arc<str>,
+    mapping: Vec<(Arc<str>, Expr)>,
+}
+
+impl RefinementSpec {
+    /// Resolve `alias` against the spec's `INSTANCE` declarations and the already
+    /// resolved instance definitions. Fails with a user-facing message when the
+    /// alias is unknown, parameterized, unresolved, or the abstract module has no
+    /// `Init`/`Next`.
+    pub fn resolve(alias: &Arc<str>, spec: &Spec) -> Result<Self, String> {
+        let instance = spec
+            .instances
+            .iter()
+            .find(|i| i.alias.as_deref() == Some(alias.as_ref()))
+            .ok_or_else(|| {
+                format!("--check-refinement: no INSTANCE alias `{alias}` in the spec")
+            })?;
+
+        if !instance.params.is_empty() {
+            return Err(format!(
+                "--check-refinement: parameterized instance `{alias}` is not supported"
+            ));
+        }
+
+        let names = resolved_instance_def_names(alias).ok_or_else(|| {
+            format!(
+                "--check-refinement: instance `{alias}` was not resolved; \
+                 refinement needs a resolvable spec file path (not available in WASM)"
+            )
+        })?;
+
+        let init_name = select_op(&names, "Init", is_init_name, alias)?;
+        let next_name = select_op(&names, "Next", is_next_name, alias)?;
+
+        let abstract_vars = resolved_instance_vars(alias).ok_or_else(|| {
+            format!("--check-refinement: the abstract module of `{alias}` has no variables")
+        })?;
+        let mapping = abstract_vars
+            .into_iter()
+            .map(|var| {
+                let concrete = instance
+                    .substitutions
+                    .iter()
+                    .find(|(name, _)| *name == var)
+                    .map(|(_, expr)| expr.clone())
+                    .unwrap_or_else(|| Expr::Var(var.clone()));
+                (var, concrete)
+            })
+            .collect();
+
+        Ok(Self {
+            alias: alias.clone(),
+            init_name,
+            next_name,
+            mapping,
+        })
+    }
+
+    pub fn alias(&self) -> Arc<str> {
+        self.alias.clone()
+    }
+
+    fn qualified(&self, op: &Arc<str>) -> Expr {
+        Expr::QualifiedCall(
+            Box::new(Expr::Var(self.alias.clone())),
+            op.clone(),
+            Vec::new(),
+        )
+    }
+
+    fn state_env(&self, base: &Env, vars: &[Arc<str>], state: &State) -> Env {
+        let mut env = base.clone();
+        for (i, var) in vars.iter().enumerate() {
+            if let Some(value) = state.values.get(i) {
+                env.insert(var.clone(), value.clone());
+            }
+        }
+        env
+    }
+
+    /// Whether the abstract image of an initial concrete state satisfies the
+    /// abstract `Init`.
+    pub fn init_holds(
+        &self,
+        state: &State,
+        vars: &[Arc<str>],
+        base: &Env,
+        defs: &Definitions,
+    ) -> Result<bool, EvalError> {
+        let mut env = self.state_env(base, vars, state);
+        match eval(&self.qualified(&self.init_name), &mut env, defs)? {
+            Value::Bool(b) => Ok(b),
+            other => Err(EvalError::type_mismatch_ctx(
+                "Bool",
+                other,
+                "refinement Init",
+            )),
+        }
+    }
+
+    /// Whether a concrete transition refines the abstract spec: the abstract
+    /// `Next` accepts the mapped transition, or the abstract image is unchanged
+    /// (a stutter). `false` is a refinement violation.
+    pub fn step_refines(
+        &self,
+        current: &State,
+        successor: &State,
+        vars: &[Arc<str>],
+        base: &Env,
+        defs: &Definitions,
+    ) -> Result<bool, EvalError> {
+        let mut env = self.state_env(base, vars, current);
+        for (i, var) in vars.iter().enumerate() {
+            if let Some(value) = successor.values.get(i) {
+                env.insert(primed_name(var), value.clone());
+            }
+        }
+        match eval(&self.qualified(&self.next_name), &mut env, defs)? {
+            Value::Bool(true) => return Ok(true),
+            Value::Bool(false) => {}
+            other => {
+                return Err(EvalError::type_mismatch_ctx(
+                    "Bool",
+                    other,
+                    "refinement Next",
+                ));
+            }
+        }
+
+        // Stutter: is the abstract image unchanged? `env` already holds the
+        // unprimed concrete state (the current state), so the mapping evaluated
+        // there is the current abstract image; a fresh env holds the successor.
+        let mut successor_env = self.state_env(base, vars, successor);
+        for (_abstract_var, mapping) in &self.mapping {
+            let before = eval(mapping, &mut env, defs)?;
+            let after = eval(mapping, &mut successor_env, defs)?;
+            if before != after {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -343,6 +343,23 @@ fn result_to_wasm(
             Some(vec![format_trace(&ce.trace, vars)]),
             warnings,
         ),
+        CheckResult::RefinementViolation(violation, stats) => WasmCheckResult::err_with_stats(
+            "RefinementViolation",
+            if violation.at_init {
+                format!(
+                    "Refinement violated: an initial state does not satisfy {}!Init",
+                    violation.alias
+                )
+            } else {
+                format!(
+                    "Refinement violated: a transition is neither a {}!Next step nor a stutter",
+                    violation.alias
+                )
+            },
+            stats,
+            Some(vec![format_trace(&violation.trace, vars)]),
+            warnings,
+        ),
         CheckResult::LivenessViolation(violation, stats) => WasmCheckResult::err_with_stats(
             "LivenessViolation",
             format!("Liveness property violated: {}", violation.property),
@@ -440,6 +457,9 @@ fn result_to_wasm(
                 ),
                 warnings,
             )
+        }
+        CheckResult::PrepareError(PrepareSpecError::RefinementConfigError(message)) => {
+            WasmCheckResult::err("RefinementConfigError", message, warnings)
         }
     }
 }

--- a/test_cases/should_pass/refinement_counter/AbsCounter.tla
+++ b/test_cases/should_pass/refinement_counter/AbsCounter.tla
@@ -1,0 +1,6 @@
+---- MODULE AbsCounter ----
+EXTENDS Naturals
+VARIABLE ac
+AInit == ac = 0
+ANext == ac' = ac + 1
+====

--- a/test_cases/should_pass/refinement_counter/refinement_counter.tla
+++ b/test_cases/should_pass/refinement_counter/refinement_counter.tla
@@ -1,0 +1,10 @@
+---- MODULE refinement_counter ----
+EXTENDS Naturals
+VARIABLES x, pending
+A == INSTANCE AbsCounter WITH ac <- x
+Init == x = 0 /\ pending = FALSE
+Begin == pending = FALSE /\ pending' = TRUE /\ x' = x
+Commit == pending = TRUE /\ x' = x + 1 /\ pending' = FALSE
+Next == (x < 3) /\ (Begin \/ Commit)
+Inv == x <= 3
+====

--- a/test_cases/should_violate/refinement_broken/AbsCounter.tla
+++ b/test_cases/should_violate/refinement_broken/AbsCounter.tla
@@ -1,0 +1,6 @@
+---- MODULE AbsCounter ----
+EXTENDS Naturals
+VARIABLE ac
+AInit == ac = 0
+ANext == ac' = ac + 1
+====

--- a/test_cases/should_violate/refinement_broken/refinement_broken.tla
+++ b/test_cases/should_violate/refinement_broken/refinement_broken.tla
@@ -1,0 +1,8 @@
+---- MODULE refinement_broken ----
+EXTENDS Naturals
+VARIABLE x
+A == INSTANCE AbsCounter WITH ac <- x
+Init == x = 0
+Next == (x < 4) /\ (x' = x + 2)
+Inv == x <= 4
+====

--- a/test_cases/should_violate/refinement_implicit_var/AbsPQ.tla
+++ b/test_cases/should_violate/refinement_implicit_var/AbsPQ.tla
@@ -1,0 +1,6 @@
+---- MODULE AbsPQ ----
+EXTENDS Integers
+VARIABLES p, q
+AInit == p = 0 /\ q = 0
+ANext == p' = p + 1 /\ q' = q
+====

--- a/test_cases/should_violate/refinement_implicit_var/refinement_implicit_var.tla
+++ b/test_cases/should_violate/refinement_implicit_var/refinement_implicit_var.tla
@@ -1,0 +1,8 @@
+---- MODULE refinement_implicit_var ----
+EXTENDS Integers
+VARIABLES p, q
+A == INSTANCE AbsPQ WITH p <- p
+Init == p = 0 /\ q = 0
+Next == (q < 3) /\ (p' = p /\ q' = q + 1)
+Inv == q <= 3
+====

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -1771,6 +1771,92 @@ fn test_should_pass_underscore_identifiers() {
     );
 }
 
+/// A concrete spec that refines an abstract counter through
+/// `A == INSTANCE AbsCounter WITH ac <- x` must pass `--check-refinement A`: the
+/// `Begin` step leaves the abstract image unchanged (a stutter) and the `Commit`
+/// step is an abstract `ANext` step (`ac' = ac + 1`).
+#[test]
+fn test_refinement_counter_passes() {
+    let path = Path::new("test_cases/should_pass/refinement_counter/refinement_counter.tla");
+    let config = CheckerConfig {
+        allow_deadlock: true,
+        check_refinement: Some("A".into()),
+        ..Default::default()
+    };
+    assert!(
+        matches!(
+            check_spec_file_with_config(path, config),
+            CheckResult::Ok(_)
+        ),
+        "refinement_counter must refine AbsCounter"
+    );
+}
+
+/// A concrete step that moves the abstract image by two (`x' = x + 2`) is neither
+/// an abstract `ANext` step (`ac' = ac + 1`) nor a stutter, so
+/// `--check-refinement A` must report a refinement violation.
+#[test]
+fn test_refinement_broken_violates() {
+    let path = Path::new("test_cases/should_violate/refinement_broken/refinement_broken.tla");
+    let config = CheckerConfig {
+        allow_deadlock: true,
+        check_refinement: Some("A".into()),
+        ..Default::default()
+    };
+    assert!(
+        matches!(
+            check_spec_file_with_config(path, config),
+            CheckResult::RefinementViolation(..)
+        ),
+        "refinement_broken must be caught as a refinement violation"
+    );
+}
+
+/// An abstract variable omitted from `WITH` takes TLA+'s implicit same-name
+/// substitution (`q <- q`), and a stutter must hold the *whole* abstract image
+/// fixed. A concrete step that changes such an implicitly-mapped variable while
+/// the explicitly-mapped one stays put is not a stutter, and the abstract `Next`
+/// rejects it — so it must be a refinement violation, not a false accept.
+#[test]
+fn test_refinement_implicit_var_violates() {
+    let path =
+        Path::new("test_cases/should_violate/refinement_implicit_var/refinement_implicit_var.tla");
+    let config = CheckerConfig {
+        allow_deadlock: true,
+        check_refinement: Some("A".into()),
+        ..Default::default()
+    };
+    assert!(
+        matches!(
+            check_spec_file_with_config(path, config),
+            CheckResult::RefinementViolation(..)
+        ),
+        "a change to an implicitly-mapped abstract variable must not be a stutter"
+    );
+}
+
+/// Refinement checking runs on the (possibly symmetry-reduced) reachable graph,
+/// so combining it with `--symmetry` could hide a refinement violation on a
+/// pruned symmetric sibling — a false pass for a verification tool. The two must
+/// be rejected as a configuration error rather than silently checked together.
+#[test]
+fn test_refinement_rejects_symmetry_combo() {
+    let path = Path::new("test_cases/should_pass/refinement_counter/refinement_counter.tla");
+    let config = CheckerConfig {
+        allow_deadlock: true,
+        check_refinement: Some("A".into()),
+        symmetric_constants: vec!["Foo".into()],
+        ..Default::default()
+    };
+    assert!(
+        matches!(
+            check_spec_file_with_config(path, config),
+            CheckResult::PrepareError(PrepareSpecError::RefinementConfigError(_))
+        ),
+        "--check-refinement combined with --symmetry must be rejected"
+    );
+}
+
 #[test]
 fn test_should_pass_extends_transitive() {
     let path = Path::new("test_cases/should_pass/extends_transitive/extends_transitive.tla");


### PR DESCRIPTION
Implements refinement checking: `--check-refinement ALIAS` verifies `Spec => ALIAS!Spec` for a non-parameterized `INSTANCE` alias.

During the concrete BFS it checks, as a transition invariant:
- INIT: every initial state's abstract image (via the WITH refinement mapping) satisfies the abstract Init.
- STEP: every concrete transition satisfies the abstract Next, or leaves the abstract image unchanged (a stutter — an internal step the abstract spec cannot observe).

The abstract module's Init/Next survive INSTANCE resolution as ordinary substituted definitions (primes pushed through the mapping), so `ALIAS!Init`/`ALIAS!Next` evaluate directly against a concrete env. Violations report a counterexample trace; bad config (unknown/parameterized/unresolved alias, missing abstract Init/Next) errors up front. The stutter comparison covers every abstract variable, including those left to TLA+'s implicit same-name substitution rather than named in WITH.

New `src/refinement.rs` + `CheckResult::RefinementViolation`; CLI flag, JSON output, and MCP mapping wired. v1 scope: non-parameterized instances, canonical/prefixed Init/Next names.

Verified: 116 tests green (3 refinement oracle tests + spec pairs), clippy/fmt clean. An adversarial quorum caught a real false-accept (the stutter check originally ignored implicitly-mapped abstract variables); that is fixed and has a regression test, and a second quorum confirms the fix holds with no false rejects (unanimous, ~34 hand-computed scenarios).

Bumps to 0.9.0 (new feature).