### PR TITLE
lex < before a digit as less-than, not a proof step (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.9.0] - 2026-09-05
+## [0.9.0] - 2026-09-06
 
 ### Added
 
@@ -9,6 +9,8 @@
 - Regression coverage for a parameterized `LET` operator defined and called on the right-hand side of a next-state assignment (`x' = LET add10(a) == a + 10 IN add10(10)`, #70). The construct already resolves as of the 0.8.0 walker; this pins the behavior with a dedicated test.
 
 ### Fixed
+
+- `<` immediately followed by a digit is now the less-than operator, not a proof-step token (#89). The lexer recognised `<digits` as a proof step with an *optional* closing `>`, so `x<5` (valid TLA+ for `x < 5`) was mis-tokenized and the comparison silently dropped — which could hide a real invariant violation as a clean pass. A proof step now requires its mandatory closing `>` (`<3>`); `x<5` lexes as `x < 5`.
 
 - `TLA_ENGINE=inference` now applies in the scenario, interactive, and validate paths, not only in `check()` — the engine selection is set once from configuration before any mode runs (#79). The selection is also scoped so a run that sets it no longer leaks the choice into a later state generation on the same thread.
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -425,26 +425,27 @@ impl<'a> Lexer<'a> {
         if self.consume("~>") {
             return Ok(Token::LeadsTo);
         }
-        if self.starts_with("<")
-            && self.input[self.pos + 1..]
-                .chars()
-                .next()
-                .is_some_and(|c| c.is_ascii_digit())
-        {
-            self.advance();
-            while self.peek_char().is_some_and(|c| c.is_ascii_digit()) {
+        if self.starts_with("<") {
+            // A proof-step token is `<level>` with a *mandatory* closing `>`
+            // (e.g. `<3>`, `<3>2.`). Without the `>` this is the less-than
+            // operator applied to a number — `x<5` means `x < 5`, not a proof
+            // step — so require the `>` before committing.
+            let after = &self.input[self.pos + 1..];
+            let after_digits = after.trim_start_matches(|c: char| c.is_ascii_digit());
+            if after_digits.len() < after.len() && after_digits.starts_with('>') {
                 self.advance();
-            }
-            if self.peek_char() == Some('>') {
+                while self.peek_char().is_some_and(|c| c.is_ascii_digit()) {
+                    self.advance();
+                }
                 self.advance();
+                while self
+                    .peek_char()
+                    .is_some_and(|c| c.is_alphanumeric() || c == '.')
+                {
+                    self.advance();
+                }
+                return Ok(Token::ProofStep);
             }
-            while self
-                .peek_char()
-                .is_some_and(|c| c.is_alphanumeric() || c == '.')
-            {
-                self.advance();
-            }
-            return Ok(Token::ProofStep);
         }
         if self.consume("<<") {
             return Ok(Token::LAngle);
@@ -904,26 +905,27 @@ impl<'a> Lexer<'a> {
         if self.consume("~>") {
             return Ok(Token::LeadsTo);
         }
-        if self.starts_with("<")
-            && self.input[self.pos + 1..]
-                .chars()
-                .next()
-                .is_some_and(|c| c.is_ascii_digit())
-        {
-            self.advance();
-            while self.peek_char().is_some_and(|c| c.is_ascii_digit()) {
+        if self.starts_with("<") {
+            // A proof-step token is `<level>` with a *mandatory* closing `>`
+            // (e.g. `<3>`, `<3>2.`). Without the `>` this is the less-than
+            // operator applied to a number — `x<5` means `x < 5`, not a proof
+            // step — so require the `>` before committing.
+            let after = &self.input[self.pos + 1..];
+            let after_digits = after.trim_start_matches(|c: char| c.is_ascii_digit());
+            if after_digits.len() < after.len() && after_digits.starts_with('>') {
                 self.advance();
-            }
-            if self.peek_char() == Some('>') {
+                while self.peek_char().is_some_and(|c| c.is_ascii_digit()) {
+                    self.advance();
+                }
                 self.advance();
+                while self
+                    .peek_char()
+                    .is_some_and(|c| c.is_alphanumeric() || c == '.')
+                {
+                    self.advance();
+                }
+                return Ok(Token::ProofStep);
             }
-            while self
-                .peek_char()
-                .is_some_and(|c| c.is_alphanumeric() || c == '.')
-            {
-                self.advance();
-            }
-            return Ok(Token::ProofStep);
         }
         if self.consume("<<") {
             return Ok(Token::LAngle);
@@ -1406,6 +1408,38 @@ mod tests {
                 Token::RParen,
                 Token::Eof,
             ]
+        );
+    }
+
+    #[test]
+    fn lex_less_than_before_digit_is_comparison() {
+        // `x<5` is the less-than operator applied to a number, not a proof step.
+        let mut lexer = Lexer::new("x<5");
+        let tokens = lexer.tokenize().unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Ident("x".into()),
+                Token::Lt,
+                Token::Int(5),
+                Token::Eof,
+            ]
+        );
+    }
+
+    #[test]
+    fn lex_proof_step_requires_closing_angle() {
+        // A real proof step keeps its mandatory `>` (and trailing label).
+        let mut lexer = Lexer::new("<3>2.");
+        assert_eq!(
+            lexer.tokenize().unwrap(),
+            vec![Token::ProofStep, Token::Eof]
+        );
+        // Bare `<3>` too.
+        let mut lexer = Lexer::new("<1>");
+        assert_eq!(
+            lexer.tokenize().unwrap(),
+            vec![Token::ProofStep, Token::Eof]
         );
     }
 

--- a/test_cases/should_violate/less_than_before_digit.tla
+++ b/test_cases/should_violate/less_than_before_digit.tla
@@ -1,0 +1,8 @@
+---- MODULE less_than_before_digit ----
+EXTENDS Integers
+VARIABLES x, y
+Val == x<3
+Init == x = 0 /\ y = FALSE
+Next == x' = (x + 1) % 4 /\ y' = Val
+Inv == y # TRUE
+====

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -849,6 +849,23 @@ fn test_should_violate_multi_bound_set_comprehension() {
     );
 }
 
+/// `<` immediately followed by a digit is the less-than operator, not a proof
+/// step: `Val == x<3` is `x < 3`, a Bool. Previously the lexer mis-tokenized it
+/// as a proof step (its closing `>` was optional), silently truncating `Val` to
+/// `x` — then `y' = Val` assigned an Int, `y` never became TRUE, and the reachable
+/// violation of `y # TRUE` was hidden as a silent pass. It must now be caught.
+#[test]
+fn test_should_violate_less_than_before_digit() {
+    let path = Path::new("test_cases/should_violate/less_than_before_digit.tla");
+    assert!(
+        matches!(
+            check_spec_file_allow_deadlock(path),
+            CheckResult::InvariantViolation(..)
+        ),
+        "x<3 must lex as x < 3, so the reachable y = TRUE violates y # TRUE"
+    );
+}
+
 #[test]
 fn test_should_violate_counter_overflow() {
     let path = Path::new("test_cases/should_violate/counter_overflow.tla");


### PR DESCRIPTION
Fixes #89. The lexer recognised `<digits` as a proof-step token with an *optional* closing `>`, so `<` immediately followed by a digit (e.g. `x<5`, valid TLA+ for `x < 5`) was mis-tokenized as a proof step and the comparison silently dropped — which downstream truncated the enclosing definition. In the worst case this hid a real invariant violation as a clean "No errors found" pass (`Val == x<3` becomes `Val == x`).

A proof step now requires its mandatory closing `>` (`<3>`, `<3>2.`); `<` followed by digits with no `>` lexes as the less-than operator. Fixed in both lexer paths.

Verified: `x<5` now gives the same result as `x < 5`; the silent-false-pass repro now correctly violates; real proof steps still lex (behavior on PROOF blocks is unchanged). The only corpus spec using the trigger is the new regression spec, so no existing spec changes behaviour. 118 tests green + 2 lexer unit tests, clippy/fmt clean.

Pre-existing bug (proof-step recognizer is long-standing); folded into 0.9.0 before release.